### PR TITLE
Add an option to reverse horizontal scrolling

### DIFF
--- a/LinearMouse/AppDefaults.swift
+++ b/LinearMouse/AppDefaults.swift
@@ -10,7 +10,13 @@ import SwiftUI
 class AppDefaults: ObservableObject {
     public static let shared = AppDefaults()
 
-    @AppStorageCompat(wrappedValue: true, "reverseScrollingOn") var reverseScrollingOn: Bool {
+    @AppStorageCompat(wrappedValue: true, "reverseScrollingOn") var reverseScrollingVerticallyOn: Bool {
+        willSet {
+            objectWillChange.send()
+        }
+    }
+
+    @AppStorageCompat(wrappedValue: false, "reverseScrollingHorizontallyOn") var reverseScrollingHorizontallyOn: Bool {
         willSet {
             objectWillChange.send()
         }

--- a/LinearMouse/Event/EventTransformer.swift
+++ b/LinearMouse/Event/EventTransformer.swift
@@ -13,13 +13,14 @@ protocol EventTransformer {
 
 func getTransformers(appDefaults: AppDefaults) -> [EventTransformer] {
     let transformers: [(Bool, () -> EventTransformer)] = [
-        (appDefaults.reverseScrollingOn,        { ReverseScrolling() }),
-        (appDefaults.linearScrollingOn,         { LinearScrolling(scrollLines: appDefaults.scrollLines) }),
-        (appDefaults.universalBackForwardOn,    { UniversalBackForward() }),
-        (true,                                  { ModifierActions(commandAction: appDefaults.modifiersCommandAction,
-                                                                  shiftAction: appDefaults.modifiersShiftAction,
-                                                                  alternateAction: appDefaults.modifiersAlternateAction,
-                                                                  controlAction: appDefaults.modifiersControlAction) }),
+        (appDefaults.reverseScrollingVerticallyOn,      { ReverseScrolling(vertically: true) }),
+        (appDefaults.reverseScrollingHorizontallyOn,    { ReverseScrolling(horizontally: true) }),
+        (appDefaults.linearScrollingOn,                 { LinearScrolling(scrollLines: appDefaults.scrollLines) }),
+        (appDefaults.universalBackForwardOn,            { UniversalBackForward() }),
+        (true,                                          { ModifierActions(commandAction: appDefaults.modifiersCommandAction,
+                                                                          shiftAction: appDefaults.modifiersShiftAction,
+                                                                          alternateAction: appDefaults.modifiersAlternateAction,
+                                                                          controlAction: appDefaults.modifiersControlAction) }),
     ]
 
     return transformers.filter { $0.0 }.map { $0.1() }

--- a/LinearMouse/Event/ReverseScrolling.swift
+++ b/LinearMouse/Event/ReverseScrolling.swift
@@ -8,13 +8,26 @@
 import Foundation
 
 class ReverseScrolling: EventTransformer {
+    private let vertically: Bool
+    private let horizontally: Bool
+
+    init(vertically: Bool = false, horizontally: Bool = false) {
+        self.vertically = vertically
+        self.horizontally = horizontally
+    }
+
     func transform(_ event: CGEvent) -> CGEvent? {
         guard event.type == .scrollWheel else {
             return event
         }
 
         let view = ScrollWheelEventView(event)
-        view.negate()
+        if vertically {
+            view.negateVertically()
+        }
+        if horizontally {
+            view.negateHorizontally()
+        }
         return event
     }
 }

--- a/LinearMouse/Event/ReverseScrolling.swift
+++ b/LinearMouse/Event/ReverseScrolling.swift
@@ -22,12 +22,7 @@ class ReverseScrolling: EventTransformer {
         }
 
         let view = ScrollWheelEventView(event)
-        if vertically {
-            view.negateVertically()
-        }
-        if horizontally {
-            view.negateHorizontally()
-        }
+        view.negate(vertically: vertically, horizontally: horizontally)
         return event
     }
 }

--- a/LinearMouse/EventTap.swift
+++ b/LinearMouse/EventTap.swift
@@ -32,7 +32,7 @@ class EventTap {
             | 1 << CGEventType.otherMouseUp.rawValue
         eventTap = CGEvent.tapCreate(
             tap: .cghidEventTap,
-            place: .tailAppendEventTap,
+            place: .headInsertEventTap,
             options: .defaultTap,
             eventsOfInterest: eventsOfInterest,
             callback: eventTapCallback,

--- a/LinearMouse/MouseEventView/ScrollWheelEventView.swift
+++ b/LinearMouse/MouseEventView/ScrollWheelEventView.swift
@@ -120,8 +120,12 @@ class ScrollWheelEventView: MouseEventView {
         transform(matrix: .init([0, 1], [1, 0]))
     }
 
-    func negate() {
+    func negateVertically() {
         transform(matrix: .init([1, 0], [0, -1]))
+    }
+
+    func negateHorizontally() {
+        transform(matrix: .init([-1, 0], [0, 1]))
     }
 
     func scale(factor: Double) {

--- a/LinearMouse/MouseEventView/ScrollWheelEventView.swift
+++ b/LinearMouse/MouseEventView/ScrollWheelEventView.swift
@@ -120,12 +120,8 @@ class ScrollWheelEventView: MouseEventView {
         transform(matrix: .init([0, 1], [1, 0]))
     }
 
-    func negateVertically() {
-        transform(matrix: .init([1, 0], [0, -1]))
-    }
-
-    func negateHorizontally() {
-        transform(matrix: .init([-1, 0], [0, 1]))
+    func negate(vertically: Bool = false, horizontally: Bool = false) {
+        transform(matrix: .init([horizontally ? -1 : 1, 0], [0, vertically ? -1 : 1]))
     }
 
     func scale(factor: Double) {

--- a/LinearMouse/UI/GeneralView.swift
+++ b/LinearMouse/UI/GeneralView.swift
@@ -15,13 +15,38 @@ struct GeneralView: View {
             Spacer()
 
             VStack(alignment: .leading) {
-                Toggle(isOn: $defaults.reverseScrollingOn) {
+                Toggle(isOn: $defaults.reverseScrollingVerticallyOn) {
                     VStack(alignment: .leading) {
-                        Text("Reverse scrolling")
+                        HStack(alignment: .firstTextBaseline, spacing: 2) {
+                            Text("Reverse scrolling")
+                            Text("(vertically)")
+                                .controlSize(.small)
+                                .foregroundColor(.secondary)
+                        }
                         Text("""
                             Reverse the scroll direction for a mouse \
                             but won't reverse the scroll direction \
                             for a Trackpad.
+                            """)
+                            .controlSize(.small)
+                            .foregroundColor(.secondary)
+                            .fixedSize(horizontal: false, vertical: true)
+                    }
+                }
+            }
+
+            VStack(alignment: .leading) {
+                Toggle(isOn: $defaults.reverseScrollingHorizontallyOn) {
+                    VStack(alignment: .leading) {
+                        HStack(alignment: .firstTextBaseline, spacing: 2) {
+                            Text("Reverse scrolling")
+                            Text("(horizontally)")
+                                .controlSize(.small)
+                                .foregroundColor(.secondary)
+                        }
+                        Text("""
+                            Some gestures, such as swiping back and forward, \
+                            may stop working.
                             """)
                             .controlSize(.small)
                             .foregroundColor(.secondary)

--- a/LinearMouse/UI/PreferencesWindow.swift
+++ b/LinearMouse/UI/PreferencesWindow.swift
@@ -11,7 +11,7 @@ import SwiftUI
 class PreferencesWindow: NSWindow {
     init() {
         super.init(
-            contentRect: .init(x: 0, y: 0, width: 500, height: 550),
+            contentRect: .init(x: 0, y: 0, width: 500, height: 600),
             styleMask: [.titled, .closable, .fullSizeContentView],
             backing: .buffered,
             defer: false

--- a/LinearMouse/UI/StatusItem.swift
+++ b/LinearMouse/UI/StatusItem.swift
@@ -11,6 +11,19 @@ import SwiftUI
 fileprivate struct StatusView: View {
     @ObservedObject var defaults = AppDefaults.shared
 
+    var reverseScrollingStatus: some View {
+        if defaults.reverseScrollingVerticallyOn && defaults.reverseScrollingHorizontallyOn {
+            return Text("on")
+        }
+        if defaults.reverseScrollingVerticallyOn {
+            return Text("vertically only")
+        }
+        if defaults.reverseScrollingHorizontallyOn {
+            return Text("horizontally only")
+        }
+        return Text("off")
+    }
+
     var body: some View {
         VStack(alignment: .leading) {
             Text(LinearMouse.appName)
@@ -22,7 +35,7 @@ fileprivate struct StatusView: View {
             ) {
                 HStack {
                     Text("Reverse scrolling:")
-                    Text(defaults.reverseScrollingOn ? "on" : "off")
+                    reverseScrollingStatus
                 }
                 HStack {
                     Text("Linear scrolling:")

--- a/LinearMouse/en.lproj/Localizable.strings
+++ b/LinearMouse/en.lproj/Localizable.strings
@@ -1,5 +1,7 @@
 "Reverse scrolling:" = "Reverse scrolling:";
 "Linear scrolling:" = "Linear scrolling:";
+"vertically only" = "vertically only";
+"horizontally only" = "horizontally only";
 "Universal back and forward:" = "Universal back and forward:";
 "on" = "on";
 "off" = "off";
@@ -14,7 +16,10 @@
 "Modifier Keys" = "Modifier Keys";
 
 "Reverse scrolling" = "Reverse scrolling";
+"(vertically)" = "(vertically)";
 "Reverse the scroll direction for a mouse but won't reverse the scroll direction for a Trackpad." = "Reverse the scroll direction for a mouse but won't reverse the scroll direction for a Trackpad.";
+"(horizontally)" = "(horizontally)";
+"Some gestures, such as swiping back and forward, may stop working." = "Some gestures, such as swiping back and forward, may stop working.";
 "Enable linear scrolling" = "Enable linear scrolling";
 "Disable mouse scrolling acceleration." = "Disable mouse scrolling acceleration.";
 "Scroll" = "Scroll";

--- a/LinearMouseUnitTests/Event/ReverseScrollingTests.swift
+++ b/LinearMouseUnitTests/Event/ReverseScrollingTests.swift
@@ -9,12 +9,21 @@ import XCTest
 @testable import LinearMouse
 
 class ReverseScrollingTests: XCTestCase {
-    func testReverseScrolling() throws {
-        let transformer = ReverseScrolling()
+    func testReverseScrollingVertically() throws {
+        let transformer = ReverseScrolling(vertically: true)
         var event = CGEvent(scrollWheelEvent2Source: nil, units: .line, wheelCount: 2, wheel1: 1, wheel2: 2, wheel3: 0)!
         event = transformer.transform(event)!
         let view = ScrollWheelEventView(event)
         XCTAssertEqual(view.deltaX, 2)
         XCTAssertEqual(view.deltaY, -1)
+    }
+
+    func testReverseScrollingHorizontally() throws {
+        let transformer = ReverseScrolling(horizontally: true)
+        var event = CGEvent(scrollWheelEvent2Source: nil, units: .line, wheelCount: 2, wheel1: 1, wheel2: 2, wheel3: 0)!
+        event = transformer.transform(event)!
+        let view = ScrollWheelEventView(event)
+        XCTAssertEqual(view.deltaX, -2)
+        XCTAssertEqual(view.deltaY, 1)
     }
 }


### PR DESCRIPTION
Related issue: #91

For the time being, I've added the ability to reverse horizontal scrolling. This may break back and forth gestures, but having an option is still preferable.