### PR TITLE
Universal back and forward: Ignore Dota 2

### DIFF
--- a/LinearMouse/Event/UniversalBackForward.swift
+++ b/LinearMouse/Event/UniversalBackForward.swift
@@ -26,6 +26,7 @@ class UniversalBackForward: EventTransformer {
         "com.microsoft.VSCode",
         "com.microsoft.rdc.macos",
         "com.parallels.desktop.console",
+        "com.valvesoftware.dota2",
         "com.vmware.fusion",
         "org.virtualbox.app.VirtualBox",
         "tv.parsec.www",


### PR DESCRIPTION
Disable universal back_forward buttons for DOTA 2