### PR TITLE
Fix freezing after granting accessibility permission

### DIFF
--- a/LinearMouse/AppDelegate.swift
+++ b/LinearMouse/AppDelegate.swift
@@ -65,6 +65,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         let options = [kAXTrustedCheckOptionPrompt.takeUnretainedValue(): shouldAskForPermission] as CFDictionary
         guard AXIsProcessTrustedWithOptions(options) else {
             DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
+                os_log("Re-checking accessibility permission", log: Self.log, type: .debug)
                 self.withAccessibilityPermission(shouldAskForPermission: false, completion: completion)
             }
             return

--- a/LinearMouse/EventTap.swift
+++ b/LinearMouse/EventTap.swift
@@ -40,7 +40,6 @@ class EventTap {
         )
         runLoopSource = CFMachPortCreateRunLoopSource(kCFAllocatorDefault, eventTap, 0)
         CFRunLoopAddSource(CFRunLoopGetCurrent(), runLoopSource, CFRunLoopMode.commonModes)
-        CFRunLoopRun()
     }
 
     func enable() {


### PR DESCRIPTION
`CFRunLoopRun()` call is unnecessary and would cause app freezing until it receives user actions.