### PR TITLE
Remove `tccutil reset Accessibility ...`

### DIFF
--- a/LinearMouse/AccessibilityPermission.swift
+++ b/LinearMouse/AccessibilityPermission.swift
@@ -30,22 +30,6 @@ class AccessibilityPermission {
         }
         completion()
     }
-
-    static func reset() throws {
-        let command = "tccutil reset Accessibility \(LinearMouse.appBundleIdentifier)"
-
-        guard let script = NSAppleScript(source: command) else {
-            os_log("Failed to reset Accessibility permission", log: Self.log, type: .error)
-            return
-        }
-
-        var error: NSDictionary?
-        script.executeAndReturnError(&error)
-
-        if error != nil {
-            throw AccessibilityPermissionError.resetError
-        }
-    }
 }
 
 enum AccessibilityPermissionError: Error {

--- a/LinearMouse/UI/AccessibilityPermissionView.swift
+++ b/LinearMouse/UI/AccessibilityPermissionView.swift
@@ -40,9 +40,6 @@ struct AccessibilityPermissionView: View {
     }
 
     func openAccessibility() {
-        do {
-            try AccessibilityPermission.reset()
-        } catch {}
         AccessibilityPermission.prompt()
         AccessibilityPermissionWindow.shared.moveAside()
     }


### PR DESCRIPTION
The code is [buggy and does not work](https://github.com/linearmouse/linearmouse/discussions/325#discussioncomment-4814085). 

Considering the current certificate is stable, the permission fixes are no longer needed.