### PR TITLE
Scrolling modifiers: Support zooming

### DIFF
--- a/Documentation/Configuration.d.ts
+++ b/Documentation/Configuration.d.ts
@@ -225,7 +225,14 @@ declare namespace Scheme {
         scale: number;
       };
 
-      type Action = None | AlterOrientation | ChangeSpeed;
+      /**
+       * @description Zoom in and out using ⌘+ and ⌘-.
+       */
+      type Zoom = {
+        type: "zoom";
+      };
+
+      type Action = None | AlterOrientation | ChangeSpeed | Zoom;
     }
   }
 

--- a/Documentation/Configuration.json
+++ b/Documentation/Configuration.json
@@ -858,6 +858,9 @@
         },
         {
           "$ref": "#/definitions/Scheme.Scrolling.Modifiers.ChangeSpeed"
+        },
+        {
+          "$ref": "#/definitions/Scheme.Scrolling.Modifiers.Zoom"
         }
       ]
     },
@@ -900,6 +903,20 @@
       "properties": {
         "type": {
           "const": "none",
+          "type": "string"
+        }
+      },
+      "required": [
+        "type"
+      ],
+      "type": "object"
+    },
+    "Scheme.Scrolling.Modifiers.Zoom": {
+      "additionalProperties": false,
+      "description": "Zoom in and out using ⌘+ and ⌘-.",
+      "properties": {
+        "type": {
+          "const": "zoom",
           "type": "string"
         }
       },

--- a/LinearMouse/Model/Configuration/Scheme/Scrolling/Modifiers.swift
+++ b/LinearMouse/Model/Configuration/Scheme/Scrolling/Modifiers.swift
@@ -17,6 +17,7 @@ extension Scheme.Scrolling.Modifiers {
         case none
         case alterOrientation
         case changeSpeed(scale: Decimal)
+        case zoom
     }
 }
 
@@ -54,7 +55,7 @@ extension Scheme.Scrolling.Modifiers.Action: Codable {
     }
 
     enum ActionType: String, Codable {
-        case none, alterOrientation, changeSpeed
+        case none, alterOrientation, changeSpeed, zoom
     }
 
     init(from decoder: Decoder) throws {
@@ -69,6 +70,8 @@ extension Scheme.Scrolling.Modifiers.Action: Codable {
         case .changeSpeed:
             let scale = try container.decode(Decimal.self, forKey: .scale)
             self = .changeSpeed(scale: scale)
+        case .zoom:
+            self = .zoom
         }
     }
 
@@ -83,6 +86,8 @@ extension Scheme.Scrolling.Modifiers.Action: Codable {
         case let .changeSpeed(scale):
             try container.encode(ActionType.changeSpeed, forKey: .type)
             try container.encode(scale, forKey: .scale)
+        case .zoom:
+            try container.encode(ActionType.zoom, forKey: .type)
         }
     }
 }

--- a/LinearMouse/UI/ScrollingSettings/ModifierKeysSection/ModifierKeyActionPicker.swift
+++ b/LinearMouse/UI/ScrollingSettings/ModifierKeysSection/ModifierKeyActionPicker.swift
@@ -38,6 +38,7 @@ extension ScrollingSettings.ModifierKeysSection.ModifierKeyActionPicker {
         case noAction = "No action"
         case alterOrientation = "Alter orientation"
         case changeSpeed = "Change speed"
+        case zoom = "Zoom"
     }
 
     var actionType: Binding<ActionType> {
@@ -54,6 +55,8 @@ extension ScrollingSettings.ModifierKeysSection.ModifierKeyActionPicker {
                     return .alterOrientation
                 case .changeSpeed:
                     return .changeSpeed
+                case .zoom:
+                    return .zoom
                 }
             },
 
@@ -65,6 +68,8 @@ extension ScrollingSettings.ModifierKeysSection.ModifierKeyActionPicker {
                     self.action = .alterOrientation
                 case .changeSpeed:
                     self.action = .changeSpeed(scale: 1)
+                case .zoom:
+                    self.action = .zoom
                 }
             }
         )

--- a/LinearMouse/en.lproj/Localizable.strings
+++ b/LinearMouse/en.lproj/Localizable.strings
@@ -13,7 +13,6 @@
 "Scrolling" = "Scrolling";
 "Pointer" = "Pointer";
 "Buttons" = "Buttons";
-"Modifier Keys" = "Modifier Keys";
 "General" = "General";
 
 "Vertical" = "Vertical";
@@ -28,6 +27,11 @@
 "Slower" = "Slower";
 "Faster" = "Faster";
 "Distance" = "Distance";
+"Modifier Keys" = "Modifier Keys";
+"No action" = "No action";
+"Alter orientation" = "Alter orientation";
+"Change speed" = "Change speed";
+"Zoom" = "Zoom";
 
 "Disable pointer acceleration" = "Disable pointer acceleration";
 "Acceleration" = "Acceleration";
@@ -36,10 +40,6 @@
 
 "Enable universal back and forward" = "Enable universal back and forward";
 "Convert the back and forward side buttons to swiping gestures to allow universal back and forward functionality." = "Convert the back and forward side buttons to swiping gestures to allow universal back and forward functionality.";
-
-"No action" = "No action";
-"Alter orientation" = "Alter orientation";
-"Change speed" = "Change speed";
 
 "Settings" = "Settings";
 "Show in menu bar" = "Show in menu bar";


### PR DESCRIPTION
Zooming in and out is implemented by pressing <kbd>⌘+</kbd> and <kbd>⌘-</kbd>.

An alternative way is to simulate a pinch gesture, but the effect is not the same. This way would cause the horizontal scrollbar to appear in apps like web browsers. We may provide this type of zooming as a “gesture zoom” or something in the future.

Closes #227.