### PR TITLE
Support disabling control+left click behavior

### DIFF
--- a/LinearMouse/EventTransformer/ControlClickTransformer.swift
+++ b/LinearMouse/EventTransformer/ControlClickTransformer.swift
@@ -1,0 +1,18 @@
+// MIT License
+// Copyright (c) 2021-2023 Jiahao Lu
+
+import Foundation
+
+class ControlClickTransformer: EventTransformer {
+    func transform(_ event: CGEvent) -> CGEvent? {
+        guard event.type == .leftMouseDown else {
+            return event
+        }
+
+        if event.flags.contains(.maskControl) {
+            event.flags.remove(.maskControl)
+        }
+
+        return event
+    }
+}

--- a/LinearMouse/EventTransformer/EventTransformerManager.swift
+++ b/LinearMouse/EventTransformer/EventTransformerManager.swift
@@ -123,6 +123,11 @@ class EventTransformerManager {
             eventTransformer.append(UniversalBackForwardTransformer(universalBackForward: universalBackForward))
         }
 
+        if let controlClickDisabled = scheme.buttons.controlClickDisabled,
+           controlClickDisabled == true {
+            eventTransformer.append(ControlClickTransformer())
+        }
+
         lastPid = pid
         lastEventTransformer = eventTransformer
 

--- a/LinearMouse/Model/Configuration/Scheme/Buttons/Buttons.swift
+++ b/LinearMouse/Model/Configuration/Scheme/Buttons/Buttons.swift
@@ -16,6 +16,8 @@ extension Scheme {
 
         var universalBackForward: UniversalBackForward?
 
+        var controlClickDisabled: Bool?
+
         @ImplicitOptional var clickDebouncing: ClickDebouncing
     }
 }
@@ -28,6 +30,10 @@ extension Scheme.Buttons {
 
         if let universalBackForward = universalBackForward {
             buttons.universalBackForward = universalBackForward
+        }
+
+        if let controlClick = controlClickDisabled {
+            buttons.controlClickDisabled = controlClick
         }
 
         if let clickDebouncing = $clickDebouncing {

--- a/LinearMouse/UI/ButtonsSettings/ButtonsSettings.swift
+++ b/LinearMouse/UI/ButtonsSettings/ButtonsSettings.swift
@@ -10,6 +10,8 @@ struct ButtonsSettings: View {
                 UniversalBackForwardSection()
 
                 ClickDebouncingSection()
+
+                ControlClickSection()
             }
             .modifier(FormViewModifier())
         }

--- a/LinearMouse/UI/ButtonsSettings/ButtonsSettingsState.swift
+++ b/LinearMouse/UI/ButtonsSettings/ButtonsSettingsState.swift
@@ -37,6 +37,15 @@ extension ButtonsSettingsState {
         }
     }
 
+    var controlClickDisabled: Bool {
+        get {
+            mergedScheme.buttons.controlClickDisabled ?? false
+        }
+        set {
+            scheme.buttons.controlClickDisabled = newValue
+        }
+    }
+
     var clickDebouncingTimeout: Int {
         get {
             mergedScheme.buttons.clickDebouncing.timeout ?? 0

--- a/LinearMouse/UI/ButtonsSettings/ControlClickSection.swift
+++ b/LinearMouse/UI/ButtonsSettings/ControlClickSection.swift
@@ -1,0 +1,19 @@
+// MIT License
+// Copyright (c) 2021-2023 Jiahao Lu
+
+import SwiftUI
+
+struct ControlClickSection: View {
+    @ObservedObject var state: ButtonsSettingsState = .shared
+
+    var body: some View {
+        Section {
+            Toggle(isOn: $state.controlClickDisabled.animation()) {
+                withDescription {
+                    Text("Disable control click")
+                    Text("Left clicking with control will not be changed to a right click")
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
I added an option under `Buttons` to disable control+left click mapping to right click