### PR TITLE
Optimize the user experience when switching between devices

### DIFF
--- a/LinearMouse/Device/Device.swift
+++ b/LinearMouse/Device/Device.swift
@@ -167,8 +167,19 @@ extension Device {
         let usagePage = element.usagePage
         let usage = element.usage
 
-        guard usagePage == kHIDPage_GenericDesktop || usagePage == kHIDPage_Digitizer || usagePage == kHIDPage_Button
-        else {
+        switch Int(usagePage) {
+        case kHIDPage_GenericDesktop:
+            switch Int(usage) {
+            case kHIDUsage_GD_X, kHIDUsage_GD_Y, kHIDUsage_GD_Z:
+                guard IOHIDValueGetIntegerValue(value) != 0 else {
+                    return
+                }
+            default:
+                return
+            }
+        case kHIDPage_Button:
+            break
+        default:
             return
         }
 

--- a/LinearMouse/EventTap.swift
+++ b/LinearMouse/EventTap.swift
@@ -32,7 +32,8 @@ class EventTap {
         }
 
         let mouseEventView = MouseEventView(event)
-        let eventTransformer = EventTransformerManager.shared.get(withSourcePid: mouseEventView.sourcePid,
+        let eventTransformer = EventTransformerManager.shared.get(withCGEvent: event,
+                                                                  withSourcePid: mouseEventView.sourcePid,
                                                                   withTargetPid: mouseEventView.targetPid)
 
         if let event = eventTransformer.transform(event) {

--- a/LinearMouse/LinearMouse-Bridging-Header.h
+++ b/LinearMouse/LinearMouse-Bridging-Header.h
@@ -35,6 +35,7 @@ static const IOHIDEventField kIOHIDEventFieldScrollX = (kIOHIDEventFieldScrollBa
 static const IOHIDEventField kIOHIDEventFieldScrollY = (kIOHIDEventFieldScrollBase | 1);
 
 IOHIDEventRef CGEventCopyIOHIDEvent(CGEventRef);
+IOHIDEventType IOHIDEventGetType(IOHIDEventRef);
 IOHIDFloat IOHIDEventGetFloatValue(IOHIDEventRef, IOHIDEventField);
 void IOHIDEventSetFloatValue(IOHIDEventRef, IOHIDEventField, IOHIDFloat);
 

--- a/Modules/PointerKit/Sources/PointerKit/PointerDeviceManager.swift
+++ b/Modules/PointerKit/Sources/PointerKit/PointerDeviceManager.swift
@@ -217,4 +217,10 @@ extension PointerDeviceManager {
             callback(self, device)
         }
     }
+
+    public func pointerDeviceFromIOHIDEvent(_ ioHidEvent: IOHIDEvent) -> PointerDevice? {
+        let senderID = IOHIDEventGetSenderID(ioHidEvent)
+        let serviceClient = IOHIDEventSystemClientCopyServiceForRegistryID(eventSystemClient, senderID)
+        return serviceClient.flatMap { serviceClientToPointerDevice[$0] }
+    }
 }


### PR DESCRIPTION
Previously, events were transformed using the settings of the last active device, which could result in problems when switching between devices frequently.

This patch attempts to identify the device that generated the events and utilizes its settings. If it fails, fallback to the previous logic.

Fixes #463. 