### PR TITLE
UniversalBackForward: Convert side buttons to swipe gestures in Opera

### DIFF
--- a/LinearMouse/EventTransformer/UniversalBackForwardTransformer.swift
+++ b/LinearMouse/EventTransformer/UniversalBackForwardTransformer.swift
@@ -11,7 +11,8 @@ class UniversalBackForwardTransformer: EventTransformer {
     private static let includes = [
         "com.apple.*",
         "com.binarynights.ForkLift*",
-        "org.mozilla.firefox"
+        "org.mozilla.firefox",
+        "com.operasoftware.Opera"
     ]
 
     private let interestedButtons: Set<CGMouseButton>


### PR DESCRIPTION
Opera's default actions for handling side buttons are not meeting our expectations. Therefore, we should convert the side buttons to swipe gestures when universal back and forward is enabled, in order to fix this issue.

Closes #479.
