### PR TITLE
Fix memory leak in event transformer cache

### DIFF
--- a/LinearMouse/EventTransformer/EventTransformerManager.swift
+++ b/LinearMouse/EventTransformer/EventTransformerManager.swift
@@ -16,9 +16,7 @@ class EventTransformerManager {
     private var eventTransformerCache = LRUCache<CacheKey, EventTransformer>(countLimit: 16)
 
     struct CacheKey: Hashable {
-        // FIXME: Minor memory leak here. However, using weak reference here will result in crashes
-        // as the hash of CacheKey could change.
-        var device: Device?
+        var deviceMatcher: DeviceMatcher?
         var pid: pid_t?
     }
 
@@ -57,7 +55,8 @@ class EventTransformerManager {
         }
 
         let device = DeviceManager.shared.deviceFromCGEvent(cgEvent)
-        let cacheKey = CacheKey(device: device, pid: pid)
+        let cacheKey = CacheKey(deviceMatcher: device.map { DeviceMatcher(of: $0) },
+                                pid: pid)
         if let eventTransformer = eventTransformerCache.value(forKey: cacheKey) {
             return eventTransformer
         }

--- a/LinearMouse/Model/Configuration/DeviceMatcher.swift
+++ b/LinearMouse/Model/Configuration/DeviceMatcher.swift
@@ -3,14 +3,14 @@
 
 import Defaults
 
-struct DeviceMatcher: Codable, Equatable, Defaults.Serializable {
+struct DeviceMatcher: Codable, Equatable, Hashable, Defaults.Serializable {
     @HexRepresentation var vendorID: Int?
     @HexRepresentation var productID: Int?
     var productName: String?
     var serialNumber: String?
     @SingleValueOrArray var category: [Category]?
 
-    enum Category: String, Codable {
+    enum Category: String, Codable, Hashable {
         case mouse, trackpad
     }
 }

--- a/LinearMouse/Utilities/Codable/HexRepresentation.swift
+++ b/LinearMouse/Utilities/Codable/HexRepresentation.swift
@@ -4,7 +4,7 @@
 import Foundation
 
 @propertyWrapper
-struct HexRepresentation<Value: BinaryInteger & Codable>: Equatable {
+struct HexRepresentation<Value: BinaryInteger & Codable>: Equatable, Hashable {
     var wrappedValue: Value?
 
     init(wrappedValue value: Value?) {

--- a/LinearMouse/Utilities/Codable/SingleValueOrArray.swift
+++ b/LinearMouse/Utilities/Codable/SingleValueOrArray.swift
@@ -21,6 +21,8 @@ extension SingleValueOrArray: CustomStringConvertible {
 
 extension SingleValueOrArray: Equatable where Value: Equatable {}
 
+extension SingleValueOrArray: Hashable where Value: Hashable {}
+
 extension SingleValueOrArray: Codable {
     init(from decoder: Decoder) throws {
         let container = try decoder.singleValueContainer()

--- a/Modules/PointerKit/Sources/PointerKit/PointerDeviceManager.swift
+++ b/Modules/PointerKit/Sources/PointerKit/PointerDeviceManager.swift
@@ -219,6 +219,10 @@ extension PointerDeviceManager {
     }
 
     public func pointerDeviceFromIOHIDEvent(_ ioHidEvent: IOHIDEvent) -> PointerDevice? {
+        guard let eventSystemClient = eventSystemClient else {
+            return nil
+        }
+
         let senderID = IOHIDEventGetSenderID(ioHidEvent)
         let serviceClient = IOHIDEventSystemClientCopyServiceForRegistryID(eventSystemClient, senderID)
         return serviceClient.flatMap { serviceClientToPointerDevice[$0] }


### PR DESCRIPTION
This could result in high CPU usage when switching to other users and then switching back.