### PR TITLE
Button mappings: Keyboard shortcut: Fix keyup order

### DIFF
--- a/LinearMouse/EventTransformer/ButtonActionsTransformer.swift
+++ b/LinearMouse/EventTransformer/ButtonActionsTransformer.swift
@@ -61,9 +61,10 @@ extension ButtonActionsTransformer: EventTransformer {
             return event
         }
 
-        if keyTypes.contains(event.type), let flags = keySimulator.updateCGEventFlags(event) {
-            os_log("CGEvent flags updated to %{public}@", log: Self.log, type: .info,
-                   String(describing: flags))
+        if keyTypes.contains(event.type), let newFlags = keySimulator.modifiedCGEventFlags(of: event) {
+            os_log("Update CGEventFlags from %{public}llu to %{public}llu", log: Self.log, type: .info,
+                   event.flags.rawValue, newFlags.rawValue)
+            event.flags = newFlags
         }
 
         repeatTimer?.invalidate()

--- a/LinearMouse/EventTransformer/ButtonActionsTransformer.swift
+++ b/LinearMouse/EventTransformer/ButtonActionsTransformer.swift
@@ -284,7 +284,7 @@ extension ButtonActionsTransformer: EventTransformer {
             postScrollEvent(direction: .right, distance: distance)
 
         case let .arg1(.keyPress(keys)):
-            try keySimulator.press(keys: keys)
+            try keySimulator.press(keys: keys, tap: .cgSessionEventTap)
             keySimulator.reset()
         }
     }
@@ -409,12 +409,12 @@ extension ButtonActionsTransformer: EventTransformer {
         case let .arg1(.keyPress(keys)) where mouseDownEventTypes.contains(event.type):
             os_log("Down keys: %{public}@", log: Self.log, type: .info,
                    String(describing: keys))
-            try? keySimulator.down(keys: keys)
+            try? keySimulator.down(keys: keys, tap: .cgSessionEventTap)
             return true
         case let .arg1(.keyPress(keys)) where mouseUpEventTypes.contains(event.type):
             os_log("Up keys: %{public}@", log: Self.log, type: .info,
                    String(describing: keys))
-            try? keySimulator.up(keys: keys)
+            try? keySimulator.up(keys: keys.reversed(), tap: .cgSessionEventTap)
             keySimulator.reset()
             return true
         default:

--- a/Modules/KeyKit/Sources/KeyKit/KeySimulator.swift
+++ b/Modules/KeyKit/Sources/KeyKit/KeySimulator.swift
@@ -103,7 +103,7 @@ public extension KeySimulator {
         try press(keys: keys, tap: tap)
     }
 
-    func updateCGEventFlags(_ event: CGEvent) -> CGEventFlags? {
+    func modifiedCGEventFlags(of event: CGEvent) -> CGEventFlags? {
         guard !flags.isEmpty else {
             return nil
         }
@@ -111,8 +111,6 @@ public extension KeySimulator {
         guard event.type == .keyDown || event.type == .keyUp else {
             return nil
         }
-
-        event.flags = flags
 
         return flags
     }

--- a/Modules/KeyKit/Sources/KeyKit/KeySimulator.swift
+++ b/Modules/KeyKit/Sources/KeyKit/KeySimulator.swift
@@ -96,7 +96,7 @@ public extension KeySimulator {
 
     func press(keys: [Key], tap: CGEventTapLocation? = nil) throws {
         try down(keys: keys, tap: tap)
-        try up(keys: keys, tap: tap)
+        try up(keys: keys.reversed(), tap: tap)
     }
 
     func press(_ keys: Key..., tap: CGEventTapLocation? = nil) throws {


### PR DESCRIPTION
The order of key releases needs to be reversed.

For instance, when <kbd>command</kbd> + <kbd>tab</kbd> is pressed the events should occur in the following order:

1. <kbd>command</kbd> down.
2. <kbd>tab</kbd> down.
3. <kbd>command</kbd> up.
4. <kbd>tab</kbd> up.