### PR TITLE
Button mappings: Keyboard shortcut: Handle modifiers separately

### DIFF
--- a/Modules/KeyKit/Sources/KeyKit/Key.swift
+++ b/Modules/KeyKit/Sources/KeyKit/Key.swift
@@ -86,6 +86,15 @@ public enum Key: String, Codable {
     case backetRight = "]"
 }
 
+extension Key {
+    private static let modifiersKeys: Set<Key> = [.command, .shift, .option, .control,
+                                                  .commandRight, .shiftRight, .optionRight, .controlRight]
+
+    public var isModifier: Bool {
+        Self.modifiersKeys.contains(self)
+    }
+}
+
 extension Key: CustomStringConvertible {
     public var description: String {
         switch self {


### PR DESCRIPTION
In general, there's no need to continuously press the keyboard shortcuts. However, if the shortcuts consist solely of modifier keys, it is needed to hold them down until the mouse button is released.