### PR TITLE
Fix potential high CPU usage

### DIFF
--- a/LinearMouse/DefaultsKeys.swift
+++ b/LinearMouse/DefaultsKeys.swift
@@ -10,5 +10,5 @@ extension Defaults.Keys {
 
     static let bypassEventsFromOtherApplications = Key("bypassEventsFromOtherApplications", default: false)
 
-    static let detailedLoggingOn = Key("detailedLoggingOn", default: false)
+    static let verbosedLoggingOn = Key("verbosedLoggingOn", default: false)
 }

--- a/LinearMouse/Model/DeviceModel.swift
+++ b/LinearMouse/Model/DeviceModel.swift
@@ -5,21 +5,29 @@ import Combine
 import Foundation
 import SwiftUI
 
-class DeviceModel: ObservableObject {
-    let device: Device
+class DeviceModel: ObservableObject, Identifiable {
+    var id = UUID()
+
+    let deviceRef: WeakRef<Device>
 
     private var subscriptions = Set<AnyCancellable>()
 
     @Published var isActive = false
     @Published var isSelected = false
 
-    init(device: Device) {
-        self.device = device
+    let name: String
+    let category: Device.Category
 
-        DeviceManager.shared.$lastActiveDevice
+    init(deviceRef: WeakRef<Device>) {
+        self.deviceRef = deviceRef
+
+        name = deviceRef.value?.name ?? "(removed)"
+        category = deviceRef.value?.category ?? .mouse
+
+        DeviceManager.shared.$lastActiveDeviceRef
             .throttle(for: 0.5, scheduler: RunLoop.main, latest: true)
             .removeDuplicates()
-            .map { $0 == device }
+            .map { deviceRef.value != nil && $0?.value == deviceRef.value }
             .sink { [weak self] value in
                 withAnimation {
                     self?.isActive = value
@@ -27,23 +35,14 @@ class DeviceModel: ObservableObject {
             }
             .store(in: &subscriptions)
 
-        DeviceState.shared.$currentDevice
-            .map { $0 == device }
+        DeviceState.shared.$currentDeviceRef
+            .map { deviceRef.value != nil && $0?.value == deviceRef.value }
             .assign(to: \.isSelected, on: self)
             .store(in: &subscriptions)
     }
 }
 
 extension DeviceModel {
-    var name: String { device.name }
-
-    var category: Device.Category { device.category }
-
-    var isMouse: Bool { device.category == .mouse }
-
-    var isTrackpad: Bool { device.category == .trackpad }
-}
-
-extension DeviceModel: Identifiable {
-    var id: Device { device }
+    var isMouse: Bool { category == .mouse }
+    var isTrackpad: Bool { category == .trackpad }
 }

--- a/LinearMouse/State/SchemeState.swift
+++ b/LinearMouse/State/SchemeState.swift
@@ -21,7 +21,7 @@ class SchemeState: ObservableObject {
             }
             .store(in: &subscriptions)
 
-        deviceState.$currentDevice
+        deviceState.$currentDeviceRef
             .sink { [weak self] _ in
                 self?.objectWillChange.send()
             }
@@ -31,7 +31,7 @@ class SchemeState: ObservableObject {
 
 extension SchemeState {
     private var device: Device? {
-        deviceState.currentDevice
+        deviceState.currentDeviceRef?.value
     }
 
     var isSchemeValid: Bool {

--- a/LinearMouse/UI/GeneralSettings/LoggingSection.swift
+++ b/LinearMouse/UI/GeneralSettings/LoggingSection.swift
@@ -6,7 +6,7 @@ import OSLog
 import SwiftUI
 
 struct LoggingSection: View {
-    @Default(.detailedLoggingOn) private var detailedLoggingOn
+    @Default(.verbosedLoggingOn) private var detailedLoggingOn
 
     private let exportQueue = DispatchQueue(label: "log-export")
     @State private var exporting = false

--- a/LinearMouse/UI/Header/AppIndicator/AppPickerSheet/AppPickerState.swift
+++ b/LinearMouse/UI/Header/AppIndicator/AppPickerSheet/AppPickerState.swift
@@ -18,7 +18,8 @@ class AppPickerState: ObservableObject {
     }
 
     private var configuredAppSet: Set<String> {
-        guard let device = deviceState.currentDevice else { return [] }
+        guard let device = deviceState.currentDeviceRef?.value else { return [] }
+
         return Set(schemeState.allDeviceSpecficSchemes(of: device).reduce([String]()) { acc, element in
             guard let app = element.element.if?.first?.app else {
                 return acc

--- a/LinearMouse/UI/Header/DeviceIndicator/DeviceIndicatorState.swift
+++ b/LinearMouse/UI/Header/DeviceIndicator/DeviceIndicatorState.swift
@@ -13,11 +13,11 @@ class DeviceIndicatorState: ObservableObject {
     private var subscriptions = Set<AnyCancellable>()
 
     init() {
-        deviceState.$currentDevice
+        deviceState.$currentDeviceRef
             .receive(on: RunLoop.main)
             .removeDuplicates()
-            .sink { [weak self] device in
-                self?.activeDeviceName = device?.name
+            .sink { [weak self] deviceRef in
+                self?.activeDeviceName = deviceRef?.value?.name
             }
             .store(in: &subscriptions)
     }

--- a/LinearMouse/UI/Header/DeviceIndicator/DevicePickerSheet/DevicePickerSectionState.swift
+++ b/LinearMouse/UI/Header/DeviceIndicator/DevicePickerSheet/DevicePickerSectionState.swift
@@ -10,6 +10,6 @@ class DevicePickerSectionState: ObservableObject {
     let deviceState = DeviceState.shared
 
     func setDevice(_ deviceModel: DeviceModel) {
-        deviceState.currentDevice = deviceModel.device
+        deviceState.currentDeviceRef = deviceModel.deviceRef
     }
 }

--- a/LinearMouse/UI/Header/DeviceIndicator/DevicePickerSheet/DevicePickerState.swift
+++ b/LinearMouse/UI/Header/DeviceIndicator/DevicePickerSheet/DevicePickerState.swift
@@ -14,7 +14,7 @@ class DevicePickerState: ObservableObject {
     init() {
         DeviceManager.shared.$devices.map {
             $0
-                .map { DeviceModel(device: $0) }
+                .map { DeviceModel(deviceRef: WeakRef($0)) }
         }
         .receive(on: RunLoop.main)
         .sink { [weak self] value in

--- a/LinearMouse/Utilities/WeakRef.swift
+++ b/LinearMouse/Utilities/WeakRef.swift
@@ -6,6 +6,8 @@ import Foundation
 class WeakRef<T: AnyObject> {
     weak var value: T?
 
+    init() {}
+
     init(_ value: T) {
         self.value = value
     }


### PR DESCRIPTION
According to the logs provided in [this comment][1] (issue #502),
I believe that there is still somewhere that `Device` will leak.

To avoid potential leaks,

1. `Device` => `WeakRef<Device>`.
2. Cancel input observation when a `Device` is removed.

[1]: https://github.com/linearmouse/linearmouse/issues/502#issuecomment-1634494476