### PR TITLE
Scrolling modifiers: Add "Default Action", "Ignore Modifier" and update the behavior of "No Action"

### DIFF
--- a/Documentation/Configuration.d.ts
+++ b/Documentation/Configuration.d.ts
@@ -233,9 +233,25 @@ declare namespace Scheme {
 
     namespace Modifiers {
       /**
-       * @description No actions.
+       * @deprecated
+       * @description Default action.
        */
       type None = { type: "none" };
+
+      /**
+       * @description Default action.
+       */
+      type Auto = { type: "auto" };
+
+      /**
+       * @description Ignore modifier.
+       */
+      type Ignore = { type: "ignore" };
+
+      /**
+       * @description No action.
+       */
+      type PreventDefault = { type: "preventDefault" };
 
       /**
        * @description Alter the scrolling orientation from vertical to horizontal or vice versa.
@@ -263,7 +279,14 @@ declare namespace Scheme {
         type: "zoom";
       };
 
-      type Action = None | AlterOrientation | ChangeSpeed | Zoom;
+      type Action =
+        | None
+        | Auto
+        | Ignore
+        | PreventDefault
+        | AlterOrientation
+        | ChangeSpeed
+        | Zoom;
     }
   }
 

--- a/Documentation/Configuration.json
+++ b/Documentation/Configuration.json
@@ -1005,6 +1005,15 @@
           "$ref": "#/definitions/Scheme.Scrolling.Modifiers.None"
         },
         {
+          "$ref": "#/definitions/Scheme.Scrolling.Modifiers.Auto"
+        },
+        {
+          "$ref": "#/definitions/Scheme.Scrolling.Modifiers.Ignore"
+        },
+        {
+          "$ref": "#/definitions/Scheme.Scrolling.Modifiers.PreventDefault"
+        },
+        {
           "$ref": "#/definitions/Scheme.Scrolling.Modifiers.AlterOrientation"
         },
         {
@@ -1021,6 +1030,20 @@
       "properties": {
         "type": {
           "const": "alterOrientation",
+          "type": "string"
+        }
+      },
+      "required": [
+        "type"
+      ],
+      "type": "object"
+    },
+    "Scheme.Scrolling.Modifiers.Auto": {
+      "additionalProperties": false,
+      "description": "Default action.",
+      "properties": {
+        "type": {
+          "const": "auto",
           "type": "string"
         }
       },
@@ -1048,12 +1071,41 @@
       ],
       "type": "object"
     },
+    "Scheme.Scrolling.Modifiers.Ignore": {
+      "additionalProperties": false,
+      "description": "Ignore modifier.",
+      "properties": {
+        "type": {
+          "const": "ignore",
+          "type": "string"
+        }
+      },
+      "required": [
+        "type"
+      ],
+      "type": "object"
+    },
     "Scheme.Scrolling.Modifiers.None": {
       "additionalProperties": false,
-      "description": "No actions.",
+      "deprecated": true,
+      "description": "Default action.",
       "properties": {
         "type": {
           "const": "none",
+          "type": "string"
+        }
+      },
+      "required": [
+        "type"
+      ],
+      "type": "object"
+    },
+    "Scheme.Scrolling.Modifiers.PreventDefault": {
+      "additionalProperties": false,
+      "description": "No action.",
+      "properties": {
+        "type": {
+          "const": "preventDefault",
           "type": "string"
         }
       },

--- a/LinearMouse/EventTransformer/ModifierActionsTransformer.swift
+++ b/LinearMouse/EventTransformer/ModifierActionsTransformer.swift
@@ -33,7 +33,7 @@ class ModifierActionsTransformer: EventTransformer {
         ]
         var event = event
         for case let (flag, action) in actions where event.flags.contains(flag) {
-            if let action = action, action != .none {
+            if let action = action, action != .auto {
                 guard let handledEvent = handleModifierKeyAction(for: event, action: action) else {
                     return nil
                 }
@@ -48,8 +48,10 @@ class ModifierActionsTransformer: EventTransformer {
         let scrollWheelEventView = ScrollWheelEventView(event)
 
         switch action {
-        case .none:
+        case .auto, .ignore:
             break
+        case .preventDefault:
+            return nil
         case .alterOrientation:
             scrollWheelEventView.swapXY()
         case let .changeSpeed(scale: scale):

--- a/LinearMouse/Model/Configuration/Scheme/Scrolling/Modifiers.swift
+++ b/LinearMouse/Model/Configuration/Scheme/Scrolling/Modifiers.swift
@@ -14,7 +14,9 @@ extension Scheme.Scrolling {
 
 extension Scheme.Scrolling.Modifiers {
     enum Action: Equatable {
-        case none
+        case auto
+        case ignore
+        case preventDefault
         case alterOrientation
         case changeSpeed(scale: Decimal)
         case zoom
@@ -55,7 +57,14 @@ extension Scheme.Scrolling.Modifiers.Action: Codable {
     }
 
     enum ActionType: String, Codable {
-        case none, alterOrientation, changeSpeed, zoom
+        @available(*, deprecated)
+        case none
+        case auto
+        case ignore
+        case preventDefault
+        case alterOrientation
+        case changeSpeed
+        case zoom
     }
 
     init(from decoder: Decoder) throws {
@@ -63,8 +72,12 @@ extension Scheme.Scrolling.Modifiers.Action: Codable {
         let type = try container.decode(ActionType.self, forKey: .type)
 
         switch type {
-        case .none:
-            self = .none
+        case .none, .auto:
+            self = .auto
+        case .ignore:
+            self = .ignore
+        case .preventDefault:
+            self = .preventDefault
         case .alterOrientation:
             self = .alterOrientation
         case .changeSpeed:
@@ -79,8 +92,12 @@ extension Scheme.Scrolling.Modifiers.Action: Codable {
         var container = encoder.container(keyedBy: CodingKeys.self)
 
         switch self {
-        case .none:
-            try container.encode(ActionType.none, forKey: .type)
+        case .auto:
+            try container.encode(ActionType.auto, forKey: .type)
+        case .ignore:
+            try container.encode(ActionType.ignore, forKey: .type)
+        case .preventDefault:
+            try container.encode(ActionType.preventDefault, forKey: .type)
         case .alterOrientation:
             try container.encode(ActionType.alterOrientation, forKey: .type)
         case let .changeSpeed(scale):

--- a/LinearMouse/ModifierKeys.swift
+++ b/LinearMouse/ModifierKeys.swift
@@ -18,7 +18,7 @@ extension ModifierKeyAction {
     var schemeAction: Scheme.Scrolling.Modifiers.Action {
         switch type {
         case .noAction:
-            return .none
+            return .preventDefault
         case .alterOrientation:
             return .alterOrientation
         case .changeSpeed:

--- a/LinearMouse/UI/ScrollingSettings/ModifierKeysSection/ModifierKeyActionPicker.swift
+++ b/LinearMouse/UI/ScrollingSettings/ModifierKeysSection/ModifierKeyActionPicker.swift
@@ -12,7 +12,7 @@ extension ScrollingSettings.ModifierKeysSection {
         var body: some View {
             Picker(label, selection: actionType) {
                 ForEach(ActionType.allCases) { type in
-                    Text(NSLocalizedString(type.rawValue, comment: "")).tag(type)
+                    Text(NSLocalizedString(type.rawValue, comment: "").capitalized).tag(type)
                 }
             }
             .modifier(PickerViewModifier())
@@ -34,6 +34,8 @@ extension ScrollingSettings.ModifierKeysSection.ModifierKeyActionPicker {
     enum ActionType: String, CaseIterable, Identifiable {
         var id: Self { self }
 
+        case defaultAction = "Default action"
+        case ignore = "Ignore modifier"
         case noAction = "No action"
         case alterOrientation = "Alter orientation"
         case changeSpeed = "Change speed"
@@ -48,7 +50,11 @@ extension ScrollingSettings.ModifierKeysSection.ModifierKeyActionPicker {
                 }
 
                 switch action {
-                case .none:
+                case .auto:
+                    return .defaultAction
+                case .ignore:
+                    return .ignore
+                case .preventDefault:
                     return .noAction
                 case .alterOrientation:
                     return .alterOrientation
@@ -61,8 +67,12 @@ extension ScrollingSettings.ModifierKeysSection.ModifierKeyActionPicker {
 
             set: { action in
                 switch action {
+                case .defaultAction:
+                    self.action = .auto
+                case .ignore:
+                    self.action = .ignore
                 case .noAction:
-                    self.action = Scheme.Scrolling.Modifiers.Action.none
+                    self.action = .preventDefault
                 case .alterOrientation:
                     self.action = .alterOrientation
                 case .changeSpeed:

--- a/LinearMouse/en.lproj/Localizable.strings
+++ b/LinearMouse/en.lproj/Localizable.strings
@@ -34,6 +34,8 @@
 "Revert to system defaults" = "Revert to system defaults";
 "Copy settings from vertical" = "Copy settings from vertical";
 "Modifier Keys" = "Modifier Keys";
+"Default action" = "Default action";
+"Ignore modifier" = "Ignore modifier";
 "No action" = "No action";
 "Alter orientation" = "Alter orientation";
 "Change speed" = "Change speed";
@@ -75,7 +77,6 @@
 "Scroll left" = "Scroll left";
 "Scroll right" = "Scroll right";
 
-"Default action" = "Default action";
 "Mission Control" = "Mission Control";
 "Move left a space" = "Move left a space";
 "Move right a space" = "Move right a space";

--- a/LinearMouseUnitTests/Event/ModifierActionsTransformerTests.swift
+++ b/LinearMouseUnitTests/Event/ModifierActionsTransformerTests.swift
@@ -7,7 +7,7 @@ import XCTest
 class ModifierActionsTransformerTests: XCTestCase {
     func testModifierActions() throws {
         var event = CGEvent(scrollWheelEvent2Source: nil, units: .line, wheelCount: 2, wheel1: 1, wheel2: 2, wheel3: 0)!
-        let modifiers = Scheme.Scrolling.Modifiers(command: Scheme.Scrolling.Modifiers.Action.preventDefault,
+        let modifiers = Scheme.Scrolling.Modifiers(command: .auto,
                                                    shift: .alterOrientation,
                                                    option: .changeSpeed(scale: 2),
                                                    control: .changeSpeed(scale: 3))

--- a/LinearMouseUnitTests/Event/ModifierActionsTransformerTests.swift
+++ b/LinearMouseUnitTests/Event/ModifierActionsTransformerTests.swift
@@ -7,7 +7,7 @@ import XCTest
 class ModifierActionsTransformerTests: XCTestCase {
     func testModifierActions() throws {
         var event = CGEvent(scrollWheelEvent2Source: nil, units: .line, wheelCount: 2, wheel1: 1, wheel2: 2, wheel3: 0)!
-        let modifiers = Scheme.Scrolling.Modifiers(command: Scheme.Scrolling.Modifiers.Action.none,
+        let modifiers = Scheme.Scrolling.Modifiers(command: Scheme.Scrolling.Modifiers.Action.preventDefault,
                                                    shift: .alterOrientation,
                                                    option: .changeSpeed(scale: 2),
                                                    control: .changeSpeed(scale: 3))


### PR DESCRIPTION
In previous versions, the scrolling modifier "No Action" was actually behaving as "Default Action". This patch addresses this issue and corrects the behavior.

This change is not considered a breaking change because the modifier action will automatically switch to "Default Action" if "No Action" was used previously.

Additionally, two new modifier actions have been added: "Default Action" and "Ignore Modifier". "Ignore Modifier" behaves as if the modifier key was not pressed.

Closes #544.
