### PR TITLE
Fix some translation

### DIFF
--- a/LinearMouse/fr.lproj/Localizable.strings
+++ b/LinearMouse/fr.lproj/Localizable.strings
@@ -78,8 +78,8 @@
 "Scroll right" = "Défiler vers la droite";
 
 "Mission Control" = "Mission Control";
-"Move left a space" = "Déplacer vers la gauche un espace";
-"Move right a space" = "Déplacer vers la gauche un espace";
+"Move left a space" = "Déplacer vers la gauche d'un espace";
+"Move right a space" = "Déplacer vers la droite d'un espace";
 "Application windows" = "Fenêtre d'application";
 "Launchpad" = "Launchpad";
 "Show desktop" = "Montrer le bureau";

--- a/LinearMouse/tr.lproj/Localizable.strings
+++ b/LinearMouse/tr.lproj/Localizable.strings
@@ -78,7 +78,7 @@
 "Scroll right" = "Sağa Kaydır";
 
 "Mission Control" = "Görev Kontrol";
-"Move left a space" = "Sağa bir boşluk kaydır";
+"Move left a space" = "Sola bir boşluk kaydır";
 "Move right a space" = "Sağa bir boşluk kaydır";
 "Application windows" = "Uygulama pencereleri";
 "Launchpad" = "Launchpad";


### PR DESCRIPTION
In FR and TR, translations for moving a space was the same for righ and left