### PR TITLE
Pointer: Pointer speed may not work properly on macOS Sonoma

### DIFF
--- a/LinearMouse/Device/DeviceManager.swift
+++ b/LinearMouse/Device/DeviceManager.swift
@@ -32,7 +32,12 @@ class DeviceManager: ObservableObject {
             self?.eventReceived($0, $1, $2)
         }).tieToLifetime(of: self)
 
-        for property in [kIOHIDMouseAccelerationType, kIOHIDTrackpadAccelerationType, kIOHIDPointerResolutionKey] {
+        for property in [
+            kIOHIDMouseAccelerationType,
+            kIOHIDTrackpadAccelerationType,
+            kIOHIDPointerResolutionKey,
+            "HIDUseLinearScalingMouseAcceleration"
+        ] {
             manager.observePropertyChanged(property: property) { [self] _ in
                 os_log("Property %{public}@ changed", log: Self.log, type: .info, property)
                 updatePointerSpeed()

--- a/Modules/PointerKit/Sources/PointerKit/PointerDevice.swift
+++ b/Modules/PointerKit/Sources/PointerKit/PointerDevice.swift
@@ -149,14 +149,14 @@ public extension PointerDevice {
         }
     }
 
-    var useLinearScalingMouseAcceleration: Bool? {
+    var useLinearScalingMouseAcceleration: Int? {
         get {
             // TODO: Use `kIOHIDUseLinearScalingMouseAccelerationKey`.
-            client.getProperty("IOHIDUseLinearScalingMouseAcceleration")
+            client.getProperty("HIDUseLinearScalingMouseAcceleration")
         }
         set {
             // TODO: Use `kIOHIDUseLinearScalingMouseAccelerationKey`.
-            client.setProperty(newValue, forKey: "IOHIDUseLinearScalingMouseAcceleration")
+            client.setProperty(newValue, forKey: "HIDUseLinearScalingMouseAcceleration")
         }
     }
 
@@ -167,7 +167,7 @@ public extension PointerDevice {
      */
     var pointerAcceleration: Double? {
         get {
-            if useLinearScalingMouseAcceleration == true {
+            if useLinearScalingMouseAcceleration == 1 {
                 return -1
             }
             return client.getPropertyIOFixed(pointerAccelerationType ?? kIOHIDMouseAccelerationTypeKey)
@@ -175,7 +175,7 @@ public extension PointerDevice {
 
         set {
             if useLinearScalingMouseAcceleration != nil, let value = newValue {
-                useLinearScalingMouseAcceleration = value == -1 ? true : false
+                useLinearScalingMouseAcceleration = value == -1 ? 1 : 0
                 if value == -1 {
                     return
                 }

--- a/Modules/PointerKit/Tests/PointerKitTests/PointerDeviceManagerTest.swift
+++ b/Modules/PointerKit/Tests/PointerKitTests/PointerDeviceManagerTest.swift
@@ -1,6 +1,7 @@
 // MIT License
 // Copyright (c) 2021-2023 LinearMouse
 
+import ObservationToken
 @testable import PointerKit
 import XCTest
 
@@ -63,6 +64,7 @@ class PointerDeviceManagerTest: XCTestCase {
                 print("Pointer resolution:", device.pointerResolution ?? "(nil)")
                 print("Pointer acceleration type:", device.pointerAccelerationType ?? "(nil)")
                 print("Pointer acceleration:", device.pointerAcceleration ?? "(nil)")
+                print("Use linear scaling mouse acceleration:", device.useLinearScalingMouseAcceleration ?? "(nil)")
                 print("==========================")
             }
         }


### PR DESCRIPTION
This is caused by a typo in the property name, which means that `HIDUseLinearScalingMouseAcceleration` is not being set correctly on macOS Sonoma. As a result, mouse pointer speed does not work properly if pointer acceleration is turned off in the System Settings.

Closes #565.