### PR TITLE
Pointer: Tracking speed can now be configured when the pointer acceleration is disabled in macOS Sonoma

### DIFF
--- a/LinearMouse/Device/Device.swift
+++ b/LinearMouse/Device/Device.swift
@@ -94,6 +94,22 @@ extension Device {
         return .mouse
     }
 
+    /**
+     This feature was introduced in macOS Sonoma. In the earlier versions of
+     macOS, this value would be nil.
+     */
+    var disablePointerAcceleration: Bool? {
+        get {
+            device.useLinearScalingMouseAcceleration.map { $0 != 0 }
+        }
+        set {
+            guard device.useLinearScalingMouseAcceleration != nil, let newValue = newValue else {
+                return
+            }
+            device.useLinearScalingMouseAcceleration = newValue ? 1 : 0
+        }
+    }
+
     var pointerAcceleration: Double {
         get {
             device.pointerAcceleration ?? Self.fallbackPointerAcceleration

--- a/LinearMouse/UI/PointerSettings/PointerSettings.swift
+++ b/LinearMouse/UI/PointerSettings/PointerSettings.swift
@@ -70,6 +70,32 @@ struct PointerSettings: View {
                                 revertPointerSpeed()
                             }
                         }
+                    } else if #available(macOS 14, *) {
+                        HStack(alignment: .firstTextBaseline) {
+                            Slider(value: $state.pointerAcceleration,
+                                   in: 0.0 ... 20.0) {
+                                labelWithDescription {
+                                    Text("Tracking speed")
+                                    Text("(0–20)")
+                                }
+                            }
+                            TextField("",
+                                      value: $state.pointerAcceleration,
+                                      formatter: state.pointerAccelerationFormatter)
+                                .labelsHidden()
+                                .textFieldStyle(.roundedBorder)
+                                .multilineTextAlignment(.trailing)
+                                .frame(width: 80)
+                        }
+
+                        Button("Revert to system defaults") {
+                            revertPointerSpeed()
+                        }
+                        .keyboardShortcut("z", modifiers: [.control, .command, .shift])
+
+                        Text("You may also press ⌃⇧⌘Z to revert to system defaults.")
+                            .controlSize(.small)
+                            .foregroundColor(.secondary)
                     }
                 }
                 .modifier(SectionViewModifier())

--- a/LinearMouse/en.lproj/Localizable.strings
+++ b/LinearMouse/en.lproj/Localizable.strings
@@ -44,6 +44,7 @@
 "Disable pointer acceleration" = "Disable pointer acceleration";
 "Pointer acceleration" = "Pointer acceleration";
 "Pointer speed" = "Pointer speed";
+"Tracking speed" = "Tracking speed";
 "You may also press ⌃⇧⌘Z to revert to system defaults." = "You may also press ⌃⇧⌘Z to revert to system defaults.";
 
 "Enable universal back and forward" = "Enable universal back and forward";


### PR DESCRIPTION
Issue: #525.