### PR TITLE
Add support for side buttons of some “unstandard” bluetooth devices

### DIFF
--- a/LinearMouse/Device/Device.swift
+++ b/LinearMouse/Device/Device.swift
@@ -24,6 +24,9 @@ class Device {
     private let initialPointerResolution: Double
 
     private var inputObservationToken: ObservationToken?
+    private var reportObservationToken: ObservationToken?
+
+    private var lastButtonStates: UInt8 = 0
 
     init(_ manager: DeviceManager, _ device: PointerDevice) {
         self.manager = manager
@@ -36,6 +39,10 @@ class Device {
             self?.inputValueCallback($0, $1)
         })
 
+        reportObservationToken = device.observeReport(using: { [weak self] in
+            self?.inputReportCallback($0, $1)
+        })
+
         os_log("Device initialized: %{public}@: HIDPointerResolution=%{public}f, HIDPointerAccelerationType=%{public}@",
                log: Self.log, type: .info,
                String(describing: device),
@@ -45,6 +52,9 @@ class Device {
 
     func markRemoved() {
         removed = true
+
+        inputObservationToken = nil
+        reportObservationToken = nil
     }
 }
 
@@ -173,15 +183,6 @@ extension Device {
     }
 
     private func inputValueCallback(_ device: PointerDevice, _ value: IOHIDValue) {
-        guard !removed else {
-            os_log("Received input from removed device: %{public}@", log: Self.log, type: .error,
-                   String(describing: device))
-            os_log("Cancelling input observation for removed device: %{public}@", log: Self.log, type: .error,
-                   String(describing: device))
-            inputObservationToken = nil
-            return
-        }
-
         if verbosedLoggingOn {
             os_log("Received input value from: %{public}@: %{public}@", log: Self.log, type: .info,
                    String(describing: device), String(describing: value))
@@ -228,6 +229,49 @@ extension Device {
                String(describing: category),
                usagePage,
                usage)
+    }
+
+    private func inputReportCallback(_ device: PointerDevice, _ report: Data) {
+        if verbosedLoggingOn {
+            let reportHex = report.map { String(format: "%02X", $0) }.joined(separator: " ")
+            os_log("Received input report from: %{public}@: %{public}@", log: Self.log, type: .info,
+                   String(describing: device), String(describing: reportHex))
+        }
+
+        // Some bluetooth devices, such as Mi Dual Mode Wireless Mouse Silent Edition, report only
+        // 3 buttons in the HID report descriptor. As a result, macOS does not recognize side button
+        // clicks from these devices.
+        //
+        // To work around this issue, we subscribe to the input reports and monitor the side button
+        // states. When the side buttons are clicked, we simulate those events.
+        guard let buttonCount = device.buttonCount, buttonCount == 3, report.count >= 2 else {
+            return
+        }
+        // | Button 0 (1 bit) | ... | Button 4 (1 bit) | Not Used (3 bits) |
+        let buttonStates = report[1] & 0x18
+        let toggled = lastButtonStates ^ buttonStates
+        guard toggled != 0 else {
+            return
+        }
+        for button in 3 ... 4 {
+            guard toggled & (1 << button) != 0 else {
+                continue
+            }
+            let down = buttonStates & (1 << button) != 0
+            os_log("Simulate button %{public}d %{public}@ event for device: %{public}@", log: Self.log, type: .info,
+                   button, down ? "down" : "up", String(describing: device))
+            guard let location = CGEvent(source: nil)?.location else {
+                continue
+            }
+            guard let event = CGEvent(mouseEventSource: nil,
+                                      mouseType: down ? .otherMouseDown : .otherMouseUp,
+                                      mouseCursorPosition: location,
+                                      mouseButton: .init(rawValue: UInt32(button))!) else {
+                continue
+            }
+            event.post(tap: .cghidEventTap)
+        }
+        lastButtonStates = buttonStates
     }
 }
 

--- a/Modules/PointerKit/Sources/PointerKit/PointerDevice.swift
+++ b/Modules/PointerKit/Sources/PointerKit/PointerDevice.swift
@@ -10,9 +10,11 @@ public class PointerDevice {
     internal let device: IOHIDDevice?
 
     public typealias InputValueClosure = (PointerDevice, IOHIDValue) -> Void
+    public typealias InputReportClosure = (PointerDevice, Data) -> Void
 
     private var observations = (
         inputValue: [UUID: InputValueClosure](),
+        inputReport: [UUID: InputReportClosure](),
         ()
     )
 
@@ -20,9 +22,18 @@ public class PointerDevice {
         guard let context = context else {
             return
         }
-
         let this = Unmanaged<PointerDevice>.fromOpaque(context).takeUnretainedValue()
+
         this.inputValueCallback(value)
+    }
+
+    private static let inputReportCallback: IOHIDReportCallback = { context, _, _, _, _, report, reportLength in
+        guard let context = context else {
+            return
+        }
+        let this = Unmanaged<PointerDevice>.fromOpaque(context).takeUnretainedValue()
+
+        this.inputReportCallback(Data(bytes: report, count: reportLength))
     }
 
     init(_ client: IOHIDServiceClient) {
@@ -32,9 +43,11 @@ public class PointerDevice {
         if let device = device {
             IOHIDDeviceOpen(device, IOOptionBits(kIOHIDOptionsTypeNone))
             IOHIDDeviceSetInputValueMatching(device, nil)
-            IOHIDDeviceRegisterInputValueCallback(device,
-                                                  Self.inputValueCallback,
-                                                  Unmanaged.passUnretained(self).toOpaque())
+            let this = Unmanaged.passUnretained(self).toOpaque()
+            IOHIDDeviceRegisterInputValueCallback(device, Self.inputValueCallback, this)
+            let reportLength = 8
+            let report = UnsafeMutablePointer<UInt8>.allocate(capacity: reportLength)
+            IOHIDDeviceRegisterInputReportCallback(device, report, reportLength, Self.inputReportCallback, this)
             IOHIDDeviceScheduleWithRunLoop(device, CFRunLoopGetCurrent(), CFRunLoopMode.defaultMode.rawValue)
         }
     }
@@ -200,6 +213,24 @@ extension PointerDevice {
 
         return ObservationToken { [weak self] in
             self?.observations.inputValue.removeValue(forKey: id)
+        }
+    }
+}
+
+// MARK: Observe input reports
+
+extension PointerDevice {
+    private func inputReportCallback(_ report: Data) {
+        for (_, callback) in observations.inputReport {
+            callback(self, report)
+        }
+    }
+
+    public func observeReport(using closure: @escaping InputReportClosure) -> ObservationToken {
+        let id = observations.inputReport.insert(closure)
+
+        return ObservationToken { [weak self] in
+            self?.observations.inputReport.removeValue(forKey: id)
         }
     }
 }


### PR DESCRIPTION
Some bluetooth devices, such as Mi Dual Mode Wireless Mouse Silent Edition, report only 3 buttons in the HID report descriptor. As a result, macOS does not recognize side button clicks from these devices.

This patch subscribes to the input reports and monitor the side button states. When the side btutons are clicked, we simulate those events.

Fixes #563.