### PR TITLE
Switch per-app settings from focused app to app under cursor

### DIFF
--- a/LinearMouse.xcodeproj/project.pbxproj
+++ b/LinearMouse.xcodeproj/project.pbxproj
@@ -106,7 +106,9 @@
 				B75A06192671E9D800BEAF77 /* Products */,
 				97C5D8F72856E18900CBED2D /* Frameworks */,
 			);
+			indentWidth = 4;
 			sourceTree = "<group>";
+			tabWidth = 4;
 		};
 		B75A06192671E9D800BEAF77 /* Products */ = {
 			isa = PBXGroup;
@@ -449,7 +451,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = LinearMouse/LinearMouse.entitlements;
 				COMBINE_HIDPI_IMAGES = YES;
-				DEVELOPMENT_ASSET_PATHS = "\"LinearMouse/Preview Content\"";
+				DEVELOPMENT_ASSET_PATHS = "";
 				ENABLE_HARDENED_RUNTIME = YES;
 				ENABLE_PREVIEWS = YES;
 				INFOPLIST_FILE = LinearMouse/Info.plist;
@@ -472,7 +474,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = LinearMouse/LinearMouse.entitlements;
 				COMBINE_HIDPI_IMAGES = YES;
-				DEVELOPMENT_ASSET_PATHS = "\"LinearMouse/Preview Content\"";
+				DEVELOPMENT_ASSET_PATHS = "";
 				ENABLE_HARDENED_RUNTIME = YES;
 				ENABLE_PREVIEWS = YES;
 				INFOPLIST_FILE = LinearMouse/Info.plist;

--- a/LinearMouse/EventTap/GlobalEventTap.swift
+++ b/LinearMouse/EventTap/GlobalEventTap.swift
@@ -18,10 +18,13 @@ class GlobalEventTap {
 
     private func callback(event: CGEvent) -> CGEvent? {
         let mouseEventView = MouseEventView(event)
-        let eventTransformer = EventTransformerManager.shared.get(withCGEvent: event,
-                                                                  withSourcePid: mouseEventView.sourcePid,
-                                                                  withTargetPid: mouseEventView.targetPid,
-                                                                  withDisplay: ScreenManager.shared.currentScreenName)
+        let eventTransformer = EventTransformerManager.shared.get(
+            withCGEvent: event,
+            withSourcePid: mouseEventView.sourcePid,
+            withTargetPid: mouseEventView.targetPid,
+            withMouseLocationPid: mouseEventView.mouseLocationWindowID.ownerPid,
+            withDisplay: ScreenManager.shared.currentScreenName
+        )
         return eventTransformer.transform(event)
     }
 

--- a/LinearMouse/EventTransformer/EventTransformerManager.swift
+++ b/LinearMouse/EventTransformer/EventTransformerManager.swift
@@ -39,7 +39,8 @@ class EventTransformerManager {
 
     func get(withCGEvent cgEvent: CGEvent,
              withSourcePid sourcePid: pid_t?,
-             withTargetPid pid: pid_t?,
+             withTargetPid targetPid: pid_t?,
+             withMouseLocationPid mouseLocationPid: pid_t?,
              withDisplay display: String?) -> EventTransformer {
         let prevActiveCacheKey = activeCacheKey
         defer {
@@ -73,18 +74,24 @@ class EventTransformerManager {
             return []
         }
 
+        let pid = mouseLocationPid ?? targetPid
+
         let device = DeviceManager.shared.deviceFromCGEvent(cgEvent)
-        let cacheKey = CacheKey(deviceMatcher: device.map { DeviceMatcher(of: $0) },
-                                pid: pid,
-                                screen: display)
+        let cacheKey = CacheKey(
+            deviceMatcher: device.map { DeviceMatcher(of: $0) },
+            pid: pid,
+            screen: display
+        )
         activeCacheKey = cacheKey
         if let eventTransformer = eventTransformerCache.value(forKey: cacheKey) {
             return eventTransformer
         }
 
-        let scheme = ConfigurationState.shared.configuration.matchScheme(withDevice: device,
-                                                                         withPid: pid,
-                                                                         withDisplay: display)
+        let scheme = ConfigurationState.shared.configuration.matchScheme(
+            withDevice: device,
+            withPid: pid,
+            withDisplay: display
+        )
 
         // TODO: Patch EventTransformer instead of rebuilding it
 

--- a/LinearMouse/EventView/MouseEventView.swift
+++ b/LinearMouse/EventView/MouseEventView.swift
@@ -47,4 +47,11 @@ class MouseEventView: EventView {
         }
         return pid
     }
+
+    var mouseLocationWindowID: CGWindowID {
+        CGWindowID(NSWindow.windowNumber(
+            at: NSPointFromCGPoint(event.unflippedLocation),
+            belowWindowWithWindowNumber: 0
+        ))
+    }
 }

--- a/LinearMouse/Preview Content/Preview Assets.xcassets/Contents.json
+++ b/LinearMouse/Preview Content/Preview Assets.xcassets/Contents.json
@@ -1,6 +1,0 @@
-{
-  "info" : {
-    "author" : "xcode",
-    "version" : 1
-  }
-}


### PR DESCRIPTION
- Previously: Settings based on focused app (using `eventTargetUnixProcessID`)
- Now: Settings based on app under mouse cursor

This change makes per-app settings more intuitive. Users can now move
the cursor over an app and immediately use its specific settings (e.g.,
custom scrolling distances) without changing focus.
