### PR TITLE
added non latin chars to keyboard shortcuts

### DIFF
--- a/Modules/KeyKit/Sources/KeyKit/Key.swift
+++ b/Modules/KeyKit/Sources/KeyKit/Key.swift
@@ -92,7 +92,7 @@ public enum Key: String, Codable {
     case å
     // Polish keyboards:
     case ą
-    case ć  
+    case ć
     case ę
     case ł
     case ń


### PR DESCRIPTION
Trying to fix #840 

The shortcut of ö, ä ü, etc. is now correctly displayed.

