### PR TITLE
docs: List SwiftFormat as a dependency in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,13 +11,14 @@ Instructions for building LinearMouse on macOS.
 ### Dependencies
 
 - [Xcode](https://apps.apple.com/app/xcode/id497799835), obviously
-- [Swiftlint](https://github.com/realm/SwiftLint), used to lint' swift files
+- [Swiftlint](https://github.com/realm/SwiftLint), used to lint swift files
+- [SwiftFormat](https://github.com/nicklockwood/SwiftFormat), used to format swit files.
 - `npm` & [ts-json-schema-generator](https://www.npmjs.com/package/ts-json-schema-generator)), used to generate and document the custom configuration JSON scheme
 
 Install tools using brew:
 
 ```bash
-$ brew install npm swiftlint
+$ brew install npm swiftlint swiftformat
 ```
 
 Install npm dependencies from the [package.json](./package.json)


### PR DESCRIPTION
SwiftFormat is being used by `make lint`, but was previously not being listed as a dependency.

Used by `Makefile` here: https://github.com/linearmouse/linearmouse/blob/f56cc95a0b5f0d11d8b9c269ecf33212520d5fdd/Makefile#L27-L29