### PR TITLE
Add numpad key support in button mapping actions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,118 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+LinearMouse is a macOS utility app that enhances mouse and trackpad functionality. It's built with Swift and uses SwiftUI for the user interface. The app provides customizable mouse button mappings, scrolling behavior, and pointer settings that can be configured per-device, per-application, or per-display.
+
+## Development Commands
+
+### Build and Test
+```bash
+# Build the project
+xcodebuild -project LinearMouse.xcodeproj -scheme LinearMouse
+
+# Run tests
+make test
+# or
+xcodebuild test -project LinearMouse.xcodeproj -scheme LinearMouse
+
+# Full build pipeline (configure, clean, lint, test, package)
+make all
+```
+
+### Code Quality
+```bash
+# Lint the codebase
+make lint
+# or run individually:
+swiftformat --lint .
+swiftlint .
+
+# Clean build artifacts
+make clean
+```
+
+### Packaging
+```bash
+# Create DMG package
+make package
+
+# For release (requires signing certificates)
+make configure-release
+make prepublish
+```
+
+### Configuration Schema Generation
+```bash
+# Generate JSON schema from TypeScript definitions
+npm run generate:json-schema
+```
+
+## Architecture Overview
+
+### Core Components
+
+1. **EventTransformer System** (`LinearMouse/EventTransformer/`):
+   - `EventTransformerManager`: Central coordinator that manages event processing
+   - Individual transformers handle specific functionality (scrolling, button mapping, etc.)
+   - Uses LRU cache for performance optimization
+
+2. **Configuration System** (`LinearMouse/Model/Configuration/`):
+   - `Configuration.swift`: Main configuration model with JSON schema validation
+   - `Scheme.swift`: Defines device-specific settings
+   - `DeviceMatcher.swift`: Logic for matching devices to configurations
+
+3. **Device Management** (`LinearMouse/Device/`):
+   - `DeviceManager.swift`: Manages connected input devices
+   - `Device.swift`: Represents individual input devices
+
+4. **Event Processing** (`LinearMouse/EventTap/`):
+   - `GlobalEventTap.swift`: Captures system-wide input events
+   - `EventTap.swift`: Base event handling functionality
+
+5. **User Interface** (`LinearMouse/UI/`):
+   - SwiftUI-based settings interface
+   - Modular components for different settings categories
+   - State management using `@Published` properties
+
+### Custom Modules
+
+The project includes several custom Swift packages in the `Modules/` directory:
+
+- **KeyKit**: Keyboard input handling and simulation
+- **PointerKit**: Mouse/trackpad device interaction
+- **GestureKit**: Gesture recognition (zoom, navigation swipes)
+- **DockKit**: Dock integration utilities
+- **ObservationToken**: Observation pattern utilities
+
+### Key Patterns
+
+1. **Event Transformation Pipeline**: Events flow through multiple transformers in sequence
+2. **Configuration-Driven Behavior**: All functionality is controlled by JSON configuration
+3. **Device Matching**: Settings are applied based on device type, application, or display
+4. **State Management**: Uses Combine framework for reactive state updates
+
+## Important Development Notes
+
+- The app requires accessibility permissions to function
+- Event processing happens at the system level using CGEvent
+- Configuration is stored as JSON and validated against a schema
+- The project uses Swift Package Manager for dependencies
+- Localization is handled through Crowdin integration
+- Code signing is required for distribution (see `Scripts/` directory)
+
+## Testing
+
+- Unit tests are in `LinearMouseUnitTests/`
+- Focus on testing event transformers and configuration parsing
+- Run tests before submitting changes: `make test`
+
+## Configuration Structure
+
+The app uses a JSON configuration format with:
+- `schemes`: Array of device-specific configurations
+- Each scheme can target specific devices, applications, or displays
+- Settings include button mappings, scrolling behavior, and pointer adjustments
+- Configuration schema is defined in `Documentation/Configuration.d.ts`

--- a/Documentation/Configuration.d.ts
+++ b/Documentation/Configuration.d.ts
@@ -319,6 +319,13 @@ declare namespace Scheme {
      * @default false
      */
     disableAcceleration?: boolean;
+
+    /**
+     * @title Redirects to scroll
+     * @description If the value is true, pointer movements will be redirected to scroll events.
+     * @default false
+     */
+    redirectsToScroll?: boolean;
   };
 
   type Buttons = {
@@ -724,7 +731,25 @@ declare namespace Scheme {
         | "\\"
         | "`"
         | "["
-        | "]";
+        | "]"
+        | "numpadPlus"
+        | "numpadMinus"
+        | "numpadMultiply"
+        | "numpadDivide"
+        | "numpadEnter"
+        | "numpadEquals"
+        | "numpadDecimal"
+        | "numpadClear"
+        | "numpad0"
+        | "numpad1"
+        | "numpad2"
+        | "numpad3"
+        | "numpad4"
+        | "numpad5"
+        | "numpad6"
+        | "numpad7"
+        | "numpad8"
+        | "numpad9";
     }
 
     type UniversalBackForward =

--- a/Documentation/Configuration.json
+++ b/Documentation/Configuration.json
@@ -366,7 +366,25 @@
         "\\",
         "`",
         "[",
-        "]"
+        "]",
+        "numpadPlus",
+        "numpadMinus",
+        "numpadMultiply",
+        "numpadDivide",
+        "numpadEnter",
+        "numpadEquals",
+        "numpadDecimal",
+        "numpadClear",
+        "numpad0",
+        "numpad1",
+        "numpad2",
+        "numpad3",
+        "numpad4",
+        "numpad5",
+        "numpad6",
+        "numpad7",
+        "numpad8",
+        "numpad9"
       ],
       "type": "string"
     },
@@ -834,6 +852,12 @@
           "default": false,
           "description": "If the value is true, the pointer acceleration will be disabled and acceleration and speed will not take effect.",
           "title": "Disable pointer acceleration",
+          "type": "boolean"
+        },
+        "redirectsToScroll": {
+          "default": false,
+          "description": "If the value is true, pointer movements will be redirected to scroll events.",
+          "title": "Redirects to scroll",
           "type": "boolean"
         },
         "speed": {

--- a/Documentation/Configuration.md
+++ b/Documentation/Configuration.md
@@ -642,4 +642,46 @@ The `<command>` will be executed with bash.
 }
 ```
 
-To see the full list of keys, please refer to [Configuration.d.ts#L609](Configuration.d.ts#L609).
+To see the full list of keys, please refer to [Configuration.d.ts#L652](Configuration.d.ts#L652).
+
+#### Numpad keys support
+
+LinearMouse supports all numpad keys for keyboard shortcuts:
+
+- Number keys: `numpad0`, `numpad1`, `numpad2`, `numpad3`, `numpad4`, `numpad5`, `numpad6`, `numpad7`, `numpad8`, `numpad9`
+- Operator keys: `numpadPlus`, `numpadMinus`, `numpadMultiply`, `numpadDivide`, `numpadEquals`
+- Function keys: `numpadEnter`, `numpadDecimal`, `numpadClear`
+
+Example usage:
+```json
+{
+  "action": {
+    "keyPress": ["numpad5"]
+  }
+}
+```
+
+## Pointer settings
+
+### Redirects to scroll
+
+The `redirectsToScroll` property allows you to redirect pointer movements to scroll events. This is useful for scenarios where you want mouse movements to control scrolling instead of cursor positioning.
+
+```json
+{
+  "schemes": [
+    {
+      "if": {
+        "device": {
+          "category": "mouse"
+        }
+      },
+      "pointer": {
+        "redirectsToScroll": true
+      }
+    }
+  ]
+}
+```
+
+When `redirectsToScroll` is set to `true`, horizontal mouse movements will generate horizontal scroll events, and vertical mouse movements will generate vertical scroll events.

--- a/Modules/KeyKit/Sources/KeyKit/Key.swift
+++ b/Modules/KeyKit/Sources/KeyKit/Key.swift
@@ -122,6 +122,22 @@ public enum Key: String, Codable {
     case backetRight = "]"
     case numpadPlus
     case numpadMinus
+    case numpadMultiply
+    case numpadDivide
+    case numpadEnter
+    case numpadEquals
+    case numpadDecimal
+    case numpadClear
+    case numpad0
+    case numpad1
+    case numpad2
+    case numpad3
+    case numpad4
+    case numpad5
+    case numpad6
+    case numpad7
+    case numpad8
+    case numpad9
 }
 
 extension Key {
@@ -146,6 +162,42 @@ extension Key: CustomStringConvertible {
             return "⌥"
         case .control, .controlRight:
             return "⌃"
+        case .numpadPlus:
+            return "Numpad +"
+        case .numpadMinus:
+            return "Numpad -"
+        case .numpadMultiply:
+            return "Numpad *"
+        case .numpadDivide:
+            return "Numpad /"
+        case .numpadEnter:
+            return "Numpad Enter"
+        case .numpadEquals:
+            return "Numpad ="
+        case .numpadDecimal:
+            return "Numpad ."
+        case .numpadClear:
+            return "Numpad Clear"
+        case .numpad0:
+            return "Numpad 0"
+        case .numpad1:
+            return "Numpad 1"
+        case .numpad2:
+            return "Numpad 2"
+        case .numpad3:
+            return "Numpad 3"
+        case .numpad4:
+            return "Numpad 4"
+        case .numpad5:
+            return "Numpad 5"
+        case .numpad6:
+            return "Numpad 6"
+        case .numpad7:
+            return "Numpad 7"
+        case .numpad8:
+            return "Numpad 8"
+        case .numpad9:
+            return "Numpad 9"
         default:
             return rawValue.prefix(1).capitalized + rawValue.dropFirst()
         }

--- a/Modules/KeyKit/Sources/KeyKit/KeyCodeResolver.swift
+++ b/Modules/KeyKit/Sources/KeyKit/KeyCodeResolver.swift
@@ -94,6 +94,22 @@ public class KeyCodeResolver {
         newMapping[Key.f12.rawValue] = 0x6F
         newMapping[Key.numpadPlus.rawValue] = 0x45
         newMapping[Key.numpadMinus.rawValue] = 0x4E
+        newMapping[Key.numpadMultiply.rawValue] = 0x43
+        newMapping[Key.numpadDivide.rawValue] = 0x4B
+        newMapping[Key.numpadEnter.rawValue] = 0x4C
+        newMapping[Key.numpadEquals.rawValue] = 0x51
+        newMapping[Key.numpadDecimal.rawValue] = 0x41
+        newMapping[Key.numpadClear.rawValue] = 0x47
+        newMapping[Key.numpad0.rawValue] = 0x52
+        newMapping[Key.numpad1.rawValue] = 0x53
+        newMapping[Key.numpad2.rawValue] = 0x54
+        newMapping[Key.numpad3.rawValue] = 0x55
+        newMapping[Key.numpad4.rawValue] = 0x56
+        newMapping[Key.numpad5.rawValue] = 0x57
+        newMapping[Key.numpad6.rawValue] = 0x58
+        newMapping[Key.numpad7.rawValue] = 0x59
+        newMapping[Key.numpad8.rawValue] = 0x5B
+        newMapping[Key.numpad9.rawValue] = 0x5C
         for (keyString, keyCode) in newMapping {
             guard let key = Key(rawValue: keyString) else {
                 continue


### PR DESCRIPTION
- Add support for all numpad keys (0-9, +, -, *, /, Enter, Clear, Decimal, Equals) in button mapping actions
- Add missing redirectsToScroll property to pointer configuration schema
- Update documentation with numpad key examples and redirectsToScroll usage
- Regenerate JSON schema to include new key types and property

#956

🤖 Generated with [Claude Code](https://claude.ai/code)