### PR TITLE
Pointer: Fix "Revert to system defaults"

### DIFF
--- a/Documentation/Configuration.d.ts
+++ b/Documentation/Configuration.d.ts
@@ -12,6 +12,12 @@ type HexString = string;
 type Button = Primary | Secondary | Auxiliary | Back | Forward | number;
 
 /**
+ * @title Unset
+ * @description A special value that explicitly restores a setting to the system or device default. Currently supported in pointer settings; may be supported more broadly in the future.
+ */
+export type Unset = "unset";
+
+/**
  * @description Primary button, usually the left button.
  */
 type Primary = 0;
@@ -299,19 +305,19 @@ declare namespace Scheme {
   type Pointer = {
     /**
      * @title Pointer acceleration
-     * @description If the value is not specified, system default value will be used.
+     * @description A number to set acceleration, or "unset" to restore system default. If omitted, the previous/merged value applies.
      * @minimum 0
      * @maximum 20
      */
-    acceleration?: number;
+    acceleration?: number | Unset;
 
     /**
      * @title Pointer speed
-     * @description If the value is not specified, device default value will be used.
+     * @description A number to set speed, or "unset" to restore device default. If omitted, the previous/merged value applies.
      * @minimal 0
      * @maximum 1
      */
-    speed?: number;
+    speed?: number | Unset;
 
     /**
      * @title Disable pointer acceleration

--- a/Documentation/Configuration.json
+++ b/Documentation/Configuration.json
@@ -842,11 +842,18 @@
       "additionalProperties": false,
       "properties": {
         "acceleration": {
-          "description": "If the value is not specified, system default value will be used.",
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "$ref": "#/definitions/Unset"
+            }
+          ],
+          "description": "A number to set acceleration, or \"unset\" to restore system default. If omitted, the previous/merged value applies.",
           "maximum": 20,
           "minimum": 0,
-          "title": "Pointer acceleration",
-          "type": "number"
+          "title": "Pointer acceleration"
         },
         "disableAcceleration": {
           "default": false,
@@ -861,10 +868,17 @@
           "type": "boolean"
         },
         "speed": {
-          "description": "If the value is not specified, device default value will be used.",
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "$ref": "#/definitions/Unset"
+            }
+          ],
+          "description": "A number to set speed, or \"unset\" to restore device default. If omitted, the previous/merged value applies.",
           "maximum": 1,
-          "title": "Pointer speed",
-          "type": "number"
+          "title": "Pointer speed"
         }
       },
       "type": "object"
@@ -1193,6 +1207,12 @@
           "type": "array"
         }
       ]
+    },
+    "Unset": {
+      "const": "unset",
+      "description": "A special value that explicitly restores a setting to the system or device default. Currently supported in pointer settings; may be supported more broadly in the future.",
+      "title": "Unset",
+      "type": "string"
     }
   }
 }

--- a/Documentation/Configuration.md
+++ b/Documentation/Configuration.md
@@ -118,6 +118,26 @@ I would create two schemes and specify the vendor ID and product ID:
 Then, the pointer speed of my Logitech mouse and Microsoft mouse will be set to 0.36 and 0.4
 respectively.
 
+### Unsetting values
+
+LinearMouse supports a special "unset" value to explicitly restore settings back to their system or
+device defaults. This differs from omitting a field, which keeps the previously merged value.
+
+Currently, "unset" is supported for pointer acceleration and speed.
+
+```json
+{
+  "schemes": [
+    {
+      "if": {
+        "device": { "category": "mouse" }
+      },
+      "pointer": { "acceleration": "unset", "speed": "unset" }
+    }
+  ]
+}
+```
+
 ## App matching
 
 App bundle ID can be provided to match a specific app.

--- a/LinearMouse/Device/DeviceManager.swift
+++ b/LinearMouse/Device/DeviceManager.swift
@@ -246,7 +246,12 @@ class DeviceManager: ObservableObject {
                 // convention, but here, the pointerAcceleration actually refers to
                 // the tracking speed.
                 if let pointerAcceleration = scheme.pointer.acceleration {
-                    device.pointerAcceleration = pointerAcceleration.asTruncatedDouble
+                    switch pointerAcceleration {
+                    case let .value(v):
+                        device.pointerAcceleration = v.asTruncatedDouble
+                    case .unset:
+                        device.restorePointerAcceleration()
+                    }
                 } else {
                     device.restorePointerAcceleration()
                 }
@@ -262,13 +267,23 @@ class DeviceManager: ObservableObject {
         }
 
         if let pointerSpeed = scheme.pointer.speed {
-            device.pointerSpeed = pointerSpeed.asTruncatedDouble
+            switch pointerSpeed {
+            case let .value(v):
+                device.pointerSpeed = v.asTruncatedDouble
+            case .unset:
+                device.restorePointerSpeed()
+            }
         } else {
             device.restorePointerSpeed()
         }
 
         if let pointerAcceleration = scheme.pointer.acceleration {
-            device.pointerAcceleration = pointerAcceleration.asTruncatedDouble
+            switch pointerAcceleration {
+            case let .value(v):
+                device.pointerAcceleration = v.asTruncatedDouble
+            case .unset:
+                device.restorePointerAcceleration()
+            }
         } else {
             device.restorePointerAcceleration()
         }

--- a/LinearMouse/Model/Configuration/Scheme/Pointer.swift
+++ b/LinearMouse/Model/Configuration/Scheme/Pointer.swift
@@ -5,21 +5,47 @@ import Foundation
 
 extension Scheme {
     struct Acceleration: Equatable, ClampRange {
-        typealias Value = Decimal
+        typealias Value = Unsettable<Decimal>
+        typealias RangeValue = Decimal
 
-        static var range: ClosedRange<Value> = 0 ... 20
+        static var range: ClosedRange<RangeValue> = 0 ... 20
+
+        static func clamp(_ value: Value?) -> Value? {
+            guard let value else {
+                return nil
+            }
+            switch value {
+            case let .value(v):
+                return .value(v.clamped(to: range))
+            case .unset:
+                return .unset
+            }
+        }
     }
 
     struct Speed: Equatable, ClampRange {
-        typealias Value = Decimal
+        typealias Value = Unsettable<Decimal>
+        typealias RangeValue = Decimal
 
-        static var range: ClosedRange<Value> = 0 ... 1
+        static var range: ClosedRange<RangeValue> = 0 ... 1
+
+        static func clamp(_ value: Value?) -> Value? {
+            guard let value else {
+                return nil
+            }
+            switch value {
+            case let .value(v):
+                return .value(v.clamped(to: range))
+            case .unset:
+                return .unset
+            }
+        }
     }
 
     struct Pointer: Codable, Equatable, ImplicitInitable {
-        @Clamp<Acceleration> var acceleration: Decimal?
+        @Clamp<Acceleration> var acceleration: Unsettable<Decimal>?
 
-        @Clamp<Speed> var speed: Decimal?
+        @Clamp<Speed> var speed: Unsettable<Decimal>?
 
         var disableAcceleration: Bool?
         var redirectsToScroll: Bool?

--- a/LinearMouse/UI/PointerSettings/PointerSettingsState.swift
+++ b/LinearMouse/UI/PointerSettings/PointerSettingsState.swift
@@ -40,7 +40,7 @@ extension PointerSettingsState {
 
     var pointerAcceleration: Double {
         get {
-            mergedScheme.pointer.acceleration?.asTruncatedDouble
+            mergedScheme.pointer.acceleration?.unwrapped?.asTruncatedDouble
                 ?? mergedScheme.firstMatchedDevice?.pointerAcceleration
                 ?? Device.fallbackPointerAcceleration
         }
@@ -49,13 +49,13 @@ extension PointerSettingsState {
                 return
             }
 
-            scheme.pointer.acceleration = Decimal(newValue).rounded(4)
+            scheme.pointer.acceleration = .value(Decimal(newValue).rounded(4))
         }
     }
 
     var pointerSpeed: Double {
         get {
-            mergedScheme.pointer.speed?.asTruncatedDouble
+            mergedScheme.pointer.speed?.unwrapped?.asTruncatedDouble
                 ?? mergedScheme.firstMatchedDevice?.pointerSpeed
                 ?? Device.fallbackPointerSpeed
         }
@@ -64,7 +64,7 @@ extension PointerSettingsState {
                 return
             }
 
-            scheme.pointer.speed = Decimal(newValue).rounded(4)
+            scheme.pointer.speed = .value(Decimal(newValue).rounded(4))
         }
     }
 
@@ -93,8 +93,8 @@ extension PointerSettingsState {
 
         Scheme(
             pointer: Scheme.Pointer(
-                acceleration: Decimal(device?.pointerAcceleration ?? Device.fallbackPointerAcceleration),
-                speed: Decimal(device?.pointerSpeed ?? Device.fallbackPointerSpeed),
+                acceleration: .unset,
+                speed: .unset,
                 disableAcceleration: false,
                 redirectsToScroll: false
             )

--- a/LinearMouse/Utilities/Codable/Unsettable.swift
+++ b/LinearMouse/Utilities/Codable/Unsettable.swift
@@ -1,0 +1,42 @@
+// MIT License
+// Copyright (c) 2021-2025 LinearMouse
+
+import Foundation
+
+enum Unsettable<T: Codable & Equatable>: Equatable, Codable {
+    case value(T)
+    case unset
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+
+        // Try decoding the sentinel string "unset"
+        if let string = try? container.decode(String.self), string == "unset" {
+            self = .unset
+            return
+        }
+
+        // Otherwise, decode the underlying value
+        let value = try container.decode(T.self)
+        self = .value(value)
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        switch self {
+        case let .value(value):
+            try container.encode(value)
+        case .unset:
+            try container.encode("unset")
+        }
+    }
+}
+
+extension Unsettable {
+    var unwrapped: T? {
+        if case let .value(value) = self {
+            return value
+        }
+        return nil
+    }
+}


### PR DESCRIPTION
Previously, clicking "Revert to system defaults" computed and wrote concrete numeric values back into configuration.  It could be subtly different from the true default values — especially on trackpads.

Fixes #944, fixes #967.