### PR TITLE
Fix click debouncing suppressing mouse up events

### DIFF
--- a/LinearMouse/EventTransformer/ClickDebouncingTransformer.swift
+++ b/LinearMouse/EventTransformer/ClickDebouncingTransformer.swift
@@ -21,11 +21,6 @@ class ClickDebouncingTransformer: EventTransformer {
 
     private var mouseUpEventType: CGEventType { button.fixedCGEventType(of: .leftMouseUp) }
 
-    enum State {
-        case unknown, waitForDown, waitForUp
-    }
-
-    private var state: State = .unknown
     private var lastClickedAtInNanoseconds: UInt64 = 0
 
     func transform(_ event: CGEvent) -> CGEvent? {
@@ -42,7 +37,6 @@ class ClickDebouncingTransformer: EventTransformer {
             let intervalSinceLastClick = intervalSinceLastClick
             touchLastClickedAt()
             if intervalSinceLastClick <= timeout {
-                state = .waitForDown
                 os_log(
                     "Mouse down ignored because interval since last click %{public}f <= %{public}f",
                     log: Self.log,
@@ -52,13 +46,11 @@ class ClickDebouncingTransformer: EventTransformer {
                 )
                 return nil
             }
-            state = .waitForUp
             return event
         case mouseUpEventType:
             if resetTimerOnMouseUp {
                 touchLastClickedAt()
             }
-            state = .waitForDown
             return event
         default:
             break


### PR DESCRIPTION
## Summary

- Fix mouse up events being suppressed when the preceding mouse down was debounced, causing window resize and drag operations to malfunction on subsequent clicks
- Remove unused state machine from ClickDebouncingTransformer

Fixes #912

## Problem

When click debouncing is enabled on a mouse with double-click issues, window resizing and drag operations malfunction:

- **Window resizing**: After resizing and releasing the mouse button, clicking elsewhere causes the window to resize to that position
- **File drag & drop**: Files don't drop at the intended destination — they remain "held" and drop wherever the user clicks next

### Reproduction video


https://github.com/user-attachments/assets/642960dd-b799-4533-9517-6f90edb9a4f8


### Root cause

When a mouse bounces, the debouncing logic correctly ignores the bounced mouse down, but also suppresses the **subsequent mouse up**. Although the OS already received a release from the bounce's mouse up (step 2), the suppression of the real mouse up (step 4) prevents macOS's window server from properly cleaning up drag/resize state.

**Event flow (before fix):**
```
1. Mouse Down (click/drag)   → passes through    → OS: button pressed
2. Mouse Up   (bounce)       → passes through    → OS: button released
3. Mouse Down (bounce)       → debounced ✓       → OS: no event
4. Mouse Up   (real release) → suppressed ✗      → OS: no event
```

Even though the OS receives a release at step 2, the bounce happens within milliseconds — too fast for the window server to fully terminate drag/resize state. The real mouse up at step 4 is needed to properly clean up, but the old code suppressed it.

As a result, subsequent click/drag interactions (step 5-6) incorrectly resume the previous resize or drag operation.

> **Note:** This issue occurs when the bounce happens during a click or short drag where step 3 falls within the debounce timeout. During a long drag, the interval since step 1 exceeds the timeout, so step 3 is not debounced and all events pass through normally.

## Fix

Remove the logic that suppresses mouse up events when the preceding mouse down was debounced. Also remove the now-unused `State` enum and `state` variable, as they were only used for this suppression logic.

**Event flow (after fix):**
```
1. Mouse Down (click/drag)   → passes through    → OS: button pressed
2. Mouse Up   (bounce)       → passes through    → OS: button released
3. Mouse Down (bounce)       → debounced ✓       → OS: no event
4. Mouse Up   (real release) → passes through ✓  → OS: properly terminates drag/resize state
```

## Test plan

- [x] Manual test: Enable click debouncing → click near window edge → verify subsequent clicks don't trigger unintended resize
- [x] Manual test: Enable click debouncing → drag window to resize → verify release works correctly