### PR TITLE
Update DeviceState.swift

### DIFF
--- a/LinearMouse/State/DeviceState.swift
+++ b/LinearMouse/State/DeviceState.swift
@@ -15,10 +15,15 @@ class DeviceState: ObservableObject {
     static let shared = DeviceState()
 
     private var subscriptions = Set<AnyCancellable>()
+    private var isSettingSelectedDevice = false
 
     @Published var currentDeviceRef: WeakRef<Device>? {
         didSet {
             guard !Defaults[.autoSwitchToActiveDevice] else {
+                return
+            }
+
+            guard !isSettingSelectedDevice else {
                 return
             }
 
@@ -27,6 +32,8 @@ class DeviceState: ObservableObject {
                 return
             }
 
+            isSettingSelectedDevice = true
+            defer { isSettingSelectedDevice = false }
             Defaults[.selectedDevice] = currentDeviceMatcher
         }
     }


### PR DESCRIPTION
Fix macOS 26.3.1 compatibility

Fixes #1090

Root cause: Defaults[.selectedDevice] KVO notifications fire synchronously inside CFPreferences withSearchListForIdentifier:perform: — before the write is committed to the store. So when didSet reads Defaults[.selectedDevice] inside the callback to check equality, it still sees the old value, the guard always fails, and Defaults[.selectedDevice] gets written again, repeating infinitely.

Fix: Added isSettingSelectedDevice re-entrancy guard around the Defaults.selectedDevice write in DeviceState.swift:19-37. When the KVO callback fires synchronously and triggers didSet again, the guard returns early instead of writing again.