### PR TITLE
Skip signing for pull request builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,15 +51,7 @@ jobs:
           make configure-release
       - name: Build pull request
         if: github.event_name == 'pull_request'
-        run: |
-          make configure clean lint
-          xcodebuild test \
-            -project LinearMouse.xcodeproj \
-            -scheme LinearMouse \
-            CODE_SIGNING_ALLOWED=NO \
-            CODE_SIGNING_REQUIRED=NO \
-            CODE_SIGN_IDENTITY="" \
-            DEVELOPMENT_TEAM=""
+        run: make configure clean lint test XCODEBUILD_ARGS="CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY= DEVELOPMENT_TEAM="
       - name: Build
         if: github.event_name != 'pull_request'
         run: make

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@ BUILD_DIR = $(CURDIR)/build
 ARCHIVE_PATH = $(CURDIR)/build/LinearMouse.xcarchive
 TARGET_DIR = $(CURDIR)/build/target
 TARGET_DMG = $(CURDIR)/build/LinearMouse.dmg
+XCODEBUILD_ARGS ?=
 
 all: configure clean lint test package
 
@@ -29,12 +30,12 @@ lint:
 	swiftlint .
 
 test:
-	xcodebuild test -project LinearMouse.xcodeproj -scheme LinearMouse
+	xcodebuild test -project LinearMouse.xcodeproj -scheme LinearMouse $(XCODEBUILD_ARGS)
 
 package: $(TARGET_DMG)
 
 $(BUILD_DIR)/Release/LinearMouse.app:
-	xcodebuild archive -project LinearMouse.xcodeproj -scheme LinearMouse -archivePath '$(ARCHIVE_PATH)'
+	xcodebuild archive -project LinearMouse.xcodeproj -scheme LinearMouse -archivePath '$(ARCHIVE_PATH)' $(XCODEBUILD_ARGS)
 	xcodebuild -exportArchive -archivePath '$(ARCHIVE_PATH)' -exportOptionsPlist ExportOptions.plist -exportPath '$(BUILD_DIR)/Release'
 
 $(TARGET_DMG): $(BUILD_DIR)/Release/LinearMouse.app


### PR DESCRIPTION
## Summary
- skip Apple certificate import for pull_request workflows
- run configure/lint/test for pull requests instead of the signed packaging path
- keep signed build, DMG upload, and release behavior for non-PR builds

## Testing
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/build.yml"); puts "YAML OK"'