### PR TITLE
Add smoothed scrolling mode

### DIFF
--- a/Documentation/Configuration.d.ts
+++ b/Documentation/Configuration.d.ts
@@ -199,6 +199,12 @@ declare namespace Scheme {
     speed?: Scrolling.Bidirectional<number>;
 
     /**
+     * @title Smoothed scrolling
+     * @description Use a preset curve or fine-tune response, speed, acceleration, and inertia.
+     */
+    smoothed?: Scrolling.Bidirectional<Scrolling.Smoothed>;
+
+    /**
      * @title Modifier keys settings
      */
     modifiers?: Scrolling.Bidirectional<Scrolling.Modifiers>;
@@ -231,6 +237,69 @@ declare namespace Scheme {
        * @pattern ^\d[1-9]*(\.\d+)?px
        */
       type Pixel = string;
+    }
+
+    type Smoothed = {
+      /**
+       * @description Set to `false` to explicitly disable inherited smoothed scrolling for this direction.
+       * @default true
+       */
+      enabled?: boolean;
+
+      /**
+       * @description The preset curve to use.
+       * @default "natural"
+       */
+      preset?: Smoothed.Preset;
+
+      /**
+       * @description How quickly the scrolling responds to input.
+       */
+      response?: number;
+
+      /**
+       * @description The scrolling speed.
+       */
+      speed?: number;
+
+      /**
+       * @description The scrolling acceleration.
+       */
+      acceleration?: number;
+
+      /**
+       * @description The scrolling inertia.
+       */
+      inertia?: number;
+    };
+
+    namespace Smoothed {
+      type Preset =
+        | "custom"
+        | "linear"
+        | "easeIn"
+        | "easeOut"
+        | "easeInOut"
+        | "easeOutIn"
+        | "quadratic"
+        | "cubic"
+        | "quartic"
+        | "easeOutCubic"
+        | "easeInOutCubic"
+        | "easeOutQuartic"
+        | "easeInOutQuartic"
+        | "quintic"
+        | "sine"
+        | "exponential"
+        | "circular"
+        | "back"
+        | "bounce"
+        | "elastic"
+        | "spring"
+        | "natural"
+        | "smooth"
+        | "snappy"
+        | "gentle";
     }
 
     type Modifiers = {

--- a/Documentation/Configuration.json
+++ b/Documentation/Configuration.json
@@ -1158,6 +1158,27 @@
           ],
           "title": "Reverse scrolling"
         },
+        "smoothed": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/Scheme.Scrolling.Smoothed"
+            },
+            {
+              "additionalProperties": false,
+              "properties": {
+                "horizontal": {
+                  "$ref": "#/definitions/Scheme.Scrolling.Smoothed"
+                },
+                "vertical": {
+                  "$ref": "#/definitions/Scheme.Scrolling.Smoothed"
+                }
+              },
+              "type": "object"
+            }
+          ],
+          "description": "Use a preset curve or fine-tune response, speed, acceleration, and inertia.",
+          "title": "Smoothed scrolling"
+        },
         "speed": {
           "anyOf": [
             {
@@ -1383,6 +1404,68 @@
         "type"
       ],
       "type": "object"
+    },
+    "Scheme.Scrolling.Smoothed": {
+      "additionalProperties": false,
+      "properties": {
+        "acceleration": {
+          "description": "The scrolling acceleration.",
+          "type": "number"
+        },
+        "enabled": {
+          "default": true,
+          "description": "Set to `false` to explicitly disable inherited smoothed scrolling for this direction.",
+          "type": "boolean"
+        },
+        "inertia": {
+          "description": "The scrolling inertia.",
+          "type": "number"
+        },
+        "preset": {
+          "$ref": "#/definitions/Scheme.Scrolling.Smoothed.Preset",
+          "default": "natural",
+          "description": "The preset curve to use."
+        },
+        "response": {
+          "description": "How quickly the scrolling responds to input.",
+          "type": "number"
+        },
+        "speed": {
+          "description": "The scrolling speed.",
+          "type": "number"
+        }
+      },
+      "type": "object"
+    },
+    "Scheme.Scrolling.Smoothed.Preset": {
+      "enum": [
+        "custom",
+        "linear",
+        "easeIn",
+        "easeOut",
+        "easeInOut",
+        "easeOutIn",
+        "quadratic",
+        "cubic",
+        "quartic",
+        "easeOutCubic",
+        "easeInOutCubic",
+        "easeOutQuartic",
+        "easeInOutQuartic",
+        "quintic",
+        "sine",
+        "exponential",
+        "circular",
+        "back",
+        "bounce",
+        "elastic",
+        "spring",
+        "natural",
+        "smooth",
+        "snappy",
+        "gentle"
+      ],
+      "type": "string"
     },
     "Secondary": {
       "const": 1,

--- a/Documentation/Configuration.md
+++ b/Documentation/Configuration.md
@@ -75,6 +75,46 @@ And the `scrolling` field in this scheme defines the scrolling behaviors, with
 }
 ```
 
+## Smoothed scrolling
+
+`scrolling.smoothed` enables a phase-aware scrolling curve that can be tuned separately for
+vertical and horizontal scrolling. You can choose a preset such as `easeIn`, `easeOut`,
+`easeInOut`, `quadratic`, `cubic`, `easeOutCubic`, `easeInOutCubic`, `quartic`,
+`easeOutQuartic`, `easeInOutQuartic`, `smooth`, or `custom`, then fine-tune `response`,
+`speed`, `acceleration`, and `inertia` as needed.
+
+Set `enabled` to `false` to explicitly disable an inherited smoothed scrolling configuration for a
+direction.
+
+For example, to use a smoother scrolling profile for a mouse:
+
+```json
+{
+  "schemes": [
+    {
+      "if": {
+        "device": {
+          "category": "mouse"
+        }
+      },
+      "scrolling": {
+        "smoothed": {
+          "enabled": true,
+          "preset": "easeInOut",
+          "response": 0.45,
+          "speed": 1,
+          "acceleration": 1.2,
+          "inertia": 0.65
+        }
+      }
+    }
+  ]
+}
+```
+
+If you want different tuning for each direction, provide `vertical` and `horizontal` values under
+`smoothed`.
+
 ## Device matching
 
 Vendor ID and product ID can be provided to match a specific device.

--- a/LinearMouse/EventTransformer/EventTransformerManager.swift
+++ b/LinearMouse/EventTransformer/EventTransformerManager.swift
@@ -62,7 +62,7 @@ class EventTransformerManager {
 
         activeCacheKey = nil
 
-        if sourcePid != nil, bypassEventsFromOtherApplications {
+        if sourcePid != nil, bypassEventsFromOtherApplications, !cgEvent.isLinearMouseSyntheticEvent {
             os_log(
                 "Return noop transformer because this event is sent by %{public}s",
                 log: Self.log,
@@ -124,20 +124,43 @@ class EventTransformerManager {
             }
         }
 
+        let smoothed = Scheme.Scrolling.Bidirectional(
+            vertical: scheme.scrolling.smoothed.vertical?.isEnabled == true ? scheme.scrolling.smoothed.vertical : nil,
+            horizontal: scheme.scrolling.smoothed.horizontal?.isEnabled == true ? scheme.scrolling.smoothed
+                .horizontal : nil
+        )
+
+        if smoothed.vertical != nil || smoothed.horizontal != nil {
+            eventTransformer.append(SmoothedScrollingTransformer(smoothed: smoothed))
+        }
+
         if let distance = scheme.scrolling.distance.horizontal {
-            eventTransformer.append(LinearScrollingHorizontalTransformer(distance: distance))
+            if smoothed.horizontal == nil {
+                eventTransformer.append(LinearScrollingHorizontalTransformer(distance: distance))
+            }
         }
 
         if let distance = scheme.scrolling.distance.vertical {
-            eventTransformer.append(LinearScrollingVerticalTransformer(distance: distance))
+            if smoothed.vertical == nil {
+                eventTransformer.append(LinearScrollingVerticalTransformer(distance: distance))
+            }
         }
 
-        if scheme.scrolling.acceleration.vertical ?? 1 != 1 || scheme.scrolling.acceleration.horizontal ?? 1 != 1 ||
-            scheme.scrolling.speed.vertical ?? 0 != 0 || scheme.scrolling.speed.horizontal ?? 0 != 0 {
+        let acceleration = Scheme.Scrolling.Bidirectional<Decimal>(
+            vertical: smoothed.vertical == nil ? scheme.scrolling.acceleration.vertical : nil,
+            horizontal: smoothed.horizontal == nil ? scheme.scrolling.acceleration.horizontal : nil
+        )
+        let speed = Scheme.Scrolling.Bidirectional<Decimal>(
+            vertical: smoothed.vertical == nil ? scheme.scrolling.speed.vertical : nil,
+            horizontal: smoothed.horizontal == nil ? scheme.scrolling.speed.horizontal : nil
+        )
+
+        if acceleration.vertical ?? 1 != 1 || acceleration.horizontal ?? 1 != 1 ||
+            speed.vertical ?? 0 != 0 || speed.horizontal ?? 0 != 0 {
             eventTransformer
                 .append(ScrollingAccelerationSpeedAdjustmentTransformer(
-                    acceleration: scheme.scrolling.acceleration,
-                    speed: scheme.scrolling.speed
+                    acceleration: acceleration,
+                    speed: speed
                 ))
         }
 

--- a/LinearMouse/EventTransformer/LinearScrollingHorizontalTransformer.swift
+++ b/LinearMouse/EventTransformer/LinearScrollingHorizontalTransformer.swift
@@ -18,6 +18,10 @@ class LinearScrollingHorizontalTransformer: EventTransformer {
             return event
         }
 
+        if event.isLinearMouseSyntheticEvent {
+            return event
+        }
+
         if case .auto = distance {
             return event
         }

--- a/LinearMouse/EventTransformer/LinearScrollingVerticalTransformer.swift
+++ b/LinearMouse/EventTransformer/LinearScrollingVerticalTransformer.swift
@@ -18,6 +18,10 @@ class LinearScrollingVerticalTransformer: EventTransformer {
             return event
         }
 
+        if event.isLinearMouseSyntheticEvent {
+            return event
+        }
+
         if case .auto = distance {
             return event
         }

--- a/LinearMouse/EventTransformer/ReverseScrollingTransformer.swift
+++ b/LinearMouse/EventTransformer/ReverseScrollingTransformer.swift
@@ -17,6 +17,10 @@ class ReverseScrollingTransformer: EventTransformer {
             return event
         }
 
+        if event.isLinearMouseSyntheticEvent {
+            return event
+        }
+
         let view = ScrollWheelEventView(event)
         view.negate(vertically: vertically, horizontally: horizontally)
         return event

--- a/LinearMouse/EventTransformer/ScrollingAccelerationSpeedAdjustmentTransformer.swift
+++ b/LinearMouse/EventTransformer/ScrollingAccelerationSpeedAdjustmentTransformer.swift
@@ -26,6 +26,10 @@ class ScrollingAccelerationSpeedAdjustmentTransformer: EventTransformer {
             return event
         }
 
+        if event.isLinearMouseSyntheticEvent {
+            return event
+        }
+
         let scrollWheelEventView = ScrollWheelEventView(event)
         let deltaYSignum = scrollWheelEventView.deltaYSignum
         let deltaXSignum = scrollWheelEventView.deltaXSignum

--- a/LinearMouse/EventTransformer/SmoothedScrollingEngine.swift
+++ b/LinearMouse/EventTransformer/SmoothedScrollingEngine.swift
@@ -1,0 +1,328 @@
+// MIT License
+// Copyright (c) 2021-2026 LinearMouse
+
+import CoreGraphics
+import Foundation
+
+final class SmoothedScrollingEngine {
+    struct Emission {
+        var deltaX: Double
+        var deltaY: Double
+        var scrollPhase: CGScrollPhase?
+        var momentumPhase: CGMomentumScrollPhase
+    }
+
+    private enum SessionState {
+        case idle
+        case touching
+        case momentum
+    }
+
+    private enum AxisBehavior {
+        case passthrough
+        case smoothed(AxisTuning)
+    }
+
+    private struct AxisTuning {
+        let configuration: Scheme.Scrolling.Smoothed
+
+        init(configuration: Scheme.Scrolling.Smoothed) {
+            self.configuration = configuration
+        }
+
+        private var presetProfile: Scheme.Scrolling.Smoothed.PresetProfile {
+            configuration.resolvedPresetProfile
+        }
+
+        private var response: Double {
+            (configuration.response?.asTruncatedDouble ?? 0.45).clamped(to: 0.05 ... 1.0)
+        }
+
+        private var speed: Double {
+            (configuration.speed?.asTruncatedDouble ?? 1).clamped(to: 0 ... 3)
+        }
+
+        private var acceleration: Double {
+            (configuration.acceleration?.asTruncatedDouble ?? 1.2).clamped(to: 0 ... 3)
+        }
+
+        private var inertia: Double {
+            (configuration.inertia?.asTruncatedDouble ?? 0.65).clamped(to: 0 ... 3)
+        }
+
+        func desiredVelocity(for input: Double) -> Double {
+            guard input != 0 else {
+                return 0
+            }
+
+            let profile = presetProfile
+            let baseMagnitude = abs(input)
+            let normalizedMagnitude = (baseMagnitude / (baseMagnitude + 24)).clamped(to: 0 ... 1)
+            let curvedMagnitude = pow(normalizedMagnitude, profile.inputExponent)
+            let magnitude = baseMagnitude * (0.58 + curvedMagnitude * 0.42)
+            let speedBoost = 0.85 + speed * 0.4
+            let accelerationBoost = 1 + acceleration * profile.accelerationGain
+            let velocity = magnitude * profile.velocityScale * speedBoost * accelerationBoost
+
+            return input.sign == .minus ? -velocity : velocity
+        }
+
+        private func reengagementDominance(inputVelocity: Double, currentVelocity: Double) -> Double {
+            let inputMagnitude = abs(inputVelocity)
+            let currentMagnitude = abs(currentVelocity)
+
+            guard inputMagnitude > 0, currentMagnitude > 0 else {
+                return 0
+            }
+
+            return (currentMagnitude / inputMagnitude).clamped(to: 0 ... 1)
+        }
+
+        private func tailRecovery(inputVelocity: Double, currentVelocity: Double) -> Double {
+            let dominance = reengagementDominance(inputVelocity: inputVelocity, currentVelocity: currentVelocity)
+            return ((0.75 - dominance) / 0.75).clamped(to: 0 ... 1)
+        }
+
+        func reengagedDesiredVelocity(for input: Double, currentVelocity: Double) -> Double {
+            let inputVelocity = desiredVelocity(for: input)
+
+            guard currentVelocity != 0 else {
+                return inputVelocity
+            }
+
+            let sameDirection = inputVelocity.sign == currentVelocity.sign
+            if sameDirection {
+                let carryFactor = (0.06 + response * 0.06 + acceleration * 0.01).clamped(to: 0.06 ... 0.16)
+                let ceilingFactor = (1.01 + presetProfile.response * 0.08 + response * 0.06).clamped(to: 1.02 ... 1.12)
+                let carriedMagnitude = min(
+                    abs(currentVelocity) + abs(inputVelocity) * carryFactor,
+                    max(abs(currentVelocity), abs(inputVelocity)) * ceilingFactor
+                )
+                let recovery = pow(tailRecovery(inputVelocity: inputVelocity, currentVelocity: currentVelocity), 0.8)
+                let targetMagnitude = carriedMagnitude + (abs(inputVelocity) - carriedMagnitude) * recovery
+                return currentVelocity.sign == .minus ? -targetMagnitude : targetMagnitude
+            }
+
+            let brakingBlend = (0.50 + response * 0.20).clamped(to: 0.50 ... 0.82)
+            return currentVelocity + (inputVelocity - currentVelocity) * brakingBlend
+        }
+
+        func blendFactor(for dt: TimeInterval) -> Double {
+            let scaled = presetProfile.response * 0.75 + response * 0.8
+            return (scaled * dt * 60).clamped(to: 0.05 ... 1.0)
+        }
+
+        func reengagementBlendFactor(for dt: TimeInterval, desiredVelocity: Double, currentVelocity: Double) -> Double {
+            let baseBlend = blendFactor(for: dt)
+            let softenedBlend = (baseBlend * (0.10 + response * 0.08)).clamped(to: 0.02 ... 0.12)
+            let recovery = pow(tailRecovery(inputVelocity: desiredVelocity, currentVelocity: currentVelocity), 0.55)
+            return (softenedBlend + (baseBlend - softenedBlend) * recovery).clamped(to: softenedBlend ... baseBlend)
+        }
+
+        func reengagementKickFactor(desiredVelocity: Double, currentVelocity: Double) -> Double {
+            guard desiredVelocity != 0, currentVelocity != 0, desiredVelocity.sign == currentVelocity.sign else {
+                return 0
+            }
+
+            let recovery = pow(tailRecovery(inputVelocity: desiredVelocity, currentVelocity: currentVelocity), 0.8)
+            let baseKick = (0.04 + response * 0.04).clamped(to: 0.04 ... 0.08)
+            let tailKick = (0.14 + response * 0.05 + acceleration * 0.02).clamped(to: 0.14 ... 0.28)
+            return (baseKick + tailKick * recovery).clamped(to: 0.04 ... 0.24)
+        }
+
+        func momentumDecay(for dt: TimeInterval) -> Double {
+            let profile = presetProfile
+            let inertiaBoost = ((inertia - 0.65) * 0.05).clamped(to: -0.08 ... 0.10)
+            let dtScale = max(dt * 60, 0.25)
+            return pow((profile.decay + inertiaBoost).clamped(to: 0.72 ... 0.98), dtScale)
+        }
+    }
+
+    private let horizontalBehavior: AxisBehavior
+    private let verticalBehavior: AxisBehavior
+
+    private var sessionState: SessionState = .idle
+    private var lastTickTimestamp: TimeInterval?
+    private var lastInputTimestamp: TimeInterval?
+    private var pendingInputX = 0.0
+    private var pendingInputY = 0.0
+    private var desiredVelocityX = 0.0
+    private var desiredVelocityY = 0.0
+    private var velocityX = 0.0
+    private var velocityY = 0.0
+    private var touchHasBegun = false
+    private var pendingMomentumBegin = false
+    private var reengagedFromMomentum = false
+
+    private let inputGrace: TimeInterval = 1.0 / 25.0
+    private let stopThreshold = 0.5
+
+    init(smoothed: Scheme.Scrolling.Bidirectional<Scheme.Scrolling.Smoothed>) {
+        horizontalBehavior = smoothed.horizontal.map { .smoothed(.init(configuration: $0)) } ?? .passthrough
+        verticalBehavior = smoothed.vertical.map { .smoothed(.init(configuration: $0)) } ?? .passthrough
+    }
+
+    var isRunning: Bool {
+        switch sessionState {
+        case .idle:
+            return pendingInputX != 0 || pendingInputY != 0
+        case .touching, .momentum:
+            return true
+        }
+    }
+
+    func feed(deltaX: Double, deltaY: Double, timestamp: TimeInterval) {
+        pendingInputX += deltaX
+        pendingInputY += deltaY
+        lastInputTimestamp = timestamp
+
+        if sessionState == .idle, deltaX != 0 || deltaY != 0 {
+            sessionState = .touching
+            touchHasBegun = false
+            pendingMomentumBegin = false
+        } else if sessionState == .momentum, deltaX != 0 || deltaY != 0 {
+            sessionState = .touching
+            touchHasBegun = false
+            pendingMomentumBegin = false
+            reengagedFromMomentum = true
+        }
+
+        if lastTickTimestamp == nil {
+            lastTickTimestamp = timestamp
+        }
+    }
+
+    func advance(to timestamp: TimeInterval) -> Emission? {
+        let previousTick = lastTickTimestamp ?? timestamp
+        let dt = (timestamp - previousTick).clamped(to: 1.0 / 240.0 ... 1.0 / 24.0)
+        lastTickTimestamp = timestamp
+
+        let hasPendingInput = pendingInputX != 0 || pendingInputY != 0
+        let hasFreshInput = lastInputTimestamp.map { timestamp - $0 <= inputGrace } ?? false
+        let shouldBlendMomentumReengagement = reengagedFromMomentum && hasPendingInput
+
+        let emissionX = advanceAxis(
+            behavior: horizontalBehavior,
+            pendingInput: &pendingInputX,
+            desiredVelocity: &desiredVelocityX,
+            velocity: &velocityX,
+            hasPendingInput: hasPendingInput,
+            hasFreshInput: hasFreshInput,
+            reengagedFromMomentum: shouldBlendMomentumReengagement,
+            dt: dt
+        )
+        let emissionY = advanceAxis(
+            behavior: verticalBehavior,
+            pendingInput: &pendingInputY,
+            desiredVelocity: &desiredVelocityY,
+            velocity: &velocityY,
+            hasPendingInput: hasPendingInput,
+            hasFreshInput: hasFreshInput,
+            reengagedFromMomentum: shouldBlendMomentumReengagement,
+            dt: dt
+        )
+        reengagedFromMomentum = false
+
+        let hasMovement = abs(emissionX) >= 0.01 || abs(emissionY) >= 0.01
+        let shouldContinueMomentum = abs(velocityX) > stopThreshold || abs(velocityY) > stopThreshold
+
+        switch sessionState {
+        case .idle:
+            return nil
+
+        case .touching:
+            if hasFreshInput {
+                guard hasMovement else {
+                    return nil
+                }
+
+                let phase: CGScrollPhase = touchHasBegun ? .changed : .began
+                touchHasBegun = true
+                return .init(deltaX: emissionX, deltaY: emissionY, scrollPhase: phase, momentumPhase: .none)
+            }
+
+            if shouldContinueMomentum {
+                sessionState = .momentum
+                pendingMomentumBegin = true
+                touchHasBegun = false
+                return .init(deltaX: 0, deltaY: 0, scrollPhase: .ended, momentumPhase: .none)
+            }
+
+            sessionState = .idle
+            velocityX = 0
+            velocityY = 0
+            desiredVelocityX = 0
+            desiredVelocityY = 0
+            touchHasBegun = false
+            return .init(deltaX: emissionX, deltaY: emissionY, scrollPhase: .ended, momentumPhase: .none)
+
+        case .momentum:
+            guard hasMovement || shouldContinueMomentum else {
+                sessionState = .idle
+                velocityX = 0
+                velocityY = 0
+                desiredVelocityX = 0
+                desiredVelocityY = 0
+                touchHasBegun = false
+                pendingMomentumBegin = false
+                return .init(deltaX: 0, deltaY: 0, scrollPhase: nil, momentumPhase: .end)
+            }
+
+            if pendingMomentumBegin {
+                pendingMomentumBegin = false
+                return .init(deltaX: emissionX, deltaY: emissionY, scrollPhase: nil, momentumPhase: .begin)
+            }
+
+            return .init(deltaX: emissionX, deltaY: emissionY, scrollPhase: nil, momentumPhase: .continuous)
+        }
+    }
+
+    private func advanceAxis(
+        behavior: AxisBehavior,
+        pendingInput: inout Double,
+        desiredVelocity: inout Double,
+        velocity: inout Double,
+        hasPendingInput: Bool,
+        hasFreshInput: Bool,
+        reengagedFromMomentum: Bool,
+        dt: TimeInterval
+    ) -> Double {
+        switch behavior {
+        case .passthrough:
+            defer {
+                pendingInput = 0
+            }
+            return pendingInput
+
+        case let .smoothed(tuning):
+            if pendingInput != 0 {
+                desiredVelocity = reengagedFromMomentum
+                    ? tuning.reengagedDesiredVelocity(for: pendingInput, currentVelocity: velocity)
+                    : tuning.desiredVelocity(for: pendingInput)
+                if reengagedFromMomentum {
+                    let kick = tuning.reengagementKickFactor(
+                        desiredVelocity: desiredVelocity,
+                        currentVelocity: velocity
+                    )
+                    velocity += (desiredVelocity - velocity) * kick
+                }
+                pendingInput = 0
+            }
+
+            if hasFreshInput || hasPendingInput {
+                let blend = reengagedFromMomentum
+                    ? tuning.reengagementBlendFactor(
+                        for: dt,
+                        desiredVelocity: desiredVelocity,
+                        currentVelocity: velocity
+                    )
+                    : tuning.blendFactor(for: dt)
+                velocity += (desiredVelocity - velocity) * blend
+            } else {
+                velocity *= tuning.momentumDecay(for: dt)
+            }
+
+            return velocity * dt
+        }
+    }
+}

--- a/LinearMouse/EventTransformer/SmoothedScrollingTransformer.swift
+++ b/LinearMouse/EventTransformer/SmoothedScrollingTransformer.swift
@@ -1,0 +1,318 @@
+// MIT License
+// Copyright (c) 2021-2026 LinearMouse
+
+import Foundation
+import os.log
+
+final class SmoothedScrollingTransformer: EventTransformer, Deactivatable {
+    private static let log = OSLog(
+        subsystem: Bundle.main.bundleIdentifier!, category: "SmoothedScrolling"
+    )
+    private static let timerInterval: TimeInterval = 1.0 / 120.0
+    private static let inputLineStepInPoints = 36.0
+    private static let outputLineStepInPoints = 12.0
+
+    private let smoothed: Scheme.Scrolling.Bidirectional<Scheme.Scrolling.Smoothed>
+    private let now: () -> TimeInterval
+    private let eventSink: (CGEvent) -> Void
+    private var engine: SmoothedScrollingEngine
+    private var timer: DispatchSourceTimer?
+    private var lastFlags: CGEventFlags = []
+
+    init(
+        smoothed: Scheme.Scrolling.Bidirectional<Scheme.Scrolling.Smoothed>,
+        now: @escaping () -> TimeInterval = { ProcessInfo.processInfo.systemUptime },
+        eventSink: @escaping (CGEvent) -> Void = { $0.post(tap: .cgSessionEventTap) }
+    ) {
+        self.smoothed = smoothed
+        self.now = now
+        self.eventSink = eventSink
+        engine = SmoothedScrollingEngine(smoothed: smoothed)
+    }
+
+    func transform(_ event: CGEvent) -> CGEvent? {
+        guard event.type == .scrollWheel else {
+            return event
+        }
+
+        let view = ScrollWheelEventView(event)
+
+        if event.isLinearMouseSyntheticEvent {
+            return event
+        }
+
+        let deltaX = deltaXInPixels(from: view)
+        let deltaY = deltaYInPixels(from: view)
+        let hasNativePhase = view.scrollPhase != nil
+        let hasNativeMomentum = view.momentumPhase != .none
+
+        let smoothsX = smoothed.horizontal != nil
+        let smoothsY = smoothed.vertical != nil
+        let handlesX = smoothsX && deltaX != 0
+        let handlesY = smoothsY && deltaY != 0
+        let interceptsX = smoothsX && deltaX != 0
+        let interceptsY = smoothsY && deltaY != 0
+
+        if view.continuous, hasNativePhase || hasNativeMomentum {
+            return transformNativeContinuousGesture(
+                event,
+                view: view,
+                deltaX: deltaX,
+                deltaY: deltaY,
+                handlesX: handlesX,
+                handlesY: handlesY
+            )
+        }
+
+        guard interceptsX || interceptsY else {
+            return event
+        }
+
+        if handlesX || handlesY {
+            lastFlags = event.flags
+            engine.feed(
+                deltaX: handlesX ? deltaX : 0,
+                deltaY: handlesY ? deltaY : 0,
+                timestamp: now()
+            )
+            startTimerIfNeeded()
+        }
+
+        let passthroughEvent = event.copy() ?? event
+        let passthroughView = ScrollWheelEventView(passthroughEvent)
+        if interceptsX {
+            zeroHorizontal(on: passthroughView)
+        }
+        if interceptsY {
+            zeroVertical(on: passthroughView)
+        }
+
+        return deltaXInPixels(from: passthroughView) == 0
+            && deltaYInPixels(from: passthroughView) == 0
+            ? nil
+            : passthroughEvent
+    }
+
+    func deactivate() {
+        stopTimer()
+        engine = SmoothedScrollingEngine(smoothed: smoothed)
+        lastFlags = []
+    }
+
+    private func startTimerIfNeeded() {
+        guard timer == nil else {
+            return
+        }
+
+        let timer = DispatchSource.makeTimerSource(queue: .main)
+        timer.schedule(deadline: .now(), repeating: Self.timerInterval)
+        timer.setEventHandler { [weak self] in
+            self?.tick()
+        }
+        self.timer = timer
+        timer.resume()
+    }
+
+    private func transformNativeContinuousGesture(
+        _ event: CGEvent,
+        view: ScrollWheelEventView,
+        deltaX: Double,
+        deltaY: Double,
+        handlesX: Bool,
+        handlesY: Bool
+    ) -> CGEvent? {
+        let interceptsX = smoothed.horizontal != nil
+        let interceptsY = smoothed.vertical != nil
+        let ensureVisibleTouchDelta = view.scrollPhase == .began || view.scrollPhase == .changed
+
+        guard interceptsX || interceptsY else {
+            return event
+        }
+
+        lastFlags = event.flags
+
+        if handlesX || handlesY {
+            engine.feed(
+                deltaX: handlesX ? deltaX : 0,
+                deltaY: handlesY ? deltaY : 0,
+                timestamp: now()
+            )
+        }
+
+        if let emission = engine.advance(to: now()) {
+            if interceptsX {
+                setHorizontal(
+                    handlesX ? emission.deltaX : 0,
+                    on: view,
+                    ensureVisiblePointDelta: ensureVisibleTouchDelta
+                )
+            }
+            if interceptsY {
+                setVertical(
+                    handlesY ? emission.deltaY : 0,
+                    on: view,
+                    ensureVisiblePointDelta: ensureVisibleTouchDelta
+                )
+            }
+        } else {
+            if interceptsX, !handlesX {
+                zeroHorizontal(on: view)
+            }
+            if interceptsY, !handlesY {
+                zeroVertical(on: view)
+            }
+        }
+
+        let shouldReset = view.scrollPhase == .ended || view.momentumPhase == .end
+        if shouldReset {
+            engine = SmoothedScrollingEngine(smoothed: smoothed)
+            stopTimer()
+        }
+
+        return event
+    }
+
+    private func stopTimer() {
+        timer?.cancel()
+        timer = nil
+    }
+
+    func tick() {
+        guard let emission = engine.advance(to: now()) else {
+            if !engine.isRunning {
+                stopTimer()
+            }
+            return
+        }
+
+        post(emission: emission)
+
+        if !engine.isRunning {
+            stopTimer()
+        }
+    }
+
+    private func post(emission: SmoothedScrollingEngine.Emission) {
+        guard
+            let event = CGEvent(
+                scrollWheelEvent2Source: nil,
+                units: .pixel,
+                wheelCount: 2,
+                wheel1: 0,
+                wheel2: 0,
+                wheel3: 0
+            )
+        else {
+            return
+        }
+
+        let view = ScrollWheelEventView(event)
+        view.continuous = true
+        setHorizontal(emission.deltaX, on: view)
+        setVertical(emission.deltaY, on: view)
+        view.scrollPhase = emission.scrollPhase
+        view.momentumPhase = emission.momentumPhase
+        event.isLinearMouseSyntheticEvent = true
+        event.flags = lastFlags
+        eventSink(event)
+
+        os_log(
+            "post smoothed scroll deltaX=%{public}.3f deltaY=%{public}.3f phase=%{public}@ momentum=%{public}@",
+            log: Self.log,
+            type: .info,
+            emission.deltaX,
+            emission.deltaY,
+            String(describing: emission.scrollPhase),
+            String(describing: emission.momentumPhase)
+        )
+    }
+
+    private func deltaXInPixels(from view: ScrollWheelEventView) -> Double {
+        if !view.continuous {
+            if view.deltaX != 0 {
+                return Double(view.deltaX) * Self.inputLineStepInPoints
+            }
+            if view.deltaXPt != 0 {
+                return view.deltaXPt * Self.inputLineStepInPoints
+            }
+            if view.deltaXFixedPt != 0 {
+                return view.deltaXFixedPt * Self.inputLineStepInPoints * 10
+            }
+        }
+        if view.deltaXPt != 0 {
+            return view.deltaXPt
+        }
+        if view.deltaXFixedPt != 0 {
+            return view.deltaXFixedPt
+        }
+        return Double(view.deltaX) * Self.inputLineStepInPoints
+    }
+
+    private func deltaYInPixels(from view: ScrollWheelEventView) -> Double {
+        if !view.continuous {
+            if view.deltaY != 0 {
+                return Double(view.deltaY) * Self.inputLineStepInPoints
+            }
+            if view.deltaYPt != 0 {
+                return view.deltaYPt * Self.inputLineStepInPoints
+            }
+            if view.deltaYFixedPt != 0 {
+                return view.deltaYFixedPt * Self.inputLineStepInPoints * 10
+            }
+        }
+        if view.deltaYPt != 0 {
+            return view.deltaYPt
+        }
+        if view.deltaYFixedPt != 0 {
+            return view.deltaYFixedPt
+        }
+        return Double(view.deltaY) * Self.inputLineStepInPoints
+    }
+
+    private func setHorizontal(
+        _ value: Double,
+        on view: ScrollWheelEventView,
+        ensureVisiblePointDelta: Bool = false
+    ) {
+        view.deltaX = integerDelta(for: value)
+        view.deltaXPt = pointDelta(for: value, ensureVisible: ensureVisiblePointDelta)
+        view.deltaXFixedPt = value
+        view.ioHidScrollX = value
+    }
+
+    private func setVertical(
+        _ value: Double,
+        on view: ScrollWheelEventView,
+        ensureVisiblePointDelta: Bool = false
+    ) {
+        view.deltaY = integerDelta(for: value)
+        view.deltaYPt = pointDelta(for: value, ensureVisible: ensureVisiblePointDelta)
+        view.deltaYFixedPt = value
+        view.ioHidScrollY = value
+    }
+
+    private func zeroHorizontal(on view: ScrollWheelEventView) {
+        setHorizontal(0, on: view)
+    }
+
+    private func zeroVertical(on view: ScrollWheelEventView) {
+        setVertical(0, on: view)
+    }
+
+    private func integerDelta(for value: Double) -> Int64 {
+        Int64((value / Self.outputLineStepInPoints).rounded(.towardZero))
+    }
+
+    private func pointDelta(for value: Double, ensureVisible: Bool) -> Double {
+        guard value != 0 else {
+            return 0
+        }
+
+        let truncated = Double(Int64(value.rounded(.towardZero)))
+        if truncated != 0 {
+            return truncated
+        }
+
+        return ensureVisible ? (value.sign == .minus ? -1 : 1) : 0
+    }
+}

--- a/LinearMouse/EventView/ScrollWheelEventView.swift
+++ b/LinearMouse/EventView/ScrollWheelEventView.swift
@@ -21,8 +21,31 @@ class ScrollWheelEventView: MouseEventView {
         set { event.setIntegerValueField(.scrollWheelEventIsContinuous, value: newValue ? 1 : 0) }
     }
 
+    var scrollPhase: CGScrollPhase? {
+        get {
+            let rawValue = UInt32(event.getIntegerValueField(.scrollWheelEventScrollPhase))
+            guard rawValue != 0 else {
+                return nil
+            }
+            return .init(rawValue: rawValue)
+        }
+        set {
+            event.setIntegerValueField(.scrollWheelEventScrollPhase, value: Int64(newValue?.rawValue ?? 0))
+        }
+    }
+
     var momentumPhase: CGMomentumScrollPhase {
-        .init(rawValue: UInt32(event.getIntegerValueField(.scrollWheelEventMomentumPhase))) ?? .none
+        get {
+            .init(rawValue: UInt32(event.getIntegerValueField(.scrollWheelEventMomentumPhase))) ?? .none
+        }
+        set {
+            event.setIntegerValueField(.scrollWheelEventMomentumPhase, value: Int64(newValue.rawValue))
+        }
+    }
+
+    var syntheticMarker: Int64 {
+        get { event.getIntegerValueField(.eventSourceUserData) }
+        set { event.setIntegerValueField(.eventSourceUserData, value: newValue) }
     }
 
     var deltaX: Int64 {

--- a/LinearMouse/Localizable.xcstrings
+++ b/LinearMouse/Localizable.xcstrings
@@ -206,6 +206,9 @@
         }
       }
     },
+    "(0–3)" : {
+
+    },
     "(0–10)" : {
       "localizations" : {
         "af" : {
@@ -4110,6 +4113,9 @@
         }
       }
     },
+    "▾" : {
+
+    },
     "0" : {
       "localizations" : {
         "af" : {
@@ -5321,6 +5327,9 @@
           }
         }
       }
+    },
+    "Adaptive" : {
+
     },
     "All Apps" : {
       "localizations" : {
@@ -9782,6 +9791,9 @@
           }
         }
       }
+    },
+    "Choose a feel preset." : {
+
     },
     "Choose a mouse button trigger. Left click without modifier keys is not allowed." : {
 
@@ -14845,6 +14857,9 @@
         }
       }
     },
+    "Editable" : {
+
+    },
     "Enable autoscroll" : {
 
     },
@@ -17676,6 +17691,9 @@
         }
       }
     },
+    "Flat" : {
+
+    },
     "Forward" : {
       "localizations" : {
         "af" : {
@@ -20119,6 +20137,9 @@
           }
         }
       }
+    },
+    "Immediate" : {
+
     },
     "Increase display brightness" : {
       "localizations" : {
@@ -22746,6 +22767,9 @@
         }
       }
     },
+    "Long" : {
+
+    },
     "Look up & data detectors" : {
       "localizations" : {
         "af" : {
@@ -22947,6 +22971,9 @@
           }
         }
       }
+    },
+    "Loose" : {
+
     },
     "Media" : {
       "localizations" : {
@@ -31647,6 +31674,20 @@
         }
       }
     },
+    "Restore default preset" : {
+
+    },
+    "Restore natural preset" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Restore natural preset"
+          }
+        }
+      }
+    },
     "Reveal Config in Finder…" : {
       "localizations" : {
         "af" : {
@@ -33465,6 +33506,9 @@
         }
       }
     },
+    "Scroll acceleration" : {
+
+    },
     "Scroll by moving away from an anchor point, similar to Windows middle-click autoscroll." : {
 
     },
@@ -34074,6 +34118,9 @@
         }
       }
     },
+    "Scroll inertia" : {
+
+    },
     "Scroll left" : {
       "localizations" : {
         "af" : {
@@ -34676,6 +34723,16 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "向左捲動…"
+          }
+        }
+      }
+    },
+    "Scroll response" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Scroll response"
           }
         }
       }
@@ -35285,6 +35342,9 @@
           }
         }
       }
+    },
+    "Scroll speed" : {
+
     },
     "Scroll up" : {
       "localizations" : {
@@ -36292,6 +36352,16 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "捲動加速度"
+          }
+        }
+      }
+    },
+    "Scrolling curve" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Scrolling curve"
           }
         }
       }
@@ -37511,6 +37581,9 @@
     "Select an item from the sidebar" : {
 
     },
+    "Selected" : {
+
+    },
     "Settings" : {
       "extractionState" : "manual",
       "localizations" : {
@@ -37719,6 +37792,9 @@
           }
         }
       }
+    },
+    "Short" : {
+
     },
     "Show desktop" : {
       "localizations" : {
@@ -40345,6 +40421,17 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "切換主要和次要按鍵"
+          }
+        }
+      }
+    },
+    "Synthetic momentum" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Synthetic momentum"
           }
         }
       }

--- a/LinearMouse/Model/Configuration/Scheme/Scrolling/Scrolling.swift
+++ b/LinearMouse/Model/Configuration/Scheme/Scrolling/Scrolling.swift
@@ -9,6 +9,7 @@ extension Scheme {
         @ImplicitOptional var distance: Bidirectional<Distance>
         @ImplicitOptional var acceleration: Bidirectional<Decimal>
         @ImplicitOptional var speed: Bidirectional<Decimal>
+        @ImplicitOptional var smoothed: Bidirectional<Smoothed>
         @ImplicitOptional var modifiers: Bidirectional<Modifiers>
 
         init() {}
@@ -18,12 +19,14 @@ extension Scheme {
             distance: Bidirectional<Distance>? = nil,
             acceleration: Bidirectional<Decimal>? = nil,
             speed: Bidirectional<Decimal>? = nil,
+            smoothed: Bidirectional<Smoothed>? = nil,
             modifiers: Bidirectional<Modifiers>? = nil
         ) {
             $reverse = reverse
             $distance = distance
             $acceleration = acceleration
             $speed = speed
+            $smoothed = smoothed
             $modifiers = modifiers
         }
     }
@@ -35,6 +38,7 @@ extension Scheme.Scrolling {
         $distance?.merge(into: &scrolling.distance)
         $acceleration?.merge(into: &scrolling.acceleration)
         $speed?.merge(into: &scrolling.speed)
+        merge(smoothed: $smoothed, into: &scrolling.smoothed)
         $modifiers?.merge(into: &scrolling.modifiers)
     }
 
@@ -44,5 +48,31 @@ extension Scheme.Scrolling {
         }
 
         merge(into: &scrolling!)
+    }
+
+    private func merge(smoothed source: Bidirectional<Smoothed>?, into target: inout Bidirectional<Smoothed>) {
+        guard let source else {
+            return
+        }
+
+        var merged = target
+
+        if let sourceVertical = source.vertical {
+            if merged.vertical == nil {
+                merged.vertical = sourceVertical
+            } else {
+                sourceVertical.merge(into: &merged.vertical!)
+            }
+        }
+
+        if let sourceHorizontal = source.horizontal {
+            if merged.horizontal == nil {
+                merged.horizontal = sourceHorizontal
+            } else {
+                sourceHorizontal.merge(into: &merged.horizontal!)
+            }
+        }
+
+        target = merged
     }
 }

--- a/LinearMouse/Model/Configuration/Scheme/Scrolling/Smoothed.swift
+++ b/LinearMouse/Model/Configuration/Scheme/Scrolling/Smoothed.swift
@@ -1,0 +1,266 @@
+// MIT License
+// Copyright (c) 2021-2026 LinearMouse
+
+import Foundation
+
+extension Scheme.Scrolling {
+    struct Smoothed: Equatable, Codable, ImplicitInitable {
+        struct PresetProfile: Equatable {
+            var response: Double
+            var inputExponent: Double
+            var accelerationGain: Double
+            var decay: Double
+            var velocityScale: Double
+        }
+
+        enum Preset: String, Codable, Equatable, CaseIterable, Identifiable {
+            var id: Self {
+                self
+            }
+
+            case custom
+            case linear
+            case easeIn
+            case easeOut
+            case easeInOut
+            case easeOutIn
+            case quadratic
+            case cubic
+            case quartic
+            case easeOutCubic
+            case easeInOutCubic
+            case easeOutQuartic
+            case easeInOutQuartic
+            case quintic
+            case sine
+            case exponential
+            case circular
+            case back
+            case bounce
+            case elastic
+            case spring
+            case natural
+            case smooth
+            case snappy
+            case gentle
+        }
+
+        var enabled: Bool?
+        var preset: Preset?
+        var response: Decimal?
+        var speed: Decimal?
+        var acceleration: Decimal?
+        var inertia: Decimal?
+
+        init() {}
+
+        init(
+            enabled: Bool? = nil,
+            preset: Preset? = nil,
+            response: Decimal? = nil,
+            speed: Decimal? = nil,
+            acceleration: Decimal? = nil,
+            inertia: Decimal? = nil
+        ) {
+            self.enabled = enabled
+            self.preset = preset
+            self.response = response
+            self.speed = speed
+            self.acceleration = acceleration
+            self.inertia = inertia
+        }
+    }
+}
+
+extension Scheme.Scrolling.Smoothed {
+    var resolvedPreset: Preset {
+        preset ?? .defaultPreset
+    }
+
+    var resolvedPresetProfile: PresetProfile {
+        resolvedPreset.profile
+    }
+
+    var isEnabled: Bool {
+        enabled ?? true
+    }
+
+    func merge(into smoothed: inout Self) {
+        if let enabled {
+            smoothed.enabled = enabled
+        }
+
+        if let preset {
+            smoothed.preset = preset
+        }
+
+        if let response {
+            smoothed.response = response
+        }
+
+        if let speed {
+            smoothed.speed = speed
+        }
+
+        if let acceleration {
+            smoothed.acceleration = acceleration
+        }
+
+        if let inertia {
+            smoothed.inertia = inertia
+        }
+    }
+
+    func merge(into smoothed: inout Self?) {
+        if smoothed == nil {
+            smoothed = Self()
+        }
+
+        merge(into: &smoothed!)
+    }
+}
+
+extension Scheme.Scrolling.Smoothed.Preset {
+    static var defaultPreset: Self {
+        .easeInOut
+    }
+
+    static var recommendedCases: [Self] {
+        [
+            .easeInOut,
+            .easeIn,
+            .easeOut,
+            .linear,
+            .quadratic,
+            .cubic,
+            .easeOutCubic,
+            .easeInOutCubic,
+            .quartic,
+            .easeOutQuartic,
+            .easeInOutQuartic,
+            .smooth,
+            .custom
+        ]
+    }
+
+    var profile: Scheme.Scrolling.Smoothed.PresetProfile {
+        switch self {
+        case .custom:
+            return .init(response: 0.64, inputExponent: 1.00, accelerationGain: 0.10, decay: 0.89, velocityScale: 32)
+        case .linear:
+            return .init(response: 0.94, inputExponent: 0.96, accelerationGain: 0.04, decay: 0.83, velocityScale: 34)
+        case .easeIn:
+            return .init(response: 0.34, inputExponent: 1.18, accelerationGain: 0.08, decay: 0.93, velocityScale: 24)
+        case .easeOut:
+            return .init(response: 0.90, inputExponent: 0.92, accelerationGain: 0.08, decay: 0.84, velocityScale: 34)
+        case .easeInOut:
+            return .init(response: 0.68, inputExponent: 1.06, accelerationGain: 0.10, decay: 0.89, velocityScale: 31)
+        case .easeOutIn:
+            return .init(response: 0.62, inputExponent: 0.98, accelerationGain: 0.10, decay: 0.87, velocityScale: 30)
+        case .quadratic:
+            return .init(response: 0.58, inputExponent: 1.12, accelerationGain: 0.12, decay: 0.88, velocityScale: 33)
+        case .cubic:
+            return .init(response: 0.52, inputExponent: 1.18, accelerationGain: 0.14, decay: 0.89, velocityScale: 35)
+        case .quartic:
+            return .init(response: 0.46, inputExponent: 1.24, accelerationGain: 0.16, decay: 0.90, velocityScale: 37)
+        case .easeOutCubic:
+            return .init(response: 0.94, inputExponent: 0.86, accelerationGain: 0.08, decay: 0.82, velocityScale: 35)
+        case .easeInOutCubic:
+            return .init(response: 0.62, inputExponent: 1.12, accelerationGain: 0.12, decay: 0.89, velocityScale: 33)
+        case .easeOutQuartic:
+            return .init(response: 0.98, inputExponent: 0.80, accelerationGain: 0.08, decay: 0.80, velocityScale: 36)
+        case .easeInOutQuartic:
+            return .init(response: 0.56, inputExponent: 1.18, accelerationGain: 0.14, decay: 0.90, velocityScale: 34)
+        case .quintic:
+            return .init(response: 0.40, inputExponent: 1.30, accelerationGain: 0.18, decay: 0.91, velocityScale: 39)
+        case .sine:
+            return .init(response: 0.74, inputExponent: 0.98, accelerationGain: 0.08, decay: 0.90, velocityScale: 30)
+        case .exponential:
+            return .init(response: 0.36, inputExponent: 1.34, accelerationGain: 0.20, decay: 0.92, velocityScale: 40)
+        case .circular:
+            return .init(response: 0.50, inputExponent: 1.14, accelerationGain: 0.14, decay: 0.91, velocityScale: 35)
+        case .back:
+            return .init(response: 0.60, inputExponent: 1.04, accelerationGain: 0.13, decay: 0.85, velocityScale: 31)
+        case .bounce:
+            return .init(response: 0.78, inputExponent: 0.94, accelerationGain: 0.08, decay: 0.80, velocityScale: 27)
+        case .elastic:
+            return .init(response: 0.44, inputExponent: 1.10, accelerationGain: 0.14, decay: 0.95, velocityScale: 36)
+        case .spring:
+            return .init(response: 0.88, inputExponent: 0.96, accelerationGain: 0.11, decay: 0.91, velocityScale: 36)
+        case .natural:
+            return .init(response: 0.86, inputExponent: 0.98, accelerationGain: 0.08, decay: 0.86, velocityScale: 32)
+        case .smooth:
+            return .init(response: 0.80, inputExponent: 0.98, accelerationGain: 0.06, decay: 0.93, velocityScale: 33)
+        case .snappy:
+            return .init(response: 1.00, inputExponent: 0.88, accelerationGain: 0.05, decay: 0.76, velocityScale: 32)
+        case .gentle:
+            return .init(response: 0.42, inputExponent: 1.00, accelerationGain: 0.05, decay: 0.97, velocityScale: 34)
+        }
+    }
+
+    var defaultConfiguration: Scheme.Scrolling.Smoothed {
+        let values: (response: Decimal, speed: Decimal, acceleration: Decimal, inertia: Decimal)
+
+        switch self {
+        case .custom:
+            values = (0.68, 1.00, 1.00, 0.80)
+        case .linear:
+            values = (0.92, 1.00, 0.78, 0.44)
+        case .easeIn:
+            values = (0.38, 0.92, 0.86, 1.00)
+        case .easeOut:
+            values = (0.88, 1.02, 0.94, 0.42)
+        case .easeInOut:
+            values = (0.68, 1.02, 1.10, 0.74)
+        case .easeOutIn:
+            values = (0.62, 1.00, 1.08, 0.70)
+        case .quadratic:
+            values = (0.58, 1.04, 1.18, 0.72)
+        case .cubic:
+            values = (0.54, 1.08, 1.24, 0.76)
+        case .quartic:
+            values = (0.48, 1.12, 1.32, 0.82)
+        case .easeOutCubic:
+            values = (0.94, 1.06, 0.92, 0.42)
+        case .easeInOutCubic:
+            values = (0.62, 1.06, 1.20, 0.78)
+        case .easeOutQuartic:
+            values = (0.98, 1.10, 0.90, 0.38)
+        case .easeInOutQuartic:
+            values = (0.56, 1.10, 1.28, 0.82)
+        case .quintic:
+            values = (0.42, 1.16, 1.40, 0.88)
+        case .sine:
+            values = (0.74, 1.00, 0.92, 0.72)
+        case .exponential:
+            values = (0.36, 1.18, 1.55, 0.92)
+        case .circular:
+            values = (0.52, 1.06, 1.26, 0.84)
+        case .back:
+            values = (0.60, 1.04, 1.16, 0.58)
+        case .bounce:
+            values = (0.80, 0.96, 0.88, 0.34)
+        case .elastic:
+            values = (0.44, 1.10, 1.22, 1.08)
+        case .spring:
+            values = (0.86, 1.06, 1.08, 0.96)
+        case .natural:
+            values = (0.84, 1.00, 0.96, 0.58)
+        case .smooth:
+            values = (0.80, 1.00, 0.88, 0.92)
+        case .snappy:
+            values = (0.98, 1.00, 0.78, 0.24)
+        case .gentle:
+            values = (0.42, 0.94, 0.76, 1.18)
+        }
+
+        return .init(
+            enabled: true,
+            preset: self,
+            response: values.response,
+            speed: values.speed,
+            acceleration: values.acceleration,
+            inertia: values.inertia
+        )
+    }
+}

--- a/LinearMouse/UI/ScrollingSettings/ScrollingModeSection.swift
+++ b/LinearMouse/UI/ScrollingSettings/ScrollingModeSection.swift
@@ -94,6 +94,9 @@ extension ScrollingSettings {
                         }
                     }
 
+                case .smoothed:
+                    ScrollingSettings.SmoothedScrollingSection()
+
                 case .byLines:
                     Slider(
                         value: $state.scrollingDistanceInLines,

--- a/LinearMouse/UI/ScrollingSettings/ScrollingSettingsState.swift
+++ b/LinearMouse/UI/ScrollingSettings/ScrollingSettingsState.swift
@@ -9,6 +9,8 @@ class ScrollingSettingsState: ObservableObject {
     static let shared: ScrollingSettingsState = .init()
 
     @PublishedObject private var schemeState = SchemeState.shared
+    private var smoothedCache = Scheme.Scrolling.Bidirectional<Scheme.Scrolling.Smoothed>()
+
     var scheme: Scheme {
         get { schemeState.scheme }
         set { schemeState.scheme = newValue }
@@ -33,12 +35,17 @@ extension ScrollingSettingsState {
         }
 
         case accelerated = "Accelerated"
+        case smoothed = "Smoothed"
         case byLines = "By Lines"
         case byPixels = "By Pixels"
     }
 
     var scrollingMode: ScrollingMode {
         get {
+            if currentSmoothedConfiguration != nil {
+                return .smoothed
+            }
+
             switch mergedScheme.scrolling.distance[direction] ?? .auto {
             case .auto:
                 return .accelerated
@@ -49,20 +56,29 @@ extension ScrollingSettingsState {
             }
         }
         set {
-            var distance: Scheme.Scrolling.Distance
-
             switch newValue {
             case .accelerated:
-                distance = .auto
+                clearSmoothedConfiguration()
+                scheme.scrolling.distance[direction] = .auto
+                scheme.scrolling.acceleration[direction] = 1
+                scheme.scrolling.speed[direction] = 0
+            case .smoothed:
+                let smoothed = currentSmoothedConfiguration ?? makeDefaultSmoothedConfiguration()
+                setSmoothedConfiguration(smoothed)
+                scheme.scrolling.distance[direction] = .auto
+                scheme.scrolling.acceleration[direction] = 1
+                scheme.scrolling.speed[direction] = 0
             case .byLines:
-                distance = .line(3)
+                clearSmoothedConfiguration()
+                scheme.scrolling.distance[direction] = .line(3)
+                scheme.scrolling.acceleration[direction] = 1
+                scheme.scrolling.speed[direction] = 0
             case .byPixels:
-                distance = .pixel(36)
+                clearSmoothedConfiguration()
+                scheme.scrolling.distance[direction] = .pixel(36)
+                scheme.scrolling.acceleration[direction] = 1
+                scheme.scrolling.speed[direction] = 0
             }
-
-            scheme.scrolling.distance[direction] = distance
-            scheme.scrolling.acceleration[direction] = 1
-            scheme.scrolling.speed[direction] = 0
         }
     }
 
@@ -72,12 +88,7 @@ extension ScrollingSettingsState {
     }
 
     var scrollingAccelerationFormatter: NumberFormatter {
-        let formatter = NumberFormatter()
-        formatter.numberStyle = NumberFormatter.Style.decimal
-        formatter.roundingMode = NumberFormatter.RoundingMode.halfUp
-        formatter.maximumFractionDigits = 2
-        formatter.thousandSeparator = ""
-        return formatter
+        decimalFormatter(maxFractionDigits: 2)
     }
 
     var scrollingSpeed: Double {
@@ -86,12 +97,7 @@ extension ScrollingSettingsState {
     }
 
     var scrollingSpeedFormatter: NumberFormatter {
-        let formatter = NumberFormatter()
-        formatter.numberStyle = NumberFormatter.Style.decimal
-        formatter.roundingMode = NumberFormatter.RoundingMode.halfUp
-        formatter.maximumFractionDigits = 2
-        formatter.thousandSeparator = ""
-        return formatter
+        decimalFormatter(maxFractionDigits: 2)
     }
 
     var scrollingDistanceInLines: Double {
@@ -118,10 +124,71 @@ extension ScrollingSettingsState {
         }
     }
 
+    var smoothedPreset: Scheme.Scrolling.Smoothed.Preset {
+        get { currentSmoothedConfiguration?.preset ?? .defaultPreset }
+        set {
+            selectSmoothedPreset(newValue)
+        }
+    }
+
+    var smoothedResponse: Double {
+        get { currentSmoothedConfiguration?.response?.asTruncatedDouble ?? 0.68 }
+        set {
+            updateSmoothedConfigurationAsCustom {
+                $0.response = Decimal(newValue).rounded(2)
+            }
+        }
+    }
+
+    var smoothedResponseFormatter: NumberFormatter {
+        decimalFormatter(maxFractionDigits: 2)
+    }
+
+    var smoothedSpeed: Double {
+        get { currentSmoothedConfiguration?.speed?.asTruncatedDouble ?? 1.02 }
+        set {
+            updateSmoothedConfigurationAsCustom {
+                $0.speed = Decimal(newValue).rounded(2)
+            }
+        }
+    }
+
+    var smoothedSpeedFormatter: NumberFormatter {
+        decimalFormatter(maxFractionDigits: 2)
+    }
+
+    var smoothedAcceleration: Double {
+        get { currentSmoothedConfiguration?.acceleration?.asTruncatedDouble ?? 1.10 }
+        set {
+            updateSmoothedConfigurationAsCustom {
+                $0.acceleration = Decimal(newValue).rounded(2)
+            }
+        }
+    }
+
+    var smoothedAccelerationFormatter: NumberFormatter {
+        decimalFormatter(maxFractionDigits: 2)
+    }
+
+    var smoothedInertia: Double {
+        get { currentSmoothedConfiguration?.inertia?.asTruncatedDouble ?? 0.74 }
+        set {
+            updateSmoothedConfigurationAsCustom {
+                $0.inertia = Decimal(newValue).rounded(2)
+            }
+        }
+    }
+
+    var smoothedInertiaFormatter: NumberFormatter {
+        decimalFormatter(maxFractionDigits: 2)
+    }
+
     var scrollingDisabled: Bool {
         switch scrollingMode {
         case .accelerated:
             return scrollingAcceleration == 0 && scrollingSpeed == 0
+        case .smoothed:
+            return smoothedResponse == 0 && smoothedSpeed == 0 && smoothedAcceleration == 0 && smoothedInertia == 0
         case .byLines:
             return scrollingDistanceInLines == 0
         case .byPixels:
@@ -136,5 +203,85 @@ extension ScrollingSettingsState {
         set {
             scheme.scrolling.modifiers[direction] = newValue
         }
+    }
+
+    private var currentSmoothedConfiguration: Scheme.Scrolling.Smoothed? {
+        let configuration = scheme.scrolling.smoothed[direction]
+            ?? mergedScheme.scrolling.smoothed[direction]
+            ?? smoothedCache[direction]
+        guard configuration?.isEnabled == true else {
+            return nil
+        }
+        return configuration
+    }
+
+    func smoothedPreviewConfiguration(for preset: Scheme.Scrolling.Smoothed.Preset) -> Scheme.Scrolling.Smoothed {
+        if preset == .custom {
+            var configuration = scheme.scrolling.smoothed[direction]
+                ?? smoothedCache[direction]
+                ?? currentSmoothedConfiguration
+                ?? makeDefaultSmoothedConfiguration()
+            configuration.enabled = true
+            configuration.preset = .custom
+            return configuration
+        }
+
+        return preset.defaultConfiguration
+    }
+
+    func restoreDefaultSmoothedPreset() {
+        selectSmoothedPreset(.defaultPreset)
+    }
+
+    private func setSmoothedConfiguration(_ configuration: Scheme.Scrolling.Smoothed) {
+        var configuration = configuration
+        configuration.enabled = true
+        scheme.scrolling.smoothed[direction] = configuration
+        smoothedCache[direction] = configuration
+    }
+
+    private func clearSmoothedConfiguration() {
+        if let currentSmoothedConfiguration {
+            smoothedCache[direction] = currentSmoothedConfiguration
+        }
+
+        scheme.scrolling.smoothed[direction] = .init(enabled: false)
+    }
+
+    private func makeDefaultSmoothedConfiguration() -> Scheme.Scrolling.Smoothed {
+        Scheme.Scrolling.Smoothed.Preset.defaultPreset.defaultConfiguration
+    }
+
+    private func selectSmoothedPreset(_ preset: Scheme.Scrolling.Smoothed.Preset) {
+        if preset == .custom {
+            setSmoothedConfiguration(makeCustomSmoothedConfiguration())
+        } else {
+            setSmoothedConfiguration(preset.defaultConfiguration)
+        }
+    }
+
+    private func makeCustomSmoothedConfiguration() -> Scheme.Scrolling.Smoothed {
+        var configuration = currentSmoothedConfiguration
+            ?? scheme.scrolling.smoothed[direction]
+            ?? smoothedCache[direction]
+            ?? makeDefaultSmoothedConfiguration()
+        configuration.enabled = true
+        configuration.preset = .custom
+        return configuration
+    }
+
+    private func updateSmoothedConfigurationAsCustom(_ update: (inout Scheme.Scrolling.Smoothed) -> Void) {
+        var configuration = makeCustomSmoothedConfiguration()
+        update(&configuration)
+        setSmoothedConfiguration(configuration)
+    }
+
+    private func decimalFormatter(maxFractionDigits: Int) -> NumberFormatter {
+        let formatter = NumberFormatter()
+        formatter.numberStyle = .decimal
+        formatter.roundingMode = .halfUp
+        formatter.maximumFractionDigits = maxFractionDigits
+        formatter.thousandSeparator = ""
+        return formatter
     }
 }

--- a/LinearMouse/UI/ScrollingSettings/SmoothedScrollingSection.swift
+++ b/LinearMouse/UI/ScrollingSettings/SmoothedScrollingSection.swift
@@ -1,0 +1,680 @@
+// MIT License
+// Copyright (c) 2021-2026 LinearMouse
+
+import AppKit
+import SwiftUI
+
+extension ScrollingSettings {
+    struct SmoothedScrollingSection: View {
+        @ObservedObject private var state = ScrollingSettingsState.shared
+        @State private var isPresetPickerPresented = false
+
+        private var visiblePresets: [Scheme.Scrolling.Smoothed.Preset] {
+            let recommended = Scheme.Scrolling.Smoothed.Preset.recommendedCases
+            let current = state.smoothedPreset
+            return recommended.contains(current) ? recommended : [current] + recommended
+        }
+
+        var body: some View {
+            VStack(alignment: .leading, spacing: 14) {
+                withDescription {
+                    Text("Scrolling curve")
+                    Text("Choose a feel preset.")
+                }
+
+                presetPicker
+
+                sliderRow(
+                    title: "Scroll response",
+                    description: "(0–1)",
+                    value: Binding(
+                        get: { state.smoothedResponse },
+                        set: { state.smoothedResponse = $0 }
+                    ),
+                    range: 0.0 ... 1.0,
+                    minimumValueLabel: "Loose",
+                    maximumValueLabel: "Immediate",
+                    formatter: state.smoothedResponseFormatter
+                )
+
+                sliderRow(
+                    title: "Scroll speed",
+                    description: "(0–3)",
+                    value: Binding(
+                        get: { state.smoothedSpeed },
+                        set: { state.smoothedSpeed = $0 }
+                    ),
+                    range: 0.0 ... 3.0,
+                    minimumValueLabel: "Slow",
+                    maximumValueLabel: "Fast",
+                    formatter: state.smoothedSpeedFormatter
+                )
+
+                sliderRow(
+                    title: "Scroll acceleration",
+                    description: "(0–3)",
+                    value: Binding(
+                        get: { state.smoothedAcceleration },
+                        set: { state.smoothedAcceleration = $0 }
+                    ),
+                    range: 0.0 ... 3.0,
+                    minimumValueLabel: "Flat",
+                    maximumValueLabel: "Adaptive",
+                    formatter: state.smoothedAccelerationFormatter
+                )
+
+                sliderRow(
+                    title: "Scroll inertia",
+                    description: "(0–3)",
+                    value: Binding(
+                        get: { state.smoothedInertia },
+                        set: { state.smoothedInertia = $0 }
+                    ),
+                    range: 0.0 ... 3.0,
+                    minimumValueLabel: "Short",
+                    maximumValueLabel: "Long",
+                    formatter: state.smoothedInertiaFormatter
+                )
+
+                HStack(spacing: 10) {
+                    Button("Restore default preset") {
+                        state.scrollingMode = .smoothed
+                        state.restoreDefaultSmoothedPreset()
+                    }
+
+                    if state.direction == .horizontal {
+                        Button("Copy settings from vertical") {
+                            state.scheme.scrolling.smoothed.horizontal = state.mergedScheme.scrolling.smoothed.vertical
+                        }
+                    }
+                }
+            }
+        }
+
+        private var presetPicker: some View {
+            Button {
+                isPresetPickerPresented.toggle()
+            } label: {
+                HStack(spacing: 12) {
+                    SmoothedCurvePreview(
+                        configuration: state.smoothedPreviewConfiguration(for: state.smoothedPreset),
+                        highlighted: false,
+                        style: .compact
+                    )
+                    .frame(width: 92, height: 44)
+
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text(state.smoothedPreset.displayName)
+                            .font(.headline)
+                            .foregroundColor(.primary)
+
+                        Text(presetFootnote(for: state.smoothedPreset))
+                            .font(.subheadline)
+                            .foregroundColor(.secondary)
+                            .lineLimit(1)
+                    }
+
+                    Spacer()
+
+                    Text("▾")
+                        .font(.system(size: 12, weight: .semibold))
+                        .foregroundColor(.secondary)
+                }
+                .padding(.horizontal, 12)
+                .padding(.vertical, 10)
+                .background(
+                    RoundedRectangle(cornerRadius: 12, style: .continuous)
+                        .fill(Color(NSColor.controlBackgroundColor))
+                )
+                .overlay(
+                    RoundedRectangle(cornerRadius: 12, style: .continuous)
+                        .stroke(Color.secondary.opacity(0.18), lineWidth: 1)
+                )
+            }
+            .buttonStyle(.plain)
+            .popover(isPresented: $isPresetPickerPresented, arrowEdge: .top) {
+                ScrollView {
+                    VStack(alignment: .leading, spacing: 8) {
+                        ForEach(visiblePresets) { preset in
+                            presetMenuRow(for: preset)
+                        }
+                    }
+                    .padding(10)
+                }
+                .frame(width: 300, height: 400)
+            }
+        }
+
+        private func presetMenuRow(for preset: Scheme.Scrolling.Smoothed.Preset) -> some View {
+            let isSelected = state.smoothedPreset == preset
+            let configuration = state.smoothedPreviewConfiguration(for: preset)
+
+            return Button {
+                state.scrollingMode = .smoothed
+                state.smoothedPreset = preset
+                isPresetPickerPresented = false
+            } label: {
+                HStack(spacing: 12) {
+                    SmoothedCurvePreview(
+                        configuration: configuration,
+                        highlighted: isSelected,
+                        style: .compact
+                    )
+                    .frame(width: 92, height: 44)
+
+                    VStack(alignment: .leading, spacing: 3) {
+                        HStack(alignment: .firstTextBaseline, spacing: 6) {
+                            Text(preset.displayName)
+                                .font(.system(size: 13, weight: .semibold))
+                                .foregroundColor(.primary)
+                                .lineLimit(1)
+
+                            if preset == .custom {
+                                Text("Editable")
+                                    .font(.system(size: 10, weight: .medium))
+                                    .foregroundColor(.secondary)
+                            }
+                        }
+                    }
+
+                    Spacer(minLength: 0)
+
+                    if isSelected {
+                        Text("Selected")
+                            .font(.system(size: 10, weight: .semibold))
+                            .foregroundColor(.accentColor)
+                    }
+                }
+                .padding(.horizontal, 10)
+                .padding(.vertical, 8)
+                .frame(maxWidth: .infinity, minHeight: 64, maxHeight: 64, alignment: .leading)
+                .background(
+                    RoundedRectangle(cornerRadius: 12, style: .continuous)
+                        .fill(isSelected ? Color.accentColor.opacity(0.12) : Color(NSColor.controlBackgroundColor))
+                )
+                .overlay(
+                    RoundedRectangle(cornerRadius: 12, style: .continuous)
+                        .stroke(
+                            isSelected ? Color.accentColor : Color.secondary.opacity(0.18),
+                            lineWidth: isSelected ? 1.5 : 1
+                        )
+                )
+            }
+            .buttonStyle(.plain)
+        }
+
+        private func presetFootnote(for preset: Scheme.Scrolling.Smoothed.Preset) -> String {
+            switch preset {
+            case .custom:
+                return "Use this when you want to fine-tune the feel yourself."
+            case .linear:
+                return "Direct and immediate, with a short controlled tail."
+            case .easeIn:
+                return "Soft start that builds momentum as you keep scrolling."
+            case .easeOut:
+                return "Fast initial response that settles quickly."
+            case .easeInOut:
+                return "Balanced ramp-up and release."
+            case .easeOutIn:
+                return "Quick pickup with a softer body."
+            case .quadratic:
+                return "Ease-in quad with a noticeable but manageable ramp-up."
+            case .cubic:
+                return "Ease-in cubic with a stronger progressive build."
+            case .quartic:
+                return "Ease-in quartic with the strongest front-loaded ramp."
+            case .easeOutCubic:
+                return "Fast cubic pickup that settles into a shorter tail."
+            case .easeInOutCubic:
+                return "Cubic ease-in-out with a weightier middle section."
+            case .easeOutQuartic:
+                return "Very fast quartic pickup with a crisp release."
+            case .easeInOutQuartic:
+                return "Quartic ease-in-out with the boldest mid-curve."
+            case .quintic:
+                return "Aggressive curve with a deep push."
+            case .sine:
+                return "Gentle, wave-like motion."
+            case .exponential:
+                return "Very strong build-up for bold flicks."
+            case .circular:
+                return "Rounded entry with a stable tail."
+            case .back:
+                return "Taut and punchy with a tighter stop."
+            case .bounce:
+                return "Playful, short-lived motion."
+            case .elastic:
+                return "Springy movement with a longer tail."
+            case .spring:
+                return "Fast pickup with a lively, cushioned rebound."
+            case .natural:
+                return "Legacy balanced preset kept for compatibility."
+            case .smooth:
+                return "Stable and fluid, with a longer carry than Linear."
+            case .snappy:
+                return "The quickest start, with the shortest tail."
+            case .gentle:
+                return "Soft and gliding, with the longest tail."
+            }
+        }
+
+        private func sliderRow(
+            title: LocalizedStringKey,
+            description: LocalizedStringKey,
+            value: Binding<Double>,
+            range: ClosedRange<Double>,
+            minimumValueLabel: LocalizedStringKey,
+            maximumValueLabel: LocalizedStringKey,
+            formatter: NumberFormatter
+        ) -> some View {
+            HStack(alignment: .firstTextBaseline) {
+                Slider(
+                    value: value,
+                    in: range
+                ) {
+                    labelWithDescription {
+                        Text(title)
+                        Text(description)
+                    }
+                } minimumValueLabel: {
+                    Text(minimumValueLabel)
+                } maximumValueLabel: {
+                    Text(maximumValueLabel)
+                }
+
+                DeferredNumberField(
+                    value: value,
+                    formatter: formatter,
+                    range: range
+                )
+                .frame(width: 60, height: 22)
+            }
+        }
+    }
+}
+
+private struct SmoothedCurvePreview: View {
+    enum Style {
+        case compact
+        case large
+    }
+
+    let configuration: Scheme.Scrolling.Smoothed
+    let highlighted: Bool
+    let style: Style
+
+    private var samples: [CGFloat] {
+        let count = style == .large ? 36 : 24
+        return (0 ..< count).map { index in
+            let t = CGFloat(index) / CGFloat(max(count - 1, 1))
+            return previewValue(at: t)
+        }
+    }
+
+    var body: some View {
+        GeometryReader { geometry in
+            let rect = geometry.frame(in: .local)
+
+            ZStack {
+                RoundedRectangle(cornerRadius: 10, style: .continuous)
+                    .fill(highlighted ? Color.accentColor.opacity(0.08) : Color(NSColor.windowBackgroundColor))
+
+                grid(in: rect)
+                    .stroke(Color.secondary.opacity(0.12), style: StrokeStyle(lineWidth: 1, dash: [3, 3]))
+
+                fillPath(in: rect)
+                    .fill(
+                        LinearGradient(
+                            colors: [
+                                Color.accentColor.opacity(highlighted ? 0.34 : 0.22),
+                                Color.accentColor.opacity(0.04)
+                            ],
+                            startPoint: .top,
+                            endPoint: .bottom
+                        )
+                    )
+
+                curvePath(in: rect)
+                    .stroke(
+                        highlighted ? Color.accentColor : Color.primary.opacity(0.72),
+                        style: StrokeStyle(lineWidth: highlighted ? 2.2 : 1.8, lineCap: .round, lineJoin: .round)
+                    )
+            }
+        }
+    }
+
+    private func grid(in rect: CGRect) -> Path {
+        var path = Path()
+
+        for step in 1 ..< 4 {
+            let y = rect.minY + (rect.height / 4) * CGFloat(step)
+            path.move(to: CGPoint(x: rect.minX + 8, y: y))
+            path.addLine(to: CGPoint(x: rect.maxX - 8, y: y))
+        }
+
+        return path
+    }
+
+    private func fillPath(in rect: CGRect) -> Path {
+        var path = curvePath(in: rect)
+        path.addLine(to: CGPoint(x: rect.maxX - 8, y: rect.maxY - 8))
+        path.addLine(to: CGPoint(x: rect.minX + 8, y: rect.maxY - 8))
+        path.closeSubpath()
+        return path
+    }
+
+    private func curvePath(in rect: CGRect) -> Path {
+        let insetRect = rect.insetBy(dx: 8, dy: 8)
+        let count = max(samples.count - 1, 1)
+
+        return Path { path in
+            for (index, sample) in samples.enumerated() {
+                let x = insetRect.minX + insetRect.width * CGFloat(index) / CGFloat(count)
+                let y = insetRect.maxY - insetRect.height * sample
+                let point = CGPoint(x: x, y: y)
+
+                if index == 0 {
+                    path.move(to: point)
+                } else {
+                    path.addLine(to: point)
+                }
+            }
+        }
+    }
+
+    private func previewValue(at t: CGFloat) -> CGFloat {
+        let preset = configuration.resolvedPreset
+
+        switch preset {
+        case .custom:
+            return dynamicPreviewValue(at: t)
+        case .linear:
+            return t
+        case .easeIn:
+            return pow(t, 2.2)
+        case .easeOut:
+            return 1 - pow(1 - t, 2.2)
+        case .easeInOut:
+            return easeInOutPower(t, power: 2.0)
+        case .easeOutIn:
+            return easeOutInPower(t, power: 2.0)
+        case .quadratic:
+            return pow(t, 2.0)
+        case .cubic:
+            return pow(t, 3.0)
+        case .quartic:
+            return pow(t, 4.0)
+        case .easeOutCubic:
+            return 1 - pow(1 - t, 3.0)
+        case .easeInOutCubic:
+            return easeInOutPower(t, power: 3.0)
+        case .easeOutQuartic:
+            return 1 - pow(1 - t, 4.0)
+        case .easeInOutQuartic:
+            return easeInOutPower(t, power: 4.0)
+        case .quintic:
+            return pow(t, 5.0)
+        case .sine:
+            return 1 - cos((t * .pi) / 2)
+        case .exponential:
+            return t == 0 ? 0 : pow(2, 10 * (t - 1))
+        case .circular:
+            return 1 - sqrt(max(0, 1 - t * t))
+        case .back:
+            return backCurve(t)
+        case .bounce:
+            return bounceCurve(t)
+        case .elastic:
+            return elasticCurve(t)
+        case .spring:
+            return springCurve(t)
+        case .natural:
+            return easeOutInPower(t, power: 1.55)
+        case .smooth:
+            return easeInOutPower(t, power: 1.45)
+        case .snappy:
+            return 1 - pow(1 - t, 3.6)
+        case .gentle:
+            return 1 - pow(1 - t, 1.35)
+        }
+    }
+
+    private func dynamicPreviewValue(at t: CGFloat) -> CGFloat {
+        let response = CGFloat(configuration.response?.asTruncatedDouble ?? 0.68)
+        let speed = CGFloat(configuration.speed?.asTruncatedDouble ?? 1.0)
+        let acceleration = CGFloat(configuration.acceleration?.asTruncatedDouble ?? 1.0)
+        let inertia = CGFloat(configuration.inertia?.asTruncatedDouble ?? 0.8)
+
+        let leadingPower = max(0.8, 2.2 - response * 1.4 - speed * 0.15)
+        let tailPower = max(1.1, 1.2 + inertia * 0.7 + acceleration * 0.08)
+        let midpoint = min(max(0.35 + response * 0.18, 0.25), 0.75)
+
+        if t < midpoint {
+            let local = t / midpoint
+            return pow(local, leadingPower) * 0.52
+        }
+
+        let local = (t - midpoint) / max(1 - midpoint, 0.001)
+        return 0.52 + (1 - pow(1 - local, tailPower)) * 0.48
+    }
+
+    private func easeInOutPower(_ t: CGFloat, power: CGFloat) -> CGFloat {
+        if t < 0.5 {
+            return 0.5 * pow(t * 2, power)
+        }
+
+        return 1 - 0.5 * pow((1 - t) * 2, power)
+    }
+
+    private func easeOutInPower(_ t: CGFloat, power: CGFloat) -> CGFloat {
+        if t < 0.5 {
+            return 0.5 * (1 - pow(1 - t * 2, power))
+        }
+
+        return 0.5 + 0.5 * pow((t - 0.5) * 2, power)
+    }
+
+    private func backCurve(_ t: CGFloat) -> CGFloat {
+        let c1: CGFloat = 1.35
+        let c3 = c1 + 1
+        let value = c3 * t * t * t - c1 * t * t
+        return max(0, min(1, value))
+    }
+
+    private func bounceCurve(_ t: CGFloat) -> CGFloat {
+        let n1: CGFloat = 7.5625
+        let d1: CGFloat = 2.75
+        let value: CGFloat
+
+        if t < 1 / d1 {
+            value = n1 * t * t
+        } else if t < 2 / d1 {
+            let local = t - 1.5 / d1
+            value = n1 * local * local + 0.75
+        } else if t < 2.5 / d1 {
+            let local = t - 2.25 / d1
+            value = n1 * local * local + 0.9375
+        } else {
+            let local = t - 2.625 / d1
+            value = n1 * local * local + 0.984375
+        }
+
+        return max(0, min(1, value))
+    }
+
+    private func elasticCurve(_ t: CGFloat) -> CGFloat {
+        guard t != 0, t != 1 else {
+            return t
+        }
+
+        let c4 = (2 * CGFloat.pi) / 3
+        let value = -pow(2, 10 * t - 10) * sin((t * 10 - 10.75) * c4)
+        return max(0, min(1, value + 1))
+    }
+
+    private func springCurve(_ t: CGFloat) -> CGFloat {
+        let value = 1 - exp(-6 * t) * cos(8.5 * t)
+        return max(0, min(1, value))
+    }
+}
+
+private struct DeferredNumberField: NSViewRepresentable {
+    @Binding var value: Double
+    let formatter: NumberFormatter
+    let range: ClosedRange<Double>
+
+    init(value: Binding<Double>, formatter: NumberFormatter, range: ClosedRange<Double>) {
+        _value = value
+        self.formatter = formatter
+        self.range = range
+    }
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(parent: self)
+    }
+
+    func makeNSView(context: Context) -> NSTextField {
+        let textField = NSTextField(string: formattedValue(value))
+        textField.isBordered = true
+        textField.isBezeled = true
+        textField.bezelStyle = .roundedBezel
+        textField.focusRingType = .default
+        textField.alignment = .right
+        textField.delegate = context.coordinator
+        textField.usesSingleLineMode = true
+        textField.maximumNumberOfLines = 1
+        textField.lineBreakMode = .byClipping
+        return textField
+    }
+
+    func updateNSView(_ textField: NSTextField, context: Context) {
+        context.coordinator.parent = self
+
+        guard !context.coordinator.isEditing else {
+            return
+        }
+
+        let formatted = formattedValue(value)
+        if textField.stringValue != formatted {
+            textField.stringValue = formatted
+        }
+    }
+
+    private func formattedValue(_ value: Double) -> String {
+        formatter.string(from: NSNumber(value: value)) ?? ""
+    }
+
+    final class Coordinator: NSObject, NSTextFieldDelegate {
+        var parent: DeferredNumberField
+        var isEditing = false
+
+        init(parent: DeferredNumberField) {
+            self.parent = parent
+        }
+
+        func controlTextDidBeginEditing(_: Notification) {
+            isEditing = true
+        }
+
+        func controlTextDidEndEditing(_ notification: Notification) {
+            guard let textField = notification.object as? NSTextField else {
+                isEditing = false
+                return
+            }
+
+            commit(textField)
+            isEditing = false
+        }
+
+        func control(_ control: NSControl, textView _: NSTextView, doCommandBy commandSelector: Selector) -> Bool {
+            guard let textField = control as? NSTextField else {
+                return false
+            }
+
+            if commandSelector == #selector(NSResponder.insertNewline(_:)) {
+                commit(textField)
+                textField.window?.makeFirstResponder(nil)
+                return true
+            }
+
+            if commandSelector == #selector(NSResponder.cancelOperation(_:)) {
+                textField.stringValue = parent.formattedValue(parent.value)
+                textField.window?.makeFirstResponder(nil)
+                return true
+            }
+
+            return false
+        }
+
+        private func commit(_ textField: NSTextField) {
+            let trimmed = textField.stringValue.trimmingCharacters(in: .whitespacesAndNewlines)
+
+            guard !trimmed.isEmpty,
+                  let number = parent.formatter.number(from: trimmed) else {
+                textField.stringValue = parent.formattedValue(parent.value)
+                return
+            }
+
+            let clamped = min(max(number.doubleValue, parent.range.lowerBound), parent.range.upperBound)
+            parent.value = clamped
+            textField.stringValue = parent.formattedValue(clamped)
+        }
+    }
+}
+
+private extension Scheme.Scrolling.Smoothed.Preset {
+    var displayName: String {
+        switch self {
+        case .custom:
+            return "Custom"
+        case .linear:
+            return "Linear"
+        case .easeIn:
+            return "Ease In"
+        case .easeOut:
+            return "Ease Out"
+        case .easeInOut:
+            return "Ease In Out"
+        case .easeOutIn:
+            return "Ease Out In"
+        case .quadratic:
+            return "Ease In Quad"
+        case .cubic:
+            return "Ease In Cubic"
+        case .quartic:
+            return "Ease In Quartic"
+        case .easeOutCubic:
+            return "Ease Out Cubic"
+        case .easeInOutCubic:
+            return "Ease In Out Cubic"
+        case .easeOutQuartic:
+            return "Ease Out Quartic"
+        case .easeInOutQuartic:
+            return "Ease In Out Quartic"
+        case .quintic:
+            return "Quintic"
+        case .sine:
+            return "Sine"
+        case .exponential:
+            return "Exponential"
+        case .circular:
+            return "Circular"
+        case .back:
+            return "Back"
+        case .bounce:
+            return "Bounce"
+        case .elastic:
+            return "Elastic"
+        case .spring:
+            return "Spring"
+        case .natural:
+            return "Natural"
+        case .smooth:
+            return "Smooth"
+        case .snappy:
+            return "Snappy"
+        case .gentle:
+            return "Gentle"
+        }
+    }
+}

--- a/LinearMouse/Utilities/CGEvent+LinearMouseSynthetic.swift
+++ b/LinearMouse/Utilities/CGEvent+LinearMouseSynthetic.swift
@@ -1,0 +1,20 @@
+// MIT License
+// Copyright (c) 2021-2026 LinearMouse
+
+import Foundation
+
+extension CGEvent {
+    private static let linearMouseSyntheticEventUserData: Int64 = 0x534D_4F4F_5448
+
+    var isLinearMouseSyntheticEvent: Bool {
+        get {
+            getIntegerValueField(.eventSourceUserData) == Self.linearMouseSyntheticEventUserData
+        }
+        set {
+            setIntegerValueField(
+                .eventSourceUserData,
+                value: newValue ? Self.linearMouseSyntheticEventUserData : 0
+            )
+        }
+    }
+}

--- a/LinearMouseUnitTests/EventTransformer/EventTransformerManagerTests.swift
+++ b/LinearMouseUnitTests/EventTransformer/EventTransformerManagerTests.swift
@@ -1,0 +1,131 @@
+// MIT License
+// Copyright (c) 2021-2026 LinearMouse
+
+@testable import LinearMouse
+import XCTest
+
+final class EventTransformerManagerTests: XCTestCase {
+    override func tearDown() {
+        super.tearDown()
+        ConfigurationState.shared.configuration = .init()
+    }
+
+    func testSyntheticSmoothedEventStillGetsModifierActions() throws {
+        let modifiers = Scheme.Scrolling.Modifiers(option: .changeSpeed(scale: 2))
+        ConfigurationState.shared.configuration = .init(schemes: [
+            Scheme(
+                scrolling: .init(
+                    reverse: .init(vertical: true),
+                    acceleration: .init(vertical: 2),
+                    smoothed: .init(vertical: .init(enabled: true, preset: .natural)),
+                    modifiers: .init(vertical: modifiers)
+                )
+            )
+        ])
+
+        let event = try XCTUnwrap(CGEvent(
+            scrollWheelEvent2Source: nil,
+            units: .pixel,
+            wheelCount: 2,
+            wheel1: 0,
+            wheel2: 0,
+            wheel3: 0
+        ))
+        let view = ScrollWheelEventView(event)
+        view.continuous = true
+        view.deltaYPt = 12
+        view.deltaYFixedPt = 12
+        event.flags = [.maskAlternate]
+        event.isLinearMouseSyntheticEvent = true
+
+        let transformer = EventTransformerManager.shared.get(
+            withCGEvent: event,
+            withSourcePid: nil,
+            withTargetPid: nil,
+            withMouseLocationPid: nil,
+            withDisplay: nil
+        )
+        let transformedEvent = try XCTUnwrap(transformer.transform(event))
+        let transformedView = ScrollWheelEventView(transformedEvent)
+
+        XCTAssertEqual(transformedView.deltaYPt, 24, accuracy: 0.001)
+        XCTAssertEqual(transformedView.deltaYFixedPt, 24, accuracy: 0.001)
+        XCTAssertEqual(transformedEvent.flags, [])
+    }
+
+    func testDisabledSmoothedConfigurationFallsBackToLegacyScrolling() throws {
+        ConfigurationState.shared.configuration = .init(schemes: [
+            Scheme(scrolling: .init(
+                smoothed: .init(vertical: .init(enabled: true, preset: .natural))
+            )),
+            Scheme(scrolling: .init(
+                distance: .init(vertical: .line(3)),
+                smoothed: .init(vertical: .init(enabled: false))
+            ))
+        ])
+
+        let event = try XCTUnwrap(CGEvent(
+            scrollWheelEvent2Source: nil,
+            units: .line,
+            wheelCount: 2,
+            wheel1: 1,
+            wheel2: 0,
+            wheel3: 0
+        ))
+
+        let transformer = EventTransformerManager.shared.get(
+            withCGEvent: event,
+            withSourcePid: nil,
+            withTargetPid: nil,
+            withMouseLocationPid: nil,
+            withDisplay: nil
+        )
+        let transformedEvent = try XCTUnwrap(transformer.transform(event))
+        let view = ScrollWheelEventView(transformedEvent)
+
+        XCTAssertEqual(view.deltaY, 3)
+        XCTAssertEqual(view.scrollPhase, nil)
+        XCTAssertEqual(view.momentumPhase, .none)
+    }
+
+    func testContinuousTrackpadEventStillGetsReverseScrollingWhenSmoothedExists() throws {
+        ConfigurationState.shared.configuration = .init(schemes: [
+            Scheme(
+                scrolling: .init(
+                    reverse: .init(vertical: true),
+                    smoothed: .init(vertical: .init(enabled: true, preset: .easeInOut))
+                )
+            )
+        ])
+
+        let event = try XCTUnwrap(CGEvent(
+            scrollWheelEvent2Source: nil,
+            units: .pixel,
+            wheelCount: 2,
+            wheel1: 0,
+            wheel2: 0,
+            wheel3: 0
+        ))
+        let view = ScrollWheelEventView(event)
+        view.continuous = true
+        view.deltaYPt = 12
+        view.deltaYFixedPt = 12
+        view.scrollPhase = .began
+
+        let transformer = EventTransformerManager.shared.get(
+            withCGEvent: event,
+            withSourcePid: nil,
+            withTargetPid: nil,
+            withMouseLocationPid: nil,
+            withDisplay: nil
+        )
+        let transformedEvent = try XCTUnwrap(transformer.transform(event))
+        let transformedView = ScrollWheelEventView(transformedEvent)
+
+        XCTAssertLessThan(transformedView.deltaYPt, 0)
+        XCTAssertEqual(transformedView.deltaYPt, -1, accuracy: 0.001)
+        XCTAssertLessThan(transformedView.deltaYFixedPt, 0)
+        XCTAssertGreaterThan(transformedView.deltaYFixedPt, -12)
+        XCTAssertEqual(transformedView.scrollPhase, .began)
+    }
+}

--- a/LinearMouseUnitTests/EventTransformer/SmoothedScrollingEngineTests.swift
+++ b/LinearMouseUnitTests/EventTransformer/SmoothedScrollingEngineTests.swift
@@ -1,0 +1,160 @@
+// MIT License
+// Copyright (c) 2021-2026 LinearMouse
+
+@testable import LinearMouse
+import XCTest
+
+final class SmoothedScrollingEngineTests: XCTestCase {
+    func testSmoothedScrollingTransitionsIntoMomentumAndEnds() {
+        let engine = SmoothedScrollingEngine(
+            smoothed: .init(
+                vertical: .init(
+                    enabled: true,
+                    preset: .natural,
+                    response: Decimal(string: "0.45"),
+                    speed: 1,
+                    acceleration: Decimal(string: "1.2"),
+                    inertia: Decimal(string: "0.65")
+                )
+            )
+        )
+
+        var emissions: [SmoothedScrollingEngine.Emission] = []
+
+        for step in 0 ..< 6 {
+            let timestamp = Double(step) / 120
+            engine.feed(deltaX: 0, deltaY: 40, timestamp: timestamp)
+            if let emission = engine.advance(to: timestamp + 1.0 / 120) {
+                emissions.append(emission)
+            }
+        }
+
+        for step in 6 ..< 240 {
+            let timestamp = Double(step + 1) / 120
+            if let emission = engine.advance(to: timestamp) {
+                emissions.append(emission)
+            }
+        }
+
+        XCTAssertEqual(emissions.first?.scrollPhase, .began)
+        XCTAssertTrue(emissions.dropFirst().contains { $0.scrollPhase == .changed })
+        let endedIndex = emissions.firstIndex { $0.scrollPhase == .ended }
+        let momentumBeginIndex = emissions.firstIndex { $0.momentumPhase == .begin }
+        XCTAssertNotNil(endedIndex)
+        XCTAssertNotNil(momentumBeginIndex)
+        if let endedIndex, let momentumBeginIndex {
+            XCTAssertLessThan(endedIndex, momentumBeginIndex)
+        }
+        XCTAssertTrue(emissions.contains { $0.momentumPhase == .begin })
+        XCTAssertTrue(emissions.contains { $0.momentumPhase == .continuous })
+        XCTAssertEqual(emissions.last?.momentumPhase, .end)
+    }
+
+    func testSmoothedScrollingPreservesPassthroughAxis() {
+        let engine = SmoothedScrollingEngine(
+            smoothed: .init(
+                vertical: .init(
+                    enabled: true,
+                    preset: .natural,
+                    response: Decimal(string: "0.45"),
+                    speed: 1,
+                    acceleration: Decimal(string: "1.2"),
+                    inertia: Decimal(string: "0.65")
+                )
+            )
+        )
+
+        engine.feed(deltaX: 18, deltaY: 24, timestamp: 0)
+        let emission = engine.advance(to: 1.0 / 120)
+
+        XCTAssertEqual(emission?.scrollPhase, .began)
+        XCTAssertEqual(emission?.deltaX ?? 0, 18, accuracy: 0.001)
+        XCTAssertGreaterThan(abs(emission?.deltaY ?? 0), 0)
+    }
+
+    func testEaseInStartsSlowerThanEaseOut() {
+        let easeInEngine = SmoothedScrollingEngine(smoothed: .init(
+            vertical: Scheme.Scrolling.Smoothed.Preset.easeIn.defaultConfiguration
+        ))
+        let easeOutEngine = SmoothedScrollingEngine(smoothed: .init(
+            vertical: Scheme.Scrolling.Smoothed.Preset.easeOut.defaultConfiguration
+        ))
+
+        easeInEngine.feed(deltaX: 0, deltaY: 36, timestamp: 0)
+        easeOutEngine.feed(deltaX: 0, deltaY: 36, timestamp: 0)
+
+        let easeInEmission = easeInEngine.advance(to: 1.0 / 120)
+        let easeOutEmission = easeOutEngine.advance(to: 1.0 / 120)
+
+        XCTAssertNotNil(easeInEmission)
+        XCTAssertNotNil(easeOutEmission)
+        XCTAssertLessThan(abs(easeInEmission?.deltaY ?? 0), abs(easeOutEmission?.deltaY ?? 0))
+    }
+
+    func testMomentumReengagementBlendsAdditionalInputWithoutSharpJump() throws {
+        let engine = SmoothedScrollingEngine(smoothed: .init(
+            vertical: Scheme.Scrolling.Smoothed.Preset.easeInOut.defaultConfiguration
+        ))
+
+        var latestMomentumEmission: SmoothedScrollingEngine.Emission?
+
+        for step in 0 ..< 6 {
+            let timestamp = Double(step) / 120
+            engine.feed(deltaX: 0, deltaY: 40, timestamp: timestamp)
+            _ = engine.advance(to: timestamp + 1.0 / 120)
+        }
+
+        for step in 6 ..< 24 {
+            let timestamp = Double(step + 1) / 120
+            if let emission = engine.advance(to: timestamp), emission.momentumPhase == .continuous {
+                latestMomentumEmission = emission
+            }
+        }
+
+        let baseline = try XCTUnwrap(latestMomentumEmission)
+        let reengagementTimestamp = 25.0 / 120.0
+        engine.feed(deltaX: 0, deltaY: 36, timestamp: reengagementTimestamp)
+        let reengagedEmission = try XCTUnwrap(engine.advance(to: reengagementTimestamp + 1.0 / 120.0))
+
+        XCTAssertEqual(reengagedEmission.scrollPhase, .began)
+        XCTAssertGreaterThan(abs(reengagedEmission.deltaY), abs(baseline.deltaY))
+        XCTAssertLessThan(abs(reengagedEmission.deltaY), abs(baseline.deltaY) * 2.6)
+    }
+
+    func testMomentumTailReengagementRecoversTowardFreshPickup() throws {
+        let configuration = Scheme.Scrolling.Smoothed.Preset.easeInOut.defaultConfiguration
+        let engine = SmoothedScrollingEngine(smoothed: .init(vertical: configuration))
+        let freshEngine = SmoothedScrollingEngine(smoothed: .init(vertical: configuration))
+
+        var tailEmission: SmoothedScrollingEngine.Emission?
+
+        for step in 0 ..< 6 {
+            let timestamp = Double(step) / 120
+            engine.feed(deltaX: 0, deltaY: 40, timestamp: timestamp)
+            _ = engine.advance(to: timestamp + 1.0 / 120)
+        }
+
+        for step in 6 ..< 240 {
+            let timestamp = Double(step + 1) / 120
+            if let emission = engine.advance(to: timestamp),
+               emission.momentumPhase == .continuous,
+               abs(emission.deltaY) < 0.25 {
+                tailEmission = emission
+                break
+            }
+        }
+
+        let baselineTail = try XCTUnwrap(tailEmission)
+
+        freshEngine.feed(deltaX: 0, deltaY: 36, timestamp: 0)
+        let freshPickup = try XCTUnwrap(freshEngine.advance(to: 1.0 / 120))
+
+        let reengagementTimestamp = 2.0
+        engine.feed(deltaX: 0, deltaY: 36, timestamp: reengagementTimestamp)
+        let reengagedEmission = try XCTUnwrap(engine.advance(to: reengagementTimestamp + 1.0 / 120.0))
+
+        XCTAssertEqual(reengagedEmission.scrollPhase, .began)
+        XCTAssertGreaterThan(abs(reengagedEmission.deltaY), abs(baselineTail.deltaY) * 3)
+        XCTAssertGreaterThan(abs(reengagedEmission.deltaY), abs(freshPickup.deltaY) * 0.7)
+    }
+}

--- a/LinearMouseUnitTests/EventTransformer/SmoothedScrollingTransformerTests.swift
+++ b/LinearMouseUnitTests/EventTransformer/SmoothedScrollingTransformerTests.swift
@@ -1,0 +1,120 @@
+// MIT License
+// Copyright (c) 2021-2026 LinearMouse
+
+@testable import LinearMouse
+import XCTest
+
+final class SmoothedScrollingTransformerTests: XCTestCase {
+    func testSmoothedScrollingPreservesUnsmoothedAxisAndEmitsSyntheticEvent() throws {
+        var emittedEvents: [CGEvent] = []
+        var now = 0.0
+        let transformer = SmoothedScrollingTransformer(
+            smoothed: .init(
+                vertical: .init(
+                    enabled: true,
+                    preset: .natural,
+                    response: Decimal(string: "0.45"),
+                    speed: 1,
+                    acceleration: Decimal(string: "1.2"),
+                    inertia: Decimal(string: "0.65")
+                )
+            ),
+            now: { now },
+            eventSink: { emittedEvents.append($0.copy() ?? $0) }
+        )
+
+        let originalEvent = try XCTUnwrap(CGEvent(
+            scrollWheelEvent2Source: nil,
+            units: .line,
+            wheelCount: 2,
+            wheel1: 2,
+            wheel2: 3,
+            wheel3: 0
+        ))
+        originalEvent.flags = [.maskAlternate]
+
+        let passthroughEvent = try XCTUnwrap(transformer.transform(originalEvent))
+        let passthroughView = ScrollWheelEventView(passthroughEvent)
+        XCTAssertEqual(passthroughView.deltaX, 3)
+        XCTAssertEqual(passthroughView.deltaY, 0)
+
+        now = 1.0 / 120.0
+        transformer.tick()
+
+        let emittedEvent = try XCTUnwrap(emittedEvents.first)
+        let emittedView = ScrollWheelEventView(emittedEvent)
+        XCTAssertTrue(emittedEvent.isLinearMouseSyntheticEvent)
+        XCTAssertEqual(emittedView.deltaX, 0)
+        XCTAssertEqual(emittedView.scrollPhase, .began)
+        XCTAssertEqual(emittedView.momentumPhase, .none)
+        XCTAssertGreaterThan(abs(emittedView.deltaYPt), 0)
+        XCTAssertEqual(emittedEvent.flags, [.maskAlternate])
+    }
+
+    func testDiscreteWheelInputUsesLineDeltaForStartupEvenWhenPointDeltaExists() throws {
+        var emittedEvents: [CGEvent] = []
+        var now = 0.0
+        let transformer = SmoothedScrollingTransformer(
+            smoothed: .init(
+                vertical: Scheme.Scrolling.Smoothed.Preset.spring.defaultConfiguration
+            ),
+            now: { now },
+            eventSink: { emittedEvents.append($0.copy() ?? $0) }
+        )
+
+        let originalEvent = try XCTUnwrap(CGEvent(
+            scrollWheelEvent2Source: nil,
+            units: .line,
+            wheelCount: 2,
+            wheel1: 1,
+            wheel2: 0,
+            wheel3: 0
+        ))
+        let originalView = ScrollWheelEventView(originalEvent)
+        originalView.deltaYPt = 1
+        originalView.deltaYFixedPt = 0.1
+        XCTAssertFalse(originalView.continuous)
+
+        XCTAssertNil(transformer.transform(originalEvent))
+
+        now = 1.0 / 120.0
+        transformer.tick()
+
+        let emittedEvent = try XCTUnwrap(emittedEvents.first)
+        let emittedView = ScrollWheelEventView(emittedEvent)
+        XCTAssertGreaterThan(abs(emittedView.deltaYPt), 3)
+        XCTAssertEqual(emittedView.scrollPhase, .began)
+    }
+
+    func testContinuousTrackpadInputWithNativePhaseIsSmoothedInPlace() throws {
+        var now = 0.0
+        let transformer = SmoothedScrollingTransformer(
+            smoothed: .init(
+                vertical: Scheme.Scrolling.Smoothed.Preset.easeInOut.defaultConfiguration
+            )
+        ) {
+            now
+        }
+
+        let originalEvent = try XCTUnwrap(CGEvent(
+            scrollWheelEvent2Source: nil,
+            units: .pixel,
+            wheelCount: 2,
+            wheel1: 0,
+            wheel2: 0,
+            wheel3: 0
+        ))
+        let originalView = ScrollWheelEventView(originalEvent)
+        originalView.continuous = true
+        originalView.deltaYPt = 9
+        originalView.deltaYFixedPt = 9
+        originalView.scrollPhase = .began
+
+        let transformedEvent = try XCTUnwrap(transformer.transform(originalEvent))
+        let transformedView = ScrollWheelEventView(transformedEvent)
+        XCTAssertEqual(transformedView.deltaYPt, 1, accuracy: 0.001)
+        XCTAssertGreaterThan(transformedView.deltaYFixedPt, 0)
+        XCTAssertLessThan(transformedView.deltaYFixedPt, 9)
+        XCTAssertEqual(transformedView.scrollPhase, .began)
+    }
+}

--- a/LinearMouseUnitTests/Model/ConfigurationTests.swift
+++ b/LinearMouseUnitTests/Model/ConfigurationTests.swift
@@ -90,4 +90,37 @@ final class ConfigurationTests: XCTestCase {
         XCTAssertEqual(autoScroll.modes, [.toggle, .hold])
         XCTAssertEqual(autoScroll.normalizedModes, [.toggle, .hold])
     }
+
+    func testMergeSmoothedScrollingPreservesInheritedFields() {
+        var scheme = Scheme(
+            scrolling: .init(
+                smoothed: .init(
+                    vertical: .init(
+                        preset: .natural,
+                        response: Decimal(string: "0.45"),
+                        speed: 1,
+                        acceleration: Decimal(string: "1.2"),
+                        inertia: Decimal(string: "0.65")
+                    )
+                )
+            )
+        )
+
+        Scheme(
+            scrolling: .init(
+                smoothed: .init(
+                    vertical: .init(
+                        preset: .snappy,
+                        inertia: 8
+                    )
+                )
+            )
+        ).merge(into: &scheme)
+
+        XCTAssertEqual(scheme.scrolling.smoothed.vertical?.preset, .snappy)
+        XCTAssertEqual(scheme.scrolling.smoothed.vertical?.response, Decimal(string: "0.45"))
+        XCTAssertEqual(scheme.scrolling.smoothed.vertical?.speed, 1)
+        XCTAssertEqual(scheme.scrolling.smoothed.vertical?.acceleration, Decimal(string: "1.2"))
+        XCTAssertEqual(scheme.scrolling.smoothed.vertical?.inertia, 8)
+    }
 }


### PR DESCRIPTION
## Summary

This PR adds a new `Smoothed` scrolling mode for pointer devices, with configurable curve presets, custom tuning controls, and synthetic momentum events that better approximate inertial scrolling.

It also refines the scrolling settings UI so preset selection and custom tuning are clearer and more compact.

## What Changed

- add a new `Smoothed` scrolling mode to scrolling configuration
- add preset curves including `Ease In`, `Ease Out`, `Ease In Out`, `Linear`, `Quadratic`, `Cubic`, `Quartic`, `Smooth`, and `Custom`
- add custom tuning controls for `response`, `speed`, `acceleration`, and `inertia`
- add a smoothed scrolling engine and transformer that emit synthetic pixel-based scroll events with scroll and momentum phases
- preserve compatibility with existing scrolling modifiers and synthetic-event handling
- refine momentum re-engagement so additional wheel input during momentum is blended more smoothly instead of causing a hard jump
- improve the settings UI for preset selection, custom tuning, and preset-to-custom transitions
- update configuration docs, schema, and tests for the new mode

## Trackpad Support

Trackpad support is still a work in progress.

The current branch keeps native trackpad scrolling settings working correctly, and includes partial groundwork for smoothed handling of continuous input, but full trackpad-specific smoothing behavior is not finalized yet.

## Related issues

- #44
- #576
- #641
- #718
- #730
- #745
- #1042
- #1049
- #1085

## Testing

- `xcodebuild test -scheme LinearMouse -destination 'platform=macOS'`

Passed locally with 58 tests.
