### PR TITLE
Fix app-specific autoscroll disable override

### DIFF
--- a/LinearMouse/UI/ButtonsSettings/ButtonsSettingsState.swift
+++ b/LinearMouse/UI/ButtonsSettings/ButtonsSettingsState.swift
@@ -136,7 +136,7 @@ extension ButtonsSettingsState {
                     scheme.buttons.autoScroll.preserveNativeMiddleClick = true
                 }
             } else {
-                scheme.buttons.$autoScroll = nil
+                scheme.buttons.autoScroll.enabled = false
             }
 
             GlobalEventTap.shared.stop()

--- a/LinearMouseUnitTests/Model/ConfigurationTests.swift
+++ b/LinearMouseUnitTests/Model/ConfigurationTests.swift
@@ -71,6 +71,19 @@ final class ConfigurationTests: XCTestCase {
         XCTAssertEqual(scheme.buttons.autoScroll.trigger?.modifierFlags.contains(.maskCommand), true)
     }
 
+    func testMergeAutoScrollAllowsDisablingInheritedSetting() {
+        var scheme = Scheme()
+        scheme.buttons.autoScroll.enabled = true
+        scheme.buttons.autoScroll.modes = [.toggle]
+
+        var override = Scheme()
+        override.buttons.autoScroll.enabled = false
+        override.merge(into: &scheme)
+
+        XCTAssertEqual(scheme.buttons.autoScroll.enabled, false)
+        XCTAssertEqual(scheme.buttons.autoScroll.modes, [.toggle])
+    }
+
     func testDecodeAutoScrollSingleMode() throws {
         let autoScroll = try JSONDecoder().decode(
             Scheme.Buttons.AutoScroll.self,


### PR DESCRIPTION
## Summary
- write `buttons.autoScroll.enabled = false` when autoscroll is turned off in an app-specific scheme instead of removing the override
- preserve inherited autoscroll settings while still allowing per-app disable behavior
- add a regression test covering the inherited-enabled plus override-disabled case

## Testing
- xcodebuild test -project LinearMouse.xcodeproj -scheme LinearMouse -only-testing:LinearMouseUnitTests/ConfigurationTests

## Reference
- https://github.com/linearmouse/linearmouse/issues/610#issuecomment-4099344824