### PR TITLE
Refine autoscroll pressable AX role detection

### DIFF
--- a/LinearMouse/EventTransformer/AutoScrollTransformer.swift
+++ b/LinearMouse/EventTransformer/AutoScrollTransformer.swift
@@ -35,6 +35,17 @@ final class AutoScrollTransformer {
         "AXWebArea",
         "AXScrollArea"
     ]
+    private static let pressableAccessibilityRoles: Set<String> = [
+        "AXLink",
+        "AXButton",
+        "AXCheckBox",
+        "AXRadioButton",
+        "AXPopUpButton",
+        "AXMenuButton",
+        "AXComboBox",
+        "AXDisclosureTriangle",
+        "AXSwitch"
+    ]
 
     private let trigger: Scheme.Buttons.Mapping
     private let modes: [Scheme.Buttons.AutoScroll.Mode]
@@ -524,7 +535,7 @@ extension AutoScrollTransformer: EventTransformer {
                 return .excludedChrome(path: path)
             }
 
-            if role == "AXLink" || actions.contains(kAXPressAction as String) {
+            if Self.isPressableActivationElement(role: role, actions: actions) {
                 return .pressable(path: path)
             }
 
@@ -549,6 +560,19 @@ extension AutoScrollTransformer: EventTransformer {
         }
 
         return false
+    }
+
+    static func isPressableActivationElement(role: String?, actions: [String]) -> Bool {
+        guard let role,
+              pressableAccessibilityRoles.contains(role) else {
+            return false
+        }
+
+        if role == "AXLink" {
+            return true
+        }
+
+        return actions.contains(kAXPressAction as String)
     }
 
     private func requiredStringValue(

--- a/LinearMouseUnitTests/EventTransformer/AutoScrollTransformerTests.swift
+++ b/LinearMouseUnitTests/EventTransformer/AutoScrollTransformerTests.swift
@@ -1,0 +1,39 @@
+// MIT License
+// Copyright (c) 2021-2026 LinearMouse
+
+import ApplicationServices
+@testable import LinearMouse
+import XCTest
+
+final class AutoScrollTransformerTests: XCTestCase {
+    func testPressableActivationElementAcceptsExplicitControls() {
+        XCTAssertTrue(AutoScrollTransformer.isPressableActivationElement(role: "AXLink", actions: []))
+        XCTAssertTrue(AutoScrollTransformer.isPressableActivationElement(
+            role: "AXButton",
+            actions: [kAXPressAction as String]
+        ))
+        XCTAssertTrue(AutoScrollTransformer.isPressableActivationElement(
+            role: "AXCheckBox",
+            actions: [kAXPressAction as String]
+        ))
+        XCTAssertTrue(AutoScrollTransformer.isPressableActivationElement(
+            role: "AXComboBox",
+            actions: [kAXPressAction as String]
+        ))
+    }
+
+    func testPressableActivationElementRejectsGenericGroupEvenWithPressAction() {
+        XCTAssertFalse(AutoScrollTransformer.isPressableActivationElement(
+            role: "AXGroup",
+            actions: [kAXPressAction as String]
+        ))
+    }
+
+    func testPressableActivationElementRejectsControlWithoutPressActionWhenNeeded() {
+        XCTAssertFalse(AutoScrollTransformer.isPressableActivationElement(role: "AXButton", actions: []))
+        XCTAssertFalse(AutoScrollTransformer.isPressableActivationElement(
+            role: nil,
+            actions: [kAXPressAction as String]
+        ))
+    }
+}


### PR DESCRIPTION
## Summary
- restrict preserved middle-click pressable detection to explicit accessibility control roles instead of treating any `AXPress`-capable element as pressable
- allow generic containers such as `AXGroup[press]` to continue into autoscroll while still preserving native behavior for links, buttons, and form controls
- add regression coverage for the new AX role whitelist behavior

## Testing
- xcodebuild test -project LinearMouse.xcodeproj -scheme LinearMouse -only-testing:LinearMouseUnitTests/AutoScrollTransformerTests -only-testing:LinearMouseUnitTests/ConfigurationTests