### PR TITLE
Fix scrolling modifiers with smoothed scrolling

### DIFF
--- a/LinearMouse/EventTransformer/EventTransformerManager.swift
+++ b/LinearMouse/EventTransformer/EventTransformerManager.swift
@@ -129,8 +129,14 @@ class EventTransformerManager {
             horizontal: scheme.scrolling.smoothed.horizontal?.isEnabled == true ? scheme.scrolling.smoothed
                 .horizontal : nil
         )
+        let hasSmoothedScrolling = smoothed.vertical != nil || smoothed.horizontal != nil
 
-        if smoothed.vertical != nil || smoothed.horizontal != nil {
+        if let modifiers = scheme.scrolling.$modifiers,
+           hasSmoothedScrolling {
+            eventTransformer.append(ModifierActionsTransformer(modifiers: modifiers))
+        }
+
+        if hasSmoothedScrolling {
             eventTransformer.append(SmoothedScrollingTransformer(smoothed: smoothed))
         }
 
@@ -176,7 +182,8 @@ class EventTransformerManager {
             }
         }
 
-        if let modifiers = scheme.scrolling.$modifiers {
+        if let modifiers = scheme.scrolling.$modifiers,
+           !hasSmoothedScrolling {
             eventTransformer.append(ModifierActionsTransformer(modifiers: modifiers))
         }
 

--- a/LinearMouse/EventTransformer/SmoothedScrollingEngine.swift
+++ b/LinearMouse/EventTransformer/SmoothedScrollingEngine.swift
@@ -5,6 +5,11 @@ import CoreGraphics
 import Foundation
 
 final class SmoothedScrollingEngine {
+    enum Axis {
+        case horizontal
+        case vertical
+    }
+
     struct Emission {
         var deltaX: Double
         var deltaY: Double
@@ -156,6 +161,7 @@ final class SmoothedScrollingEngine {
 
     private let inputGrace: TimeInterval = 1.0 / 25.0
     private let stopThreshold = 0.5
+    private let axisActivityThreshold = 0.01
 
     init(smoothed: Scheme.Scrolling.Bidirectional<Scheme.Scrolling.Smoothed>) {
         horizontalBehavior = smoothed.horizontal.map { .smoothed(.init(configuration: $0)) } ?? .passthrough
@@ -168,6 +174,58 @@ final class SmoothedScrollingEngine {
             return pendingInputX != 0 || pendingInputY != 0
         case .touching, .momentum:
             return true
+        }
+    }
+
+    var exclusiveActiveAxis: Axis? {
+        let horizontalActive = axisIsActive(
+            pendingInput: pendingInputX,
+            desiredVelocity: desiredVelocityX,
+            velocity: velocityX
+        )
+        let verticalActive = axisIsActive(
+            pendingInput: pendingInputY,
+            desiredVelocity: desiredVelocityY,
+            velocity: velocityY
+        )
+
+        switch (horizontalActive, verticalActive) {
+        case (true, false):
+            return .horizontal
+        case (false, true):
+            return .vertical
+        default:
+            return nil
+        }
+    }
+
+    func resetOtherAxis(ifExclusiveIncomingAxis incomingAxis: Axis) {
+        guard let activeAxis = exclusiveActiveAxis,
+              activeAxis != incomingAxis else {
+            return
+        }
+
+        switch activeAxis {
+        case .horizontal:
+            pendingInputX = 0
+            desiredVelocityX = 0
+            velocityX = 0
+        case .vertical:
+            pendingInputY = 0
+            desiredVelocityY = 0
+            velocityY = 0
+        }
+
+        if abs(velocityX) <= stopThreshold,
+           abs(velocityY) <= stopThreshold,
+           pendingInputX == 0,
+           pendingInputY == 0 {
+            pendingMomentumBegin = false
+            reengagedFromMomentum = false
+            if sessionState == .momentum {
+                sessionState = .idle
+                touchHasBegun = false
+            }
         }
     }
 
@@ -324,5 +382,11 @@ final class SmoothedScrollingEngine {
 
             return velocity * dt
         }
+    }
+
+    private func axisIsActive(pendingInput: Double, desiredVelocity: Double, velocity: Double) -> Bool {
+        abs(pendingInput) >= axisActivityThreshold
+            || abs(desiredVelocity) >= axisActivityThreshold
+            || abs(velocity) >= axisActivityThreshold
     }
 }

--- a/LinearMouse/EventTransformer/SmoothedScrollingTransformer.swift
+++ b/LinearMouse/EventTransformer/SmoothedScrollingTransformer.swift
@@ -70,6 +70,9 @@ final class SmoothedScrollingTransformer: EventTransformer, Deactivatable {
 
         if handlesX || handlesY {
             lastFlags = event.flags
+            if handlesX != handlesY {
+                engine.resetOtherAxis(ifExclusiveIncomingAxis: handlesX ? .horizontal : .vertical)
+            }
             engine.feed(
                 deltaX: handlesX ? deltaX : 0,
                 deltaY: handlesY ? deltaY : 0,
@@ -132,6 +135,9 @@ final class SmoothedScrollingTransformer: EventTransformer, Deactivatable {
         lastFlags = event.flags
 
         if handlesX || handlesY {
+            if handlesX != handlesY {
+                engine.resetOtherAxis(ifExclusiveIncomingAxis: handlesX ? .horizontal : .vertical)
+            }
             engine.feed(
                 deltaX: handlesX ? deltaX : 0,
                 deltaY: handlesY ? deltaY : 0,

--- a/LinearMouseUnitTests/EventTransformer/SmoothedScrollingEngineTests.swift
+++ b/LinearMouseUnitTests/EventTransformer/SmoothedScrollingEngineTests.swift
@@ -157,4 +157,38 @@ final class SmoothedScrollingEngineTests: XCTestCase {
         XCTAssertGreaterThan(abs(reengagedEmission.deltaY), abs(baselineTail.deltaY) * 3)
         XCTAssertGreaterThan(abs(reengagedEmission.deltaY), abs(freshPickup.deltaY) * 0.7)
     }
+
+    func testExclusiveAxisSwitchResetsPreviousAxisMomentum() throws {
+        let configuration = Scheme.Scrolling.Smoothed.Preset.easeInOut.defaultConfiguration
+        let engine = SmoothedScrollingEngine(smoothed: .init(
+            vertical: configuration,
+            horizontal: configuration
+        ))
+
+        for step in 0 ..< 6 {
+            let timestamp = Double(step) / 120
+            engine.feed(deltaX: 0, deltaY: 40, timestamp: timestamp)
+            _ = engine.advance(to: timestamp + 1.0 / 120)
+        }
+
+        var verticalMomentumDetected = false
+        for step in 6 ..< 60 {
+            let timestamp = Double(step + 1) / 120
+            if let emission = engine.advance(to: timestamp), emission.momentumPhase == .continuous,
+               abs(emission.deltaY) > 0.01 {
+                verticalMomentumDetected = true
+                break
+            }
+        }
+        XCTAssertTrue(verticalMomentumDetected)
+
+        let switchTimestamp = 1.0
+        engine.resetOtherAxis(ifExclusiveIncomingAxis: .horizontal)
+        engine.feed(deltaX: 36, deltaY: 0, timestamp: switchTimestamp)
+        let switchedEmission = try XCTUnwrap(engine.advance(to: switchTimestamp + 1.0 / 120.0))
+
+        XCTAssertEqual(switchedEmission.scrollPhase, .began)
+        XCTAssertGreaterThan(abs(switchedEmission.deltaX), 0.01)
+        XCTAssertEqual(switchedEmission.deltaY, 0, accuracy: 0.001)
+    }
 }

--- a/LinearMouseUnitTests/EventTransformer/SmoothedScrollingTransformerTests.swift
+++ b/LinearMouseUnitTests/EventTransformer/SmoothedScrollingTransformerTests.swift
@@ -5,6 +5,158 @@
 import XCTest
 
 final class SmoothedScrollingTransformerTests: XCTestCase {
+    func testModifierAlterOrientationAppliesBeforeDiscreteSmoothedScrolling() throws {
+        var emittedEvents: [CGEvent] = []
+        var now = 0.0
+        let modifiers = Scheme.Scrolling.Modifiers(shift: .alterOrientation)
+        let smoothedTransformer = SmoothedScrollingTransformer(
+            smoothed: .init(vertical: Scheme.Scrolling.Smoothed.Preset.natural.defaultConfiguration),
+            now: { now },
+            eventSink: { emittedEvents.append($0.copy() ?? $0) }
+        )
+        let transformer: [EventTransformer] = [
+            ModifierActionsTransformer(modifiers: .init(vertical: modifiers, horizontal: modifiers)),
+            smoothedTransformer
+        ]
+
+        let originalEvent = try XCTUnwrap(CGEvent(
+            scrollWheelEvent2Source: nil,
+            units: .line,
+            wheelCount: 2,
+            wheel1: 1,
+            wheel2: 0,
+            wheel3: 0
+        ))
+        originalEvent.flags = [.maskShift]
+
+        let transformedEvent = try XCTUnwrap(transformer.transform(originalEvent))
+        let transformedView = ScrollWheelEventView(transformedEvent)
+        XCTAssertEqual(transformedView.deltaX, 1)
+        XCTAssertEqual(transformedView.deltaY, 0)
+        XCTAssertEqual(transformedEvent.flags, [])
+
+        now = 1.0 / 120.0
+        smoothedTransformer.tick()
+        XCTAssertTrue(emittedEvents.isEmpty)
+    }
+
+    func testModifierChangeSpeedAppliesBeforeDiscreteSmoothedScrolling() throws {
+        var baselineEmittedEvents: [CGEvent] = []
+        var scaledEmittedEvents: [CGEvent] = []
+        var now = 0.0
+        let modifiers = Scheme.Scrolling.Modifiers(option: .changeSpeed(scale: 2))
+
+        let baselineTransformer = SmoothedScrollingTransformer(
+            smoothed: .init(vertical: Scheme.Scrolling.Smoothed.Preset.spring.defaultConfiguration),
+            now: { now },
+            eventSink: { baselineEmittedEvents.append($0.copy() ?? $0) }
+        )
+        let scaledTransformer = SmoothedScrollingTransformer(
+            smoothed: .init(vertical: Scheme.Scrolling.Smoothed.Preset.spring.defaultConfiguration),
+            now: { now },
+            eventSink: { scaledEmittedEvents.append($0.copy() ?? $0) }
+        )
+
+        let baselineChain: [EventTransformer] = [
+            ModifierActionsTransformer(modifiers: .init(vertical: modifiers, horizontal: modifiers)),
+            baselineTransformer
+        ]
+        let scaledChain: [EventTransformer] = [
+            ModifierActionsTransformer(modifiers: .init(vertical: modifiers, horizontal: modifiers)),
+            scaledTransformer
+        ]
+
+        let baselineEvent = try XCTUnwrap(CGEvent(
+            scrollWheelEvent2Source: nil,
+            units: .line,
+            wheelCount: 2,
+            wheel1: 1,
+            wheel2: 0,
+            wheel3: 0
+        ))
+        let scaledEvent = try XCTUnwrap(CGEvent(
+            scrollWheelEvent2Source: nil,
+            units: .line,
+            wheelCount: 2,
+            wheel1: 1,
+            wheel2: 0,
+            wheel3: 0
+        ))
+        scaledEvent.flags = [.maskAlternate]
+
+        XCTAssertNil(baselineChain.transform(baselineEvent))
+        XCTAssertNil(scaledChain.transform(scaledEvent))
+
+        now = 1.0 / 120.0
+        baselineTransformer.tick()
+        scaledTransformer.tick()
+
+        let baselineView = try ScrollWheelEventView(XCTUnwrap(baselineEmittedEvents.first))
+        let scaledView = try ScrollWheelEventView(XCTUnwrap(scaledEmittedEvents.first))
+        XCTAssertGreaterThan(abs(scaledView.deltaYPt), abs(baselineView.deltaYPt))
+    }
+
+    func testShiftOrientationSwitchClearsPreviousAxisMomentum() throws {
+        var emittedEvents: [CGEvent] = []
+        var now = 0.0
+        let modifiers = Scheme.Scrolling.Modifiers(shift: .alterOrientation)
+        let smoothedTransformer = SmoothedScrollingTransformer(
+            smoothed: .init(
+                vertical: Scheme.Scrolling.Smoothed.Preset.easeInOut.defaultConfiguration,
+                horizontal: Scheme.Scrolling.Smoothed.Preset.easeInOut.defaultConfiguration
+            ),
+            now: { now },
+            eventSink: { emittedEvents.append($0.copy() ?? $0) }
+        )
+        let transformer: [EventTransformer] = [
+            ModifierActionsTransformer(modifiers: .init(vertical: modifiers, horizontal: modifiers)),
+            smoothedTransformer
+        ]
+
+        for step in 0 ..< 6 {
+            let event = try XCTUnwrap(CGEvent(
+                scrollWheelEvent2Source: nil,
+                units: .line,
+                wheelCount: 2,
+                wheel1: 1,
+                wheel2: 0,
+                wheel3: 0
+            ))
+            now = Double(step) / 120
+            XCTAssertNil(transformer.transform(event))
+            now += 1.0 / 120.0
+            smoothedTransformer.tick()
+        }
+
+        var sawVerticalMomentum = false
+        for _ in 0 ..< 30 {
+            now += 1.0 / 120.0
+            smoothedTransformer.tick()
+            if let view = emittedEvents.last.map(ScrollWheelEventView.init), abs(view.deltaYPt) > 0.01 {
+                sawVerticalMomentum = true
+            }
+        }
+        XCTAssertTrue(sawVerticalMomentum)
+
+        let shiftedEvent = try XCTUnwrap(CGEvent(
+            scrollWheelEvent2Source: nil,
+            units: .line,
+            wheelCount: 2,
+            wheel1: 1,
+            wheel2: 0,
+            wheel3: 0
+        ))
+        shiftedEvent.flags = [.maskShift]
+        XCTAssertNil(transformer.transform(shiftedEvent))
+
+        now += 1.0 / 120.0
+        smoothedTransformer.tick()
+
+        let switchedView = try ScrollWheelEventView(XCTUnwrap(emittedEvents.last))
+        XCTAssertGreaterThan(abs(switchedView.deltaXPt), 0.01)
+        XCTAssertEqual(switchedView.deltaYPt, 0, accuracy: 0.001)
+    }
+
     func testSmoothedScrollingPreservesUnsmoothedAxisAndEmitsSyntheticEvent() throws {
         var emittedEvents: [CGEvent] = []
         var now = 0.0


### PR DESCRIPTION
## Summary
- fix scrolling modifier actions so `alter orientation` and `change speed` still work when smoothed scrolling is enabled
- keep the smoothed scrolling state aligned with modifier-driven axis changes as part of that fix
- add regression coverage for modifier handling with smoothed scrolling

## Testing
- xcodebuild test -quiet -project LinearMouse.xcodeproj -scheme LinearMouse -only-testing:LinearMouseUnitTests/SmoothedScrollingEngineTests -only-testing:LinearMouseUnitTests/SmoothedScrollingTransformerTests -only-testing:LinearMouseUnitTests/EventTransformerManagerTests -only-testing:LinearMouseUnitTests/ModifierActionsTransformerTests