### PR TITLE
Add pointer speed limitation warning for Apple devices

### DIFF
--- a/LinearMouse/Device/Device.swift
+++ b/LinearMouse/Device/Device.swift
@@ -128,6 +128,11 @@ extension Device {
         case mouse, trackpad
     }
 
+    private static let appleVendorIDs = Set([0x004C, 0x05AC])
+    private static let appleMagicMouseProductIDs = Set([0x0269, 0x030D])
+    private static let appleMagicTrackpadProductIDs = Set([0x0265, 0x030E])
+    private static let appleBuiltInTrackpadProductIDs = Set([0x0273, 0x0276, 0x0278, 0x0340])
+
     private static func detectCategory(for device: PointerDevice) -> Category {
         if let vendorID = device.vendorID,
            let productID = device.productID,
@@ -143,8 +148,28 @@ extension Device {
     }
 
     private static func isAppleMagicMouse(vendorID: Int, productID: Int) -> Bool {
-        [0x004C, 0x05AC].contains(vendorID)
-            && [0x0269, 0x030D].contains(productID)
+        appleVendorIDs.contains(vendorID)
+            && appleMagicMouseProductIDs.contains(productID)
+    }
+
+    private static func isAppleMagicTrackpad(vendorID: Int, productID: Int) -> Bool {
+        appleVendorIDs.contains(vendorID)
+            && appleMagicTrackpadProductIDs.contains(productID)
+    }
+
+    private static func isAppleBuiltInTrackpad(vendorID: Int, productID: Int) -> Bool {
+        vendorID == 0x05AC
+            && appleBuiltInTrackpadProductIDs.contains(productID)
+    }
+
+    var showsPointerSpeedLimitationNotice: Bool {
+        guard let vendorID, let productID else {
+            return false
+        }
+
+        return Self.isAppleMagicMouse(vendorID: vendorID, productID: productID)
+            || Self.isAppleMagicTrackpad(vendorID: vendorID, productID: productID)
+            || Self.isAppleBuiltInTrackpad(vendorID: vendorID, productID: productID)
     }
 
     /**

--- a/LinearMouse/Localizable.xcstrings
+++ b/LinearMouse/Localizable.xcstrings
@@ -17152,6 +17152,9 @@
         }
       }
     },
+    "Due to system limitations, this device may not support adjusting Pointer Speed on newer versions of macOS." : {
+
+    },
     "Edit" : {
       "localizations" : {
         "af" : {
@@ -26109,6 +26112,9 @@
           }
         }
       }
+    },
+    "Learn more" : {
+
     },
     "Left button" : {
       "localizations" : {

--- a/LinearMouse/UI/PointerSettings/PointerSettings.swift
+++ b/LinearMouse/UI/PointerSettings/PointerSettings.swift
@@ -5,6 +5,7 @@ import SwiftUI
 
 struct PointerSettings: View {
     @ObservedObject var state = PointerSettingsState.shared
+    @State private var isPointerSpeedLimitationPopoverPresented = false
 
     var body: some View {
         DetailView {
@@ -58,7 +59,41 @@ struct PointerSettings: View {
                                 in: 0.0 ... 1.0
                             ) {
                                 labelWithDescription {
-                                    Text("Pointer speed")
+                                    HStack(spacing: 4) {
+                                        Text("Pointer speed")
+
+                                        if state.showsPointerSpeedLimitationNotice {
+                                            Button {
+                                                isPointerSpeedLimitationPopoverPresented.toggle()
+                                            } label: {
+                                                Text(verbatim: "⚠︎")
+                                                    .foregroundColor(.orange)
+                                            }
+                                            .buttonStyle(PlainButtonStyle())
+                                            .popover(
+                                                isPresented: $isPointerSpeedLimitationPopoverPresented,
+                                                arrowEdge: .top
+                                            ) {
+                                                VStack(alignment: .leading, spacing: 10) {
+                                                    Text(
+                                                        "Due to system limitations, this device may not support adjusting Pointer Speed on newer versions of macOS."
+                                                    )
+                                                    .fixedSize(horizontal: false, vertical: true)
+
+                                                    HyperLink(
+                                                        URL(
+                                                            string: "https://go.linearmouse.app/pointer-speed-limitations"
+                                                        )!
+                                                    ) {
+                                                        Text("Learn more")
+                                                    }
+                                                }
+                                                .padding()
+                                                .frame(width: 280, alignment: .leading)
+                                            }
+                                        }
+                                    }
+
                                     Text("(0–1)")
                                 }
                             }

--- a/LinearMouse/UI/PointerSettings/PointerSettingsState.swift
+++ b/LinearMouse/UI/PointerSettings/PointerSettingsState.swift
@@ -88,6 +88,10 @@ extension PointerSettingsState {
         return formatter
     }
 
+    var showsPointerSpeedLimitationNotice: Bool {
+        mergedScheme.firstMatchedDevice?.showsPointerSpeedLimitationNotice ?? false
+    }
+
     func revertPointerSpeed() {
         let device = scheme.firstMatchedDevice
 


### PR DESCRIPTION
## Summary
- show a pointer speed warning icon in Pointer Settings for Apple devices that may not support pointer speed changes on newer macOS versions
- match Magic Mouse, Magic Trackpad, and built-in Apple trackpads by vendor and product IDs before showing the warning
- open a popover with the limitation message and a Learn more link to the support page

## Testing
- xcodebuild -project LinearMouse.xcodeproj -scheme LinearMouse -quiet