### PR TITLE
Fix menu bar battery indicator for active device

### DIFF
--- a/LinearMouse/UI/StatusItem.swift
+++ b/LinearMouse/UI/StatusItem.swift
@@ -164,11 +164,22 @@ class StatusItem: NSObject, NSMenuDelegate {
     }
 
     private func currentDeviceBatteryLevel() -> Int? {
-        guard let currentDevice = DeviceState.shared.currentDeviceRef?.value else {
+        guard let currentDevice = currentBatteryIndicatorDevice() else {
             return nil
         }
 
         return BatteryDeviceMonitor.shared.currentDeviceBatteryLevel(for: currentDevice)
+    }
+
+    private func currentBatteryIndicatorDevice() -> Device? {
+        Self.menuBarBatteryDevice(
+            activeDeviceRef: DeviceManager.shared.lastActiveDeviceRef,
+            selectedDeviceRef: DeviceState.shared.currentDeviceRef
+        )
+    }
+
+    static func menuBarBatteryDevice<T: AnyObject>(activeDeviceRef: WeakRef<T>?, selectedDeviceRef: WeakRef<T>?) -> T? {
+        activeDeviceRef?.value ?? selectedDeviceRef?.value
     }
 
     static func menuBarBatteryTitle(currentBatteryLevel: Int?, mode: MenuBarBatteryDisplayMode) -> String? {
@@ -282,6 +293,14 @@ class StatusItem: NSObject, NSMenuDelegate {
 
         DeviceState.shared
             .$currentDeviceRef
+            .receive(on: RunLoop.main)
+            .sink { [weak self] _ in
+                self?.updateStatusItemBatteryIndicator()
+            }
+            .store(in: &subscriptions)
+
+        DeviceManager.shared
+            .$lastActiveDeviceRef
             .receive(on: RunLoop.main)
             .sink { [weak self] _ in
                 self?.updateStatusItemBatteryIndicator()

--- a/LinearMouseUnitTests/UI/StatusItemBatteryIndicatorTests.swift
+++ b/LinearMouseUnitTests/UI/StatusItemBatteryIndicatorTests.swift
@@ -1,6 +1,7 @@
 // MIT License
 // Copyright (c) 2021-2026 LinearMouse
 
+import Foundation
 @testable import LinearMouse
 import XCTest
 
@@ -19,6 +20,29 @@ final class StatusItemBatteryIndicatorTests: XCTestCase {
 
     func testMenuBarBatteryTitleAlwaysShowMode() {
         XCTAssertEqual(StatusItem.menuBarBatteryTitle(currentBatteryLevel: 100, mode: .always), "100%")
+    }
+
+    func testMenuBarBatteryDevicePrefersActiveDeviceOverSelectedDevice() {
+        let activeDevice = NSObject()
+        let selectedDevice = NSObject()
+
+        XCTAssertTrue(
+            StatusItem.menuBarBatteryDevice(
+                activeDeviceRef: WeakRef(activeDevice),
+                selectedDeviceRef: WeakRef(selectedDevice)
+            ) === activeDevice
+        )
+    }
+
+    func testMenuBarBatteryDeviceFallsBackToSelectedDevice() {
+        let selectedDevice = NSObject()
+
+        XCTAssertTrue(
+            StatusItem.menuBarBatteryDevice(
+                activeDeviceRef: nil,
+                selectedDeviceRef: WeakRef(selectedDevice)
+            ) === selectedDevice
+        )
     }
 
     func testCurrentDeviceBatteryLevelUsesLowestReceiverBattery() {


### PR DESCRIPTION
## Summary
- make the menu bar battery indicator prefer the last active device instead of the picker selection
- keep the status item refreshed when the active device changes even if auto-switch is disabled
- add unit coverage for the active-device preference and selected-device fallback

## Testing
- xcodebuild test -project LinearMouse.xcodeproj -scheme LinearMouse -only-testing:LinearMouseUnitTests/StatusItemBatteryIndicatorTests