### PR TITLE
Fix default scroll modifier action

### DIFF
--- a/LinearMouse/UI/ScrollingSettings/ModifierKeysSection/ModifierKeyActionPicker.swift
+++ b/LinearMouse/UI/ScrollingSettings/ModifierKeysSection/ModifierKeyActionPicker.swift
@@ -58,7 +58,7 @@ extension ScrollingSettings.ModifierKeysSection.ModifierKeyActionPicker {
         Binding<ActionType>(
             get: {
                 guard let action else {
-                    return .noAction
+                    return .defaultAction
                 }
 
                 switch action {

--- a/LinearMouseUnitTests/UI/ModifierKeyActionPickerTests.swift
+++ b/LinearMouseUnitTests/UI/ModifierKeyActionPickerTests.swift
@@ -1,0 +1,45 @@
+// MIT License
+// Copyright (c) 2021-2026 LinearMouse
+
+@testable import LinearMouse
+import SwiftUI
+import XCTest
+
+final class ModifierKeyActionPickerTests: XCTestCase {
+    func testNilActionDisplaysDefaultAction() {
+        let picker = makePicker(action: nil)
+
+        XCTAssertEqual(picker.actionType.wrappedValue, .defaultAction)
+    }
+
+    func testSelectingDefaultActionStoresAutoAction() {
+        var action: Scheme.Scrolling.Modifiers.Action?
+        let picker = makePicker(action: action) { action = $0 }
+
+        picker.actionType.wrappedValue = .defaultAction
+
+        XCTAssertEqual(action, .auto)
+    }
+
+    func testSelectingNoActionStoresPreventDefaultAction() {
+        var action: Scheme.Scrolling.Modifiers.Action?
+        let picker = makePicker(action: action) { action = $0 }
+
+        picker.actionType.wrappedValue = .noAction
+
+        XCTAssertEqual(action, .preventDefault)
+    }
+
+    private func makePicker(
+        action: Scheme.Scrolling.Modifiers.Action?,
+        setter: @escaping (Scheme.Scrolling.Modifiers.Action?) -> Void = { _ in }
+    ) -> ScrollingSettings.ModifierKeysSection.ModifierKeyActionPicker {
+        ScrollingSettings.ModifierKeysSection.ModifierKeyActionPicker(
+            label: "Test",
+            action: Binding(
+                get: { action },
+                set: setter
+            )
+        )
+    }
+}


### PR DESCRIPTION
## Summary
- show `Default action` for unset scroll modifier actions instead of `No action`
- keep explicit `No action` mapped to `preventDefault`, so blocking scroll still works as before
- add picker tests covering unset, default, and no-action mappings

## Testing
- xcodebuild test -project LinearMouse.xcodeproj -scheme LinearMouse -only-testing:LinearMouseUnitTests/ModifierKeyActionPickerTests -only-testing:LinearMouseUnitTests/ModifierActionsTransformerTests -only-testing:LinearMouseUnitTests/SmoothedScrollingTransformerTests