### PR TITLE
Fix mapped back/forward universal behavior

### DIFF
--- a/LinearMouse/EventTransformer/ButtonActionsTransformer.swift
+++ b/LinearMouse/EventTransformer/ButtonActionsTransformer.swift
@@ -12,6 +12,7 @@ class ButtonActionsTransformer {
     static let log = OSLog(subsystem: Bundle.main.bundleIdentifier!, category: "ButtonActions")
 
     let mappings: [Scheme.Buttons.Mapping]
+    let universalBackForward: Scheme.Buttons.UniversalBackForward?
 
     var repeatTimer: Timer?
     private var logitechRepeatTimer: Timer?
@@ -30,8 +31,12 @@ class ButtonActionsTransformer {
         let modifierFlags: CGEventFlags
     }
 
-    init(mappings: [Scheme.Buttons.Mapping]) {
+    init(
+        mappings: [Scheme.Buttons.Mapping],
+        universalBackForward: Scheme.Buttons.UniversalBackForward? = nil
+    ) {
         self.mappings = mappings
+        self.universalBackForward = universalBackForward
     }
 
     deinit {
@@ -200,6 +205,7 @@ extension ButtonActionsTransformer: EventTransformer {
         queueLogitechActions(
             event: nil,
             action: action,
+            targetBundleIdentifier: context.pid?.bundleIdentifier,
             keyRepeatEnabled: keyRepeatEnabled,
             keyRepeatDelay: keyRepeatDelay,
             keyRepeatInterval: keyRepeatInterval
@@ -230,14 +236,16 @@ extension ButtonActionsTransformer: EventTransformer {
     }
 
     private func queueActions(
-        event _: CGEvent?,
+        event: CGEvent?,
         action: Scheme.Buttons.Mapping.Action,
         keyRepeatEnabled: Bool = false,
         keyRepeatDelay: TimeInterval = 0,
         keyRepeatInterval: TimeInterval = 0
     ) {
+        let targetBundleIdentifier = event.flatMap { MouseEventView($0).targetPid?.bundleIdentifier }
+
         DispatchQueue.main.async { [self] in
-            executeIgnoreErrors(action: action)
+            executeIgnoreErrors(action: action, targetBundleIdentifier: targetBundleIdentifier)
 
             guard keyRepeatEnabled else {
                 return
@@ -251,7 +259,7 @@ extension ButtonActionsTransformer: EventTransformer {
                     return
                 }
 
-                self.executeIgnoreErrors(action: action)
+                self.executeIgnoreErrors(action: action, targetBundleIdentifier: targetBundleIdentifier)
 
                 self.repeatTimer = Timer.scheduledTimer(
                     withTimeInterval: keyRepeatInterval,
@@ -261,7 +269,7 @@ extension ButtonActionsTransformer: EventTransformer {
                         return
                     }
 
-                    self.executeIgnoreErrors(action: action)
+                    self.executeIgnoreErrors(action: action, targetBundleIdentifier: targetBundleIdentifier)
                 }
             }
         }
@@ -270,12 +278,13 @@ extension ButtonActionsTransformer: EventTransformer {
     private func queueLogitechActions(
         event _: CGEvent?,
         action: Scheme.Buttons.Mapping.Action,
+        targetBundleIdentifier: String?,
         keyRepeatEnabled: Bool = false,
         keyRepeatDelay: TimeInterval = 0,
         keyRepeatInterval: TimeInterval = 0
     ) {
         DispatchQueue.main.async { [self] in
-            executeIgnoreErrors(action: action)
+            executeIgnoreErrors(action: action, targetBundleIdentifier: targetBundleIdentifier)
 
             guard keyRepeatEnabled else {
                 return
@@ -289,7 +298,7 @@ extension ButtonActionsTransformer: EventTransformer {
                     return
                 }
 
-                self.executeIgnoreErrors(action: action)
+                self.executeIgnoreErrors(action: action, targetBundleIdentifier: targetBundleIdentifier)
 
                 self.logitechRepeatTimer = Timer.scheduledTimer(
                     withTimeInterval: keyRepeatInterval,
@@ -299,13 +308,16 @@ extension ButtonActionsTransformer: EventTransformer {
                         return
                     }
 
-                    self.executeIgnoreErrors(action: action)
+                    self.executeIgnoreErrors(action: action, targetBundleIdentifier: targetBundleIdentifier)
                 }
             }
         }
     }
 
-    private func executeIgnoreErrors(action: Scheme.Buttons.Mapping.Action) {
+    private func executeIgnoreErrors(
+        action: Scheme.Buttons.Mapping.Action,
+        targetBundleIdentifier: String?
+    ) {
         do {
             os_log(
                 "Execute action: %{public}@",
@@ -314,7 +326,7 @@ extension ButtonActionsTransformer: EventTransformer {
                 String(describing: action)
             )
 
-            try execute(action: action)
+            try execute(action: action, targetBundleIdentifier: targetBundleIdentifier)
         } catch {
             os_log(
                 "Failed to execute: %{public}@: %{public}@",
@@ -327,7 +339,10 @@ extension ButtonActionsTransformer: EventTransformer {
     }
 
     // swiftlint:disable:next cyclomatic_complexity
-    private func execute(action: Scheme.Buttons.Mapping.Action) throws {
+    private func execute(
+        action: Scheme.Buttons.Mapping.Action,
+        targetBundleIdentifier: String?
+    ) throws {
         switch action {
         case .arg0(.none), .arg0(.auto):
             return
@@ -418,10 +433,10 @@ extension ButtonActionsTransformer: EventTransformer {
             postClickEvent(mouseButton: .right)
 
         case .arg0(.mouseButtonBack):
-            postClickEvent(mouseButton: .back)
+            postMouseButtonAction(mouseButton: .back, targetBundleIdentifier: targetBundleIdentifier)
 
         case .arg0(.mouseButtonForward):
-            postClickEvent(mouseButton: .forward)
+            postMouseButtonAction(mouseButton: .forward, targetBundleIdentifier: targetBundleIdentifier)
 
         case let .arg1(.run(command)):
             let task = Process()
@@ -445,6 +460,21 @@ extension ButtonActionsTransformer: EventTransformer {
             try keySimulator.press(keys: keys, tap: .cgSessionEventTap)
             keySimulator.reset()
         }
+    }
+
+    private func postMouseButtonAction(
+        mouseButton: CGMouseButton,
+        targetBundleIdentifier: String?
+    ) {
+        guard !UniversalBackForwardTransformer.postNavigationSwipeIfNeeded(
+            for: mouseButton,
+            universalBackForward: universalBackForward,
+            targetBundleIdentifier: targetBundleIdentifier
+        ) else {
+            return
+        }
+
+        postClickEvent(mouseButton: mouseButton)
     }
 
     private func postScrollEvent(horizontal: Int32, vertical: Int32) {

--- a/LinearMouse/EventTransformer/EventTransformerManager.swift
+++ b/LinearMouse/EventTransformer/EventTransformerManager.swift
@@ -225,7 +225,10 @@ class EventTransformerManager {
         }
 
         if let mappings = scheme.buttons.mappings {
-            eventTransformer.append(ButtonActionsTransformer(mappings: mappings))
+            eventTransformer.append(ButtonActionsTransformer(
+                mappings: mappings,
+                universalBackForward: scheme.buttons.universalBackForward
+            ))
         }
 
         if let universalBackForward = scheme.buttons.universalBackForward,

--- a/LinearMouse/EventTransformer/UniversalBackForwardTransformer.swift
+++ b/LinearMouse/EventTransformer/UniversalBackForwardTransformer.swift
@@ -15,31 +15,46 @@ class UniversalBackForwardTransformer: EventTransformer {
         "com.operasoftware.Opera"
     ]
 
-    private let interestedButtons: Set<CGMouseButton>
+    enum Replacement: Equatable {
+        case mouseButton(CGMouseButton)
+        case navigationSwipe(NavigationSwipeDirection)
+    }
 
-    init(universalBackForward: Scheme.Buttons.UniversalBackForward) {
-        switch universalBackForward {
-        case .none:
-            interestedButtons = []
-        case .both:
-            interestedButtons = [.back, .forward]
-        case .backOnly:
-            interestedButtons = [.back]
-        case .forwardOnly:
-            interestedButtons = [.forward]
+    enum NavigationSwipeDirection: Equatable {
+        case left
+        case right
+
+        var hidDirection: IOHIDSwipeMask {
+            switch self {
+            case .left:
+                return .swipeLeft
+            case .right:
+                return .swipeRight
+            }
         }
     }
 
-    private func shouldHandleEvent(_ view: MouseEventView) -> Bool {
-        guard let mouseButton = view.mouseButton else {
-            return false
-        }
+    private let universalBackForward: Scheme.Buttons.UniversalBackForward
 
-        guard interestedButtons.contains(mouseButton) else {
-            return false
-        }
+    init(universalBackForward: Scheme.Buttons.UniversalBackForward) {
+        self.universalBackForward = universalBackForward
+    }
 
-        guard let bundleIdentifier = view.targetPid?.bundleIdentifier else {
+    static func interestedButtons(for universalBackForward: Scheme.Buttons.UniversalBackForward) -> Set<CGMouseButton> {
+        switch universalBackForward {
+        case .none:
+            return []
+        case .both:
+            return [.back, .forward]
+        case .backOnly:
+            return [.back]
+        case .forwardOnly:
+            return [.forward]
+        }
+    }
+
+    static func supportsTargetBundleIdentifier(_ bundleIdentifier: String?) -> Bool {
+        guard let bundleIdentifier else {
             return false
         }
 
@@ -51,11 +66,65 @@ class UniversalBackForwardTransformer: EventTransformer {
         }
     }
 
+    static func replacement(
+        for mouseButton: CGMouseButton,
+        universalBackForward: Scheme.Buttons.UniversalBackForward?,
+        targetBundleIdentifier: String?
+    ) -> Replacement {
+        guard let universalBackForward,
+              interestedButtons(for: universalBackForward).contains(mouseButton),
+              supportsTargetBundleIdentifier(targetBundleIdentifier) else {
+            return .mouseButton(mouseButton)
+        }
+
+        switch mouseButton {
+        case .back:
+            return .navigationSwipe(.left)
+        case .forward:
+            return .navigationSwipe(.right)
+        default:
+            return .mouseButton(mouseButton)
+        }
+    }
+
+    @discardableResult
+    static func postNavigationSwipeIfNeeded(
+        for mouseButton: CGMouseButton,
+        universalBackForward: Scheme.Buttons.UniversalBackForward?,
+        targetBundleIdentifier: String?
+    ) -> Bool {
+        guard case let .navigationSwipe(direction) = replacement(
+            for: mouseButton,
+            universalBackForward: universalBackForward,
+            targetBundleIdentifier: targetBundleIdentifier
+        ) else {
+            return false
+        }
+
+        guard let event = GestureEvent(
+            navigationSwipeSource: nil,
+            direction: direction.hidDirection
+        ) else {
+            return false
+        }
+
+        event.post(tap: .cgSessionEventTap)
+        return true
+    }
+
     func transform(_ event: CGEvent) -> CGEvent? {
         let view = MouseEventView(event)
+        guard let mouseButton = view.mouseButton else {
+            return event
+        }
 
-        let targetBundleIdentifierString = view.targetPid?.bundleIdentifier ?? "(nil)"
-        guard shouldHandleEvent(view) else {
+        let targetBundleIdentifier = view.targetPid?.bundleIdentifier
+        let targetBundleIdentifierString = targetBundleIdentifier ?? "(nil)"
+        guard case let .navigationSwipe(direction) = Self.replacement(
+            for: mouseButton,
+            universalBackForward: universalBackForward,
+            targetBundleIdentifier: targetBundleIdentifier
+        ) else {
             return event
         }
 
@@ -71,18 +140,8 @@ class UniversalBackForwardTransformer: EventTransformer {
         }
 
         os_log("Convert to swipe: %{public}@", log: Self.log, type: .info, targetBundleIdentifierString)
-        switch view.mouseButton {
-        case CGMouseButton.back:
-            if let event = GestureEvent(navigationSwipeSource: nil, direction: .swipeLeft) {
-                event.post(tap: .cgSessionEventTap)
-            }
-        case CGMouseButton.forward:
-            if let event = GestureEvent(navigationSwipeSource: nil, direction: .swipeRight) {
-                event.post(tap: .cgSessionEventTap)
-            }
-        default:
-            break
-        }
+        GestureEvent(navigationSwipeSource: nil, direction: direction.hidDirection)?
+            .post(tap: .cgSessionEventTap)
         return nil
     }
 }

--- a/LinearMouseUnitTests/EventTransformer/EventTransformerManagerTests.swift
+++ b/LinearMouseUnitTests/EventTransformer/EventTransformerManagerTests.swift
@@ -128,4 +128,35 @@ final class EventTransformerManagerTests: XCTestCase {
         XCTAssertGreaterThan(transformedView.deltaYFixedPt, -12)
         XCTAssertEqual(transformedView.scrollPhase, .began)
     }
+
+    func testButtonActionTransformerReceivesUniversalBackForwardSetting() throws {
+        ConfigurationState.shared.configuration = .init(schemes: [
+            Scheme(buttons: .init(
+                mappings: [.init(scroll: .left, action: .arg0(.mouseButtonBack))],
+                universalBackForward: .both
+            ))
+        ])
+
+        let event = try XCTUnwrap(CGEvent(
+            scrollWheelEvent2Source: nil,
+            units: .line,
+            wheelCount: 2,
+            wheel1: 0,
+            wheel2: 1,
+            wheel3: 0
+        ))
+
+        let transformer = EventTransformerManager.shared.get(
+            withCGEvent: event,
+            withSourcePid: nil,
+            withTargetPid: nil,
+            withMouseLocationPid: nil,
+            withDisplay: nil
+        )
+        let buttonActionsTransformer = try XCTUnwrap((transformer as? [EventTransformer])?
+            .compactMap { $0 as? ButtonActionsTransformer }
+            .first)
+
+        XCTAssertEqual(buttonActionsTransformer.universalBackForward, .both)
+    }
 }

--- a/LinearMouseUnitTests/EventTransformer/UniversalBackForwardTransformerTests.swift
+++ b/LinearMouseUnitTests/EventTransformer/UniversalBackForwardTransformerTests.swift
@@ -1,0 +1,62 @@
+// MIT License
+// Copyright (c) 2021-2026 LinearMouse
+
+@testable import LinearMouse
+import XCTest
+
+final class UniversalBackForwardTransformerTests: XCTestCase {
+    func testReplacementUsesSwipeForBackInSupportedApp() {
+        XCTAssertEqual(
+            UniversalBackForwardTransformer.replacement(
+                for: .back,
+                universalBackForward: .both,
+                targetBundleIdentifier: "com.apple.Safari"
+            ),
+            .navigationSwipe(.left)
+        )
+    }
+
+    func testReplacementUsesSwipeForForwardInSupportedApp() {
+        XCTAssertEqual(
+            UniversalBackForwardTransformer.replacement(
+                for: .forward,
+                universalBackForward: .both,
+                targetBundleIdentifier: "com.binarynights.ForkLift"
+            ),
+            .navigationSwipe(.right)
+        )
+    }
+
+    func testReplacementFallsBackToMouseButtonWhenUniversalBackForwardDisabled() {
+        XCTAssertEqual(
+            UniversalBackForwardTransformer.replacement(
+                for: .back,
+                universalBackForward: .none,
+                targetBundleIdentifier: "com.apple.Safari"
+            ),
+            .mouseButton(.back)
+        )
+    }
+
+    func testReplacementFallsBackToMouseButtonWhenDirectionIsNotEnabled() {
+        XCTAssertEqual(
+            UniversalBackForwardTransformer.replacement(
+                for: .forward,
+                universalBackForward: .backOnly,
+                targetBundleIdentifier: "com.apple.Safari"
+            ),
+            .mouseButton(.forward)
+        )
+    }
+
+    func testReplacementFallsBackToMouseButtonInUnsupportedApp() {
+        XCTAssertEqual(
+            UniversalBackForwardTransformer.replacement(
+                for: .back,
+                universalBackForward: .both,
+                targetBundleIdentifier: "com.example.CustomBrowser"
+            ),
+            .mouseButton(.back)
+        )
+    }
+}


### PR DESCRIPTION
## Summary
- reuse the universal back/forward decision logic for mapped Back and Forward actions
- apply the same behavior to scroll-triggered and Logitech-triggered button actions
- add regression tests for the shared decision logic and manager wiring

## Testing
- xcodebuild test -project LinearMouse.xcodeproj -scheme LinearMouse -only-testing:LinearMouseUnitTests/UniversalBackForwardTransformerTests -only-testing:LinearMouseUnitTests/EventTransformerManagerTests -only-testing:LinearMouseUnitTests/ButtonActionsTransformerTests

Closes #1083