### PR TITLE
Make Logitech receiver monitoring event-driven and fix UInt32 crash

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -61,7 +61,7 @@ jobs:
           NOTARIZATION_PASSWORD: ${{ secrets.NOTARIZATION_PASSWORD }}
         run: make prepublish
       - name: Prepare dSYM archive
-        if: github.event_name != 'pull_request'
+        if: startsWith(github.ref, 'refs/tags/')
         run: cd build/LinearMouse.xcarchive/dSYMs && zip -r "$GITHUB_WORKSPACE/build/LinearMouse.dSYM.zip" LinearMouse.app.dSYM
       - name: Upload dmg
         if: github.event_name != 'pull_request'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -60,6 +60,9 @@ jobs:
         env:
           NOTARIZATION_PASSWORD: ${{ secrets.NOTARIZATION_PASSWORD }}
         run: make prepublish
+      - name: Prepare dSYM archive
+        if: github.event_name != 'pull_request'
+        run: cd build/LinearMouse.xcarchive/dSYMs && zip -r "$GITHUB_WORKSPACE/build/LinearMouse.dSYM.zip" LinearMouse.app.dSYM
       - name: Upload dmg
         if: github.event_name != 'pull_request'
         uses: actions/upload-artifact@v4
@@ -73,6 +76,8 @@ jobs:
         with:
           draft: true
           prerelease: ${{ contains(github.ref, '-') }}
-          files: build/LinearMouse.dmg
+          files: |
+            build/LinearMouse.dmg
+            build/LinearMouse.dSYM.zip
           fail_on_unmatched_files: true
           generate_release_notes: true

--- a/LinearMouse/Device/DeviceManager.swift
+++ b/LinearMouse/Device/DeviceManager.swift
@@ -176,10 +176,10 @@ class DeviceManager: ObservableObject {
 
             if hasRemainingReceiverAtLocation {
                 os_log(
-                    "Keep receiver monitor running because another receiver device shares locationID=%{public}u",
+                    "Keep receiver monitor running because another receiver device shares locationID=%{public}d",
                     log: Self.log,
                     type: .info,
-                    UInt32(locationID)
+                    locationID
                 )
             } else {
                 receiverMonitor.stopMonitoring(device: device)
@@ -371,10 +371,10 @@ class DeviceManager: ObservableObject {
 
         let identities = receiverPairedDeviceIdentities[locationID] ?? []
         os_log(
-            "Receiver paired device lookup: locationID=%{public}u device=%{public}@ count=%{public}u",
+            "Receiver paired device lookup: locationID=%{public}d device=%{public}@ count=%{public}u",
             log: Self.log,
             type: .info,
-            UInt32(locationID),
+            locationID,
             String(describing: device),
             UInt32(identities.count)
         )
@@ -407,10 +407,10 @@ class DeviceManager: ObservableObject {
     private func receiverPointingDevicesChanged(locationID: Int, identities: [ReceiverLogicalDeviceIdentity]) {
         guard pointerDeviceToDevice.values.contains(where: { $0.pointerDevice.locationID == locationID }) else {
             os_log(
-                "Drop receiver logical device update because no visible device matches locationID=%{public}u count=%{public}u",
+                "Drop receiver logical device update because no visible device matches locationID=%{public}d count=%{public}u",
                 log: Self.log,
                 type: .info,
-                UInt32(locationID),
+                locationID,
                 UInt32(identities.count)
             )
             return
@@ -425,10 +425,10 @@ class DeviceManager: ObservableObject {
         .joined(separator: ", ")
 
         os_log(
-            "Receiver logical devices updated for locationID=%{public}u: %{public}@",
+            "Receiver logical devices updated for locationID=%{public}d: %{public}@",
             log: Self.log,
             type: .info,
-            UInt32(locationID),
+            locationID,
             identitiesDescription
         )
     }

--- a/LinearMouse/Device/ReceiverMonitor.swift
+++ b/LinearMouse/Device/ReceiverMonitor.swift
@@ -123,6 +123,15 @@ struct ReceiverSlotStateStore {
         }
     }
 
+    mutating func updateSlotIdentity(_ identity: ReceiverLogicalDeviceIdentity) {
+        pairedIdentitiesBySlot[identity.slot] = identity
+        slotPresenceBySlot[identity.slot] = .connected
+    }
+
+    func needsIdentityRefresh(slot: UInt8) -> Bool {
+        pairedIdentitiesBySlot[slot] == nil
+    }
+
     func currentPublishedIdentities() -> [ReceiverLogicalDeviceIdentity] {
         pairedIdentitiesBySlot.keys.sorted().compactMap { slot in
             guard let identity = pairedIdentitiesBySlot[slot] else {
@@ -185,18 +194,20 @@ private final class ReceiverContext {
         let initialDeadline = Date().addingTimeInterval(ReceiverMonitor.initialDiscoveryTimeout)
         var hasPublishedInitialState = false
         var receiverChannel: LogitechReceiverChannel?
+        var hasCompletedInitialDiscovery = false
 
         while shouldContinueRunning() {
             if receiverChannel == nil {
                 receiverChannel = provider.openReceiverChannel(for: device.pointerDevice)
+                hasCompletedInitialDiscovery = false
             }
 
             guard let receiverChannel else {
                 os_log(
-                    "Receiver monitor is waiting for channel: locationID=%{public}u device=%{public}@",
+                    "Receiver monitor is waiting for channel: locationID=%{public}d device=%{public}@",
                     log: ReceiverMonitor.log,
                     type: .info,
-                    UInt32(locationID),
+                    locationID,
                     String(describing: device)
                 )
 
@@ -211,44 +222,52 @@ private final class ReceiverContext {
                 continue
             }
 
-            let discovery = provider.receiverPointingDeviceDiscovery(for: device.pointerDevice, using: receiverChannel)
-            mergeDiscovery(discovery)
-            let identities = currentPublishedIdentities()
-            let identitiesDescription = identities.map { identity in
-                let battery = identity.batteryLevel.map(String.init) ?? "(nil)"
-                return "slot=\(identity.slot) name=\(identity.name) battery=\(battery)"
-            }
-            .joined(separator: ", ")
+            // Full discovery only once per channel open
+            if !hasCompletedInitialDiscovery {
+                let discovery = provider.receiverPointingDeviceDiscovery(
+                    for: device.pointerDevice, using: receiverChannel
+                )
+                mergeDiscovery(discovery)
+                hasCompletedInitialDiscovery = true
 
-            os_log(
-                "Receiver scan completed: locationID=%{public}u count=%{public}u identities=%{public}@",
-                log: ReceiverMonitor.log,
-                type: .info,
-                UInt32(locationID),
-                UInt32(identities.count),
-                identitiesDescription
-            )
+                let identities = currentPublishedIdentities()
+                let identitiesDescription = identities.map { identity in
+                    let battery = identity.batteryLevel.map(String.init) ?? "(nil)"
+                    return "slot=\(identity.slot) name=\(identity.name) battery=\(battery)"
+                }
+                .joined(separator: ", ")
 
-            if identities != lastPublishedIdentities {
-                publish(identities)
-                hasPublishedInitialState = true
-            } else if !hasPublishedInitialState, !identities.isEmpty {
-                publish(identities)
-                hasPublishedInitialState = true
-            } else if !hasPublishedInitialState, Date() >= initialDeadline {
                 os_log(
-                    "Receiver logical discovery timed out: locationID=%{public}u device=%{public}@",
+                    "Receiver initial discovery completed: locationID=%{public}d count=%{public}u identities=%{public}@",
                     log: ReceiverMonitor.log,
                     type: .info,
-                    UInt32(locationID),
-                    String(describing: device)
+                    locationID,
+                    UInt32(identities.count),
+                    identitiesDescription
                 )
-                DispatchQueue.main.async { [weak self] in
-                    self?.onDiscoveryTimedOut?()
+
+                if identities != lastPublishedIdentities {
+                    publish(identities)
+                    hasPublishedInitialState = true
+                } else if !hasPublishedInitialState, !identities.isEmpty {
+                    publish(identities)
+                    hasPublishedInitialState = true
+                } else if !hasPublishedInitialState, Date() >= initialDeadline {
+                    os_log(
+                        "Receiver logical discovery timed out: locationID=%{public}d device=%{public}@",
+                        log: ReceiverMonitor.log,
+                        type: .info,
+                        locationID,
+                        String(describing: device)
+                    )
+                    DispatchQueue.main.async { [weak self] in
+                        self?.onDiscoveryTimedOut?()
+                    }
+                    hasPublishedInitialState = true
                 }
-                hasPublishedInitialState = true
             }
 
+            // Wait for connection events (event-driven, no periodic rescan)
             let connectionSnapshots = provider.waitForReceiverConnectionChange(
                 using: receiverChannel,
                 timeout: ReceiverMonitor.refreshInterval
@@ -260,34 +279,47 @@ private final class ReceiverContext {
                 break
             }
 
+            guard !connectionSnapshots.isEmpty else {
+                // Timeout with no events — just continue waiting
+                continue
+            }
+
             mergeConnectionSnapshots(connectionSnapshots)
 
-            if !connectionSnapshots.isEmpty {
-                let snapshotDescription = connectionSnapshots.keys
-                    .sorted()
-                    .compactMap { slot -> String? in
-                        guard let snapshot = connectionSnapshots[slot] else {
-                            return nil
-                        }
-
-                        return "slot=\(slot) connected=\(snapshot.isConnected)"
-                    }
-                    .joined(separator: ", ")
-
-                os_log(
-                    "Receiver connection change detected: locationID=%{public}u device=%{public}@ snapshots=%{public}@",
-                    log: ReceiverMonitor.log,
-                    type: .info,
-                    UInt32(locationID),
-                    String(describing: device),
-                    snapshotDescription
-                )
-
-                let identities = currentPublishedIdentities()
-                if identities != lastPublishedIdentities {
-                    publish(identities)
+            // For newly connected devices, read their identity info
+            for (slot, snapshot) in connectionSnapshots where snapshot.isConnected {
+                if needsIdentityRefresh(slot: slot) {
+                    refreshSlotIdentity(
+                        slot: slot,
+                        connectionSnapshot: snapshot,
+                        using: receiverChannel
+                    )
                 }
-                continue
+            }
+
+            let snapshotDescription = connectionSnapshots.keys
+                .sorted()
+                .compactMap { slot -> String? in
+                    guard let snapshot = connectionSnapshots[slot] else {
+                        return nil
+                    }
+
+                    return "slot=\(slot) connected=\(snapshot.isConnected)"
+                }
+                .joined(separator: ", ")
+
+            os_log(
+                "Receiver connection change detected: locationID=%{public}d device=%{public}@ snapshots=%{public}@",
+                log: ReceiverMonitor.log,
+                type: .info,
+                locationID,
+                String(describing: device),
+                snapshotDescription
+            )
+
+            let identities = currentPublishedIdentities()
+            if identities != lastPublishedIdentities {
+                publish(identities)
             }
         }
     }
@@ -302,10 +334,10 @@ private final class ReceiverContext {
         .joined(separator: ", ")
 
         os_log(
-            "Receiver logical discovery updated: locationID=%{public}u identities=%{public}@",
+            "Receiver logical discovery updated: locationID=%{public}d identities=%{public}@",
             log: ReceiverMonitor.log,
             type: .info,
-            UInt32(locationID),
+            locationID,
             identitiesDescription
         )
 
@@ -336,6 +368,42 @@ private final class ReceiverContext {
         stateLock.lock()
         stateStore.mergeConnectionSnapshots(newSnapshots)
         stateLock.unlock()
+    }
+
+    private func refreshSlotIdentity(
+        slot: UInt8,
+        connectionSnapshot: LogitechHIDPPDeviceMetadataProvider.ReceiverConnectionSnapshot?,
+        using receiverChannel: LogitechReceiverChannel
+    ) {
+        guard let identity = provider.receiverSlotIdentity(
+            for: device.pointerDevice,
+            slot: slot,
+            connectionSnapshot: connectionSnapshot,
+            using: receiverChannel
+        ) else {
+            return
+        }
+
+        stateLock.lock()
+        stateStore.updateSlotIdentity(identity)
+        stateLock.unlock()
+
+        os_log(
+            "Refreshed slot identity: locationID=%{public}d slot=%{public}u name=%{public}@ battery=%{public}@",
+            log: ReceiverMonitor.log,
+            type: .info,
+            locationID,
+            slot,
+            identity.name,
+            identity.batteryLevel.map(String.init) ?? "(nil)"
+        )
+    }
+
+    private func needsIdentityRefresh(slot: UInt8) -> Bool {
+        stateLock.lock()
+        let needs = stateStore.needsIdentityRefresh(slot: slot)
+        stateLock.unlock()
+        return needs
     }
 
     private func currentPublishedIdentities() -> [ReceiverLogicalDeviceIdentity] {

--- a/LinearMouse/Device/ReceiverMonitor.swift
+++ b/LinearMouse/Device/ReceiverMonitor.swift
@@ -119,7 +119,15 @@ struct ReceiverSlotStateStore {
         _ newSnapshots: [UInt8: LogitechHIDPPDeviceMetadataProvider.ReceiverConnectionSnapshot]
     ) {
         for (slot, snapshot) in newSnapshots {
-            slotPresenceBySlot[slot] = snapshot.isConnected ? .connected : .disconnected
+            let newPresence: SlotPresenceState = snapshot.isConnected ? .connected : .disconnected
+            let oldPresence = slotPresenceBySlot[slot]
+            slotPresenceBySlot[slot] = newPresence
+
+            // Clear stale identity when a device reconnects to a slot,
+            // so the next needsIdentityRefresh check will trigger a refresh.
+            if newPresence == .connected, oldPresence == .disconnected {
+                pairedIdentitiesBySlot.removeValue(forKey: slot)
+            }
         }
     }
 
@@ -193,16 +201,16 @@ private final class ReceiverContext {
     private func workerMain() {
         let initialDeadline = Date().addingTimeInterval(ReceiverMonitor.initialDiscoveryTimeout)
         var hasPublishedInitialState = false
-        var receiverChannel: LogitechReceiverChannel?
+        var currentChannel: LogitechReceiverChannel?
         var hasCompletedInitialDiscovery = false
 
         while shouldContinueRunning() {
-            if receiverChannel == nil {
-                receiverChannel = provider.openReceiverChannel(for: device.pointerDevice)
+            if currentChannel == nil {
+                currentChannel = provider.openReceiverChannel(for: device.pointerDevice)
                 hasCompletedInitialDiscovery = false
             }
 
-            guard let receiverChannel else {
+            guard let receiverChannel = currentChannel else {
                 os_log(
                     "Receiver monitor is waiting for channel: locationID=%{public}d device=%{public}@",
                     log: ReceiverMonitor.log,
@@ -280,7 +288,17 @@ private final class ReceiverContext {
             }
 
             guard !connectionSnapshots.isEmpty else {
-                // Timeout with no events — just continue waiting
+                // Timeout with no events — verify channel is still alive
+                if receiverChannel.readNotificationFlags() == nil {
+                    os_log(
+                        "Receiver channel appears dead, will reopen: locationID=%{public}d device=%{public}@",
+                        log: ReceiverMonitor.log,
+                        type: .info,
+                        locationID,
+                        String(describing: device)
+                    )
+                    currentChannel = nil
+                }
                 continue
             }
 

--- a/LinearMouse/Device/VendorSpecific/Logitech/LogitechHIDPPDeviceMetadataProvider.swift
+++ b/LinearMouse/Device/VendorSpecific/Logitech/LogitechHIDPPDeviceMetadataProvider.swift
@@ -216,10 +216,10 @@ struct LogitechHIDPPDeviceMetadataProvider: VendorSpecificDeviceMetadataProvider
 
         guard let receiverChannel = openReceiverChannel(for: device) else {
             os_log(
-                "Failed to open receiver channel: locationID=%{public}u name=%{public}@",
+                "Failed to open receiver channel: locationID=%{public}d name=%{public}@",
                 log: Self.log,
                 type: .info,
-                UInt32(locationID),
+                locationID,
                 device.product ?? device.name
             )
             return .init(identities: [], connectionSnapshots: [:], liveReachableSlots: [])
@@ -236,10 +236,10 @@ struct LogitechHIDPPDeviceMetadataProvider: VendorSpecificDeviceMetadataProvider
         .joined(separator: ", ")
 
         os_log(
-            "Receiver discovery produced identities: locationID=%{public}u count=%{public}u identities=%{public}@",
+            "Receiver discovery produced identities: locationID=%{public}d count=%{public}u identities=%{public}@",
             log: Self.log,
             type: .info,
-            UInt32(locationID),
+            locationID,
             UInt32(slots.count),
             slotSummary
         )
@@ -281,6 +281,35 @@ struct LogitechHIDPPDeviceMetadataProvider: VendorSpecificDeviceMetadataProvider
         using receiverChannel: LogitechReceiverChannel
     ) -> ReceiverPointingDeviceDiscovery {
         receiverChannel.discoverPointingDeviceDiscovery(baseName: device.product ?? device.name)
+    }
+
+    func receiverSlotIdentity(
+        for device: VendorSpecificDeviceContext,
+        slot: UInt8,
+        connectionSnapshot: ReceiverConnectionSnapshot?,
+        using receiverChannel: LogitechReceiverChannel
+    ) -> ReceiverLogicalDeviceIdentity? {
+        guard let locationID = receiverChannel.locationID else {
+            return nil
+        }
+
+        guard let slotInfo = receiverChannel.discoverSlotInfo(slot, connectionSnapshot: connectionSnapshot) else {
+            return nil
+        }
+
+        guard let kind = ReceiverLogicalDeviceKind(rawValue: slotInfo.kind), kind.isPointingDevice else {
+            return nil
+        }
+
+        return ReceiverLogicalDeviceIdentity(
+            receiverLocationID: locationID,
+            slot: slot,
+            kind: kind,
+            name: slotInfo.name ?? device.product ?? device.name,
+            serialNumber: slotInfo.serialNumber,
+            productID: slotInfo.productID,
+            batteryLevel: slotInfo.batteryLevel
+        )
     }
 
     func waitForReceiverConnectionChange(
@@ -938,6 +967,53 @@ final class LogitechReceiverChannel: VendorSpecificDeviceContext {
         )
 
         return pairedSlots.isEmpty ? nil : .init(slots: pairedSlots, connectionSnapshots: connectionSnapshots)
+    }
+
+    func discoverSlotInfo(
+        _ slot: UInt8,
+        connectionSnapshot: LogitechHIDPPDeviceMetadataProvider.ReceiverConnectionSnapshot? = nil
+    ) -> LogitechHIDPPDeviceMetadataProvider.ReceiverSlotInfo? {
+        let metadataProvider = LogitechHIDPPDeviceMetadataProvider()
+        let pairingResponse = hidpp10LongRequest(
+            register: LogitechHIDPPDeviceMetadataProvider.Constants.receiverInfoRegister,
+            subregister: UInt8(0x20 + Int(slot) - 1)
+        )
+        let extendedPairingResponse = hidpp10LongRequest(
+            register: LogitechHIDPPDeviceMetadataProvider.Constants.receiverInfoRegister,
+            subregister: UInt8(0x30 + Int(slot) - 1)
+        )
+        let nameResponse = hidpp10LongRequest(
+            register: LogitechHIDPPDeviceMetadataProvider.Constants.receiverInfoRegister,
+            subregister: UInt8(0x40 + Int(slot) - 1)
+        )
+
+        guard pairingResponse != nil || nameResponse != nil else {
+            return nil
+        }
+
+        let kind = connectionSnapshot?.kind
+            ?? pairingResponse.flatMap(Self.parseReceiverKind)
+            ?? 0
+        let routedTransport = LogitechHIDPPTransport(device: self, deviceIndex: slot)
+        let routedName = routedTransport.flatMap { transport in
+            metadataProvider.readFriendlyName(using: transport) ?? metadataProvider.readName(using: transport)
+        }
+        let batteryLevel = routedTransport.flatMap {
+            metadataProvider.readReceiverBatteryLevel(using: $0)
+        }
+        let name = nameResponse.flatMap(Self.parseReceiverName) ?? routedName
+        let productID = pairingResponse.flatMap(Self.parseReceiverProductID)
+        let serialNumber = extendedPairingResponse.flatMap(Self.parseReceiverSerialNumber)
+
+        return .init(
+            slot: slot,
+            kind: kind,
+            name: name,
+            productID: productID,
+            serialNumber: serialNumber,
+            batteryLevel: batteryLevel,
+            hasLiveMetadata: routedName != nil || batteryLevel != nil
+        )
     }
 
     private func discoverConnectionSnapshots()
@@ -1689,10 +1765,10 @@ final class LogitechReprogrammableControlsMonitor {
             if monitoredControls.isEmpty {
                 finishVirtualButtonRecordingPreparationIfNeeded(sessionID: recordingSessionID)
                 os_log(
-                    "Pause Logitech control diversion until configuration changes: locationID=%{public}u slot=%{public}u device=%{public}@ recording=%{public}@",
+                    "Pause Logitech control diversion until configuration changes: locationID=%{public}d slot=%{public}u device=%{public}@ recording=%{public}@",
                     log: Self.log,
                     type: .info,
-                    UInt32(locationID),
+                    locationID,
                     slot,
                     targetName,
                     isRecording ? "true" : "false"
@@ -1720,10 +1796,10 @@ final class LogitechReprogrammableControlsMonitor {
             let activeControlIDs = monitoredControls.compactMap { control -> UInt16? in
                 guard setDiverted(true, for: control.controlID, using: transport, featureIndex: featureIndex) else {
                     os_log(
-                        "Failed to enable Logitech control diversion: locationID=%{public}u slot=%{public}u cid=0x%{public}04X",
+                        "Failed to enable Logitech control diversion: locationID=%{public}d slot=%{public}u cid=0x%{public}04X",
                         log: Self.log,
                         type: .error,
-                        UInt32(locationID),
+                        locationID,
                         slot,
                         control.controlID
                     )
@@ -1736,10 +1812,10 @@ final class LogitechReprogrammableControlsMonitor {
             guard !activeControlIDs.isEmpty else {
                 finishVirtualButtonRecordingPreparationIfNeeded(sessionID: recordingSessionID)
                 os_log(
-                    "Failed to enable any Logitech control diversion: locationID=%{public}u slot=%{public}u device=%{public}@",
+                    "Failed to enable any Logitech control diversion: locationID=%{public}d slot=%{public}u device=%{public}@",
                     log: Self.log,
                     type: .error,
-                    UInt32(locationID),
+                    locationID,
                     slot,
                     targetName
                 )
@@ -1780,10 +1856,10 @@ final class LogitechReprogrammableControlsMonitor {
             .joined(separator: " | ")
 
             os_log(
-                "Logitech controls monitor enabled: locationID=%{public}u slot=%{public}u device=%{public}@ controls=%{public}@",
+                "Logitech controls monitor enabled: locationID=%{public}d slot=%{public}u device=%{public}@ controls=%{public}@",
                 log: Self.log,
                 type: .info,
-                UInt32(locationID),
+                locationID,
                 slot,
                 targetName,
                 controlSummary
@@ -1813,10 +1889,10 @@ final class LogitechReprogrammableControlsMonitor {
             while shouldContinueRunning() {
                 if consumeReconfigurationRequest() {
                     os_log(
-                        "Restart Logitech control monitor to refresh diverted controls: locationID=%{public}u slot=%{public}u device=%{public}@",
+                        "Restart Logitech control monitor to refresh diverted controls: locationID=%{public}d slot=%{public}u device=%{public}@",
                         log: Self.log,
                         type: .info,
-                        UInt32(locationID),
+                        locationID,
                         slot,
                         targetName
                     )
@@ -1840,10 +1916,10 @@ final class LogitechReprogrammableControlsMonitor {
                 for controlID in changedControls {
                     let isPressed = activeControls.contains(controlID)
                     os_log(
-                        "Logitech reprogrammable control event: locationID=%{public}u slot=%{public}u device=%{public}@ cid=0x%{public}04X button=%{public}d state=%{public}@ active=%{public}@",
+                        "Logitech reprogrammable control event: locationID=%{public}d slot=%{public}u device=%{public}@ cid=0x%{public}04X button=%{public}d state=%{public}@ active=%{public}@",
                         log: Self.log,
                         type: .info,
-                        UInt32(locationID),
+                        locationID,
                         slot,
                         targetName,
                         controlID,
@@ -2353,11 +2429,11 @@ final class LogitechReprogrammableControlsMonitor {
 
             guard setDiverted(shouldBeDiverted, for: controlID, using: transport, featureIndex: featureIndex) else {
                 os_log(
-                    "%{public}s failed: locationID=%{public}u slot=%{public}u cid=0x%{public}04X target=%{public}@",
+                    "%{public}s failed: locationID=%{public}d slot=%{public}u cid=0x%{public}04X target=%{public}@",
                     log: Self.log,
                     type: .error,
                     String(describing: reason),
-                    UInt32(locationID),
+                    locationID,
                     slot,
                     controlID,
                     shouldBeDiverted ? "diverted" : "native"
@@ -2372,11 +2448,11 @@ final class LogitechReprogrammableControlsMonitor {
                 featureIndex: featureIndex
             ) else {
                 os_log(
-                    "%{public}s verification failed: locationID=%{public}u slot=%{public}u cid=0x%{public}04X",
+                    "%{public}s verification failed: locationID=%{public}d slot=%{public}u cid=0x%{public}04X",
                     log: Self.log,
                     type: .error,
                     String(describing: reason),
-                    UInt32(locationID),
+                    locationID,
                     slot,
                     controlID
                 )
@@ -2387,11 +2463,11 @@ final class LogitechReprogrammableControlsMonitor {
             let isDiverted = currentReportingInfo.flags.contains(.diverted)
             guard isDiverted == shouldBeDiverted else {
                 os_log(
-                    "%{public}s verification mismatch: locationID=%{public}u slot=%{public}u cid=0x%{public}04X target=%{public}@ actual=%{public}@ reporting=%{public}@",
+                    "%{public}s verification mismatch: locationID=%{public}d slot=%{public}u cid=0x%{public}04X target=%{public}@ actual=%{public}@ reporting=%{public}@",
                     log: Self.log,
                     type: .error,
                     String(describing: reason),
-                    UInt32(locationID),
+                    locationID,
                     slot,
                     controlID,
                     shouldBeDiverted ? "diverted" : "native",
@@ -2476,10 +2552,10 @@ final class LogitechReprogrammableControlsMonitor {
         let controls = fetchControls(using: transport, featureIndex: featureIndex)
         guard !controls.isEmpty else {
             os_log(
-                "No Logitech reprogrammable controls discovered: locationID=%{public}u slot=%{public}u",
+                "No Logitech reprogrammable controls discovered: locationID=%{public}d slot=%{public}u",
                 log: Self.log,
                 type: .info,
-                UInt32(locationID),
+                locationID,
                 slot
             )
             return
@@ -2502,10 +2578,10 @@ final class LogitechReprogrammableControlsMonitor {
         .joined(separator: " | ")
 
         os_log(
-            "Logitech REPROG_CONTROLS_V4 dump: locationID=%{public}u slot=%{public}u controls=%{public}@",
+            "Logitech REPROG_CONTROLS_V4 dump: locationID=%{public}d slot=%{public}u controls=%{public}@",
             log: Self.log,
             type: .info,
-            UInt32(locationID),
+            locationID,
             slot,
             summary
         )

--- a/LinearMouse/Device/VendorSpecific/Logitech/LogitechHIDPPDeviceMetadataProvider.swift
+++ b/LinearMouse/Device/VendorSpecific/Logitech/LogitechHIDPPDeviceMetadataProvider.swift
@@ -862,7 +862,6 @@ final class LogitechReceiverChannel: VendorSpecificDeviceContext {
     }
 
     func discoverSlots() -> LogitechHIDPPDeviceMetadataProvider.ReceiverSlotDiscovery? {
-        let metadataProvider = LogitechHIDPPDeviceMetadataProvider()
         let connectedDeviceCount = readConnectionState().flatMap { response in
             LogitechHIDPPDeviceMetadataProvider.parseConnectedDeviceCount(response)
         }
@@ -890,20 +889,7 @@ final class LogitechReceiverChannel: VendorSpecificDeviceContext {
 
         var pairedSlots = [LogitechHIDPPDeviceMetadataProvider.ReceiverSlotInfo]()
         for slot in UInt8(1) ... UInt8(6) {
-            let pairingResponse = hidpp10LongRequest(
-                register: LogitechHIDPPDeviceMetadataProvider.Constants.receiverInfoRegister,
-                subregister: UInt8(0x20 + Int(slot) - 1)
-            )
-            let extendedPairingResponse = hidpp10LongRequest(
-                register: LogitechHIDPPDeviceMetadataProvider.Constants.receiverInfoRegister,
-                subregister: UInt8(0x30 + Int(slot) - 1)
-            )
-            let nameResponse = hidpp10LongRequest(
-                register: LogitechHIDPPDeviceMetadataProvider.Constants.receiverInfoRegister,
-                subregister: UInt8(0x40 + Int(slot) - 1)
-            )
-
-            guard pairingResponse != nil || nameResponse != nil else {
+            guard let slotInfo = discoverSlotInfo(slot, connectionSnapshot: connectionSnapshots[slot]) else {
                 os_log(
                     "Receiver slot %u has no pairing or name response",
                     log: LogitechHIDPPDeviceMetadataProvider.log,
@@ -913,40 +899,16 @@ final class LogitechReceiverChannel: VendorSpecificDeviceContext {
                 continue
             }
 
-            let kind = connectionSnapshots[slot]?.kind
-                ?? pairingResponse.flatMap(Self.parseReceiverKind)
-                ?? 0
-            let routedTransport = LogitechHIDPPTransport(device: self, deviceIndex: slot)
-            let routedName = routedTransport.flatMap { transport in
-                metadataProvider.readFriendlyName(using: transport) ?? metadataProvider.readName(using: transport)
-            }
-            let batteryLevel = routedTransport.flatMap {
-                metadataProvider.readReceiverBatteryLevel(using: $0)
-            }
-            let name = nameResponse.flatMap(Self.parseReceiverName) ?? routedName
-            let productID = pairingResponse.flatMap(Self.parseReceiverProductID)
-            let serialNumber = extendedPairingResponse.flatMap(Self.parseReceiverSerialNumber)
-            pairedSlots.append(
-                .init(
-                    slot: slot,
-                    kind: kind,
-                    name: name,
-                    productID: productID,
-                    serialNumber: serialNumber,
-                    batteryLevel: batteryLevel,
-                    hasLiveMetadata: routedName != nil || batteryLevel != nil
-                )
-            )
+            pairedSlots.append(slotInfo)
 
             os_log(
-                "Receiver slot %u raw candidate: pairing=%{public}@ name=%{public}@ kind=%{public}u battery=%{public}@",
+                "Receiver slot %u raw candidate: name=%{public}@ kind=%{public}u battery=%{public}@",
                 log: LogitechHIDPPDeviceMetadataProvider.log,
                 type: .info,
                 slot,
-                pairingResponse != nil ? "yes" : "no",
-                name ?? "(nil)",
-                UInt32(kind),
-                batteryLevel.map(String.init) ?? "(nil)"
+                slotInfo.name ?? "(nil)",
+                UInt32(slotInfo.kind),
+                slotInfo.batteryLevel.map(String.init) ?? "(nil)"
             )
         }
 

--- a/LinearMouse/UI/SettingsWindowController.swift
+++ b/LinearMouse/UI/SettingsWindowController.swift
@@ -28,7 +28,12 @@ class SettingsWindowController: NSWindowController {
         window.delegate = self
         window.title = LinearMouse.appName
         window.minSize = NSSize(width: 850, height: 600)
-        window.titlebarAppearsTransparent = true
+
+        if #available(macOS 26.0, *) {
+            // On macOS 26+, keep titlebar opaque to enable scroll edge effect (progressive blur)
+        } else {
+            window.titlebarAppearsTransparent = true
+        }
 
         // Setup split view controller
         let splitVC = SettingsSplitViewController()

--- a/LinearMouseUnitTests/Device/VendorSpecificDeviceMetadataTests.swift
+++ b/LinearMouseUnitTests/Device/VendorSpecificDeviceMetadataTests.swift
@@ -199,7 +199,7 @@ final class VendorSpecificDeviceMetadataTests: XCTestCase {
         XCTAssertTrue(store.currentPublishedIdentities().isEmpty)
     }
 
-    func testReceiverSlotStateStoreRestoresSlotAfterReconnectSnapshot() {
+    func testReceiverSlotStateStoreClearsIdentityOnReconnectAndAllowsRefresh() {
         var store = ReceiverSlotStateStore()
         let identity = ReceiverLogicalDeviceIdentity(
             receiverLocationID: 0x1234,
@@ -214,10 +214,17 @@ final class VendorSpecificDeviceMetadataTests: XCTestCase {
         store.mergeDiscovery(.init(identities: [identity], connectionSnapshots: [
             1: .init(isConnected: false, kind: ReceiverLogicalDeviceKind.mouse.rawValue)
         ], liveReachableSlots: []))
+
+        // After disconnect→connect transition, identity is cleared for refresh
         store.mergeConnectionSnapshots([
             1: .init(isConnected: true, kind: ReceiverLogicalDeviceKind.mouse.rawValue)
         ])
+        XCTAssertTrue(store.needsIdentityRefresh(slot: 1))
+        XCTAssertEqual(store.currentPublishedIdentities(), [])
 
+        // After refresh, identity is restored
+        store.updateSlotIdentity(identity)
+        XCTAssertFalse(store.needsIdentityRefresh(slot: 1))
         XCTAssertEqual(store.currentPublishedIdentities(), [identity])
     }
 


### PR DESCRIPTION
## Summary

- **Event-driven receiver monitoring**: Replace 15-second periodic full receiver rescans with pure event-driven monitoring, matching the approach used by the Linux kernel (`hid-logitech-dj`) and Solaar. Full discovery now only runs once at startup; afterwards the monitor waits for HID++ wireless connection notifications (0x41/0x42) and performs targeted per-slot reads for newly connected devices only.

  This eliminates the repeated `triggerConnectionNotifications()` calls (write `0x02` to register `0x02`) every 15 seconds, which forces the receiver to re-announce all devices and can cause momentary disconnections — especially on Thunderbolt-connected USB hubs.

  | Operation | Before | After |
  |---|---|---|
  | Trigger fake device arrival (write reg 0x02) | Every 15s | Once at startup |
  | Full slot scan (6 slots × 3 registers + HID++ 2.0) | Every 15s | Once at startup |
  | Per-slot identity read on connection event | N/A (full rescan) | Only the changed slot |

- **Fix `EXC_BREAKPOINT` crash**: `UInt32(locationID)` in `os_log` calls traps when `locationID` (Int) is out of UInt32 range. Replaced with direct `Int` / `%d` format specifier across `LogitechHIDPPDeviceMetadataProvider`, `ReceiverMonitor`, and `DeviceManager`.

- **dSYM in releases**: Include `LinearMouse.dSYM.zip` in GitHub Release attachments for crash symbolication.

## Test plan

- [x] All 133 unit tests pass
- [ ] Verify Logitech mouse connected via Unifying/Bolt USB receiver is detected on app launch
- [ ] Verify device reconnection (power cycle mouse) is detected via connection event
- [ ] Verify no periodic rescans in Console.app logs (no repeated "Receiver scan completed" messages)
- [ ] Verify battery level is populated on initial discovery
- [ ] Verify dSYM.zip is attached to GitHub Release

🤖 Generated with [Claude Code](https://claude.com/claude-code)