### PR TITLE
Add Logitech control button support for gesture trigger and auto scroll

### DIFF
--- a/Documentation/Configuration.d.ts
+++ b/Documentation/Configuration.d.ts
@@ -1006,6 +1006,13 @@ declare namespace Scheme {
       trigger?: Gesture.Trigger;
 
       /**
+       * @title Button
+       * @description Deprecated. Use trigger instead.
+       * @deprecated
+       */
+      button?: PhysicalButton;
+
+      /**
        * @title Threshold
        * @description The distance in pixels that must be dragged before triggering a gesture.
        * @default 50

--- a/Documentation/Configuration.d.ts
+++ b/Documentation/Configuration.d.ts
@@ -1000,11 +1000,10 @@ declare namespace Scheme {
       enabled?: boolean;
 
       /**
-       * @title Button
-       * @description The button number to use for gestures. Default is 2 (middle button/scroll wheel).
-       * @default 2
+       * @title Trigger
+       * @description Choose the mouse button and modifier keys used to activate gestures.
        */
-      button?: PhysicalButton;
+      trigger?: Gesture.Trigger;
 
       /**
        * @title Threshold
@@ -1041,6 +1040,34 @@ declare namespace Scheme {
     };
 
     namespace Gesture {
+      type Trigger = {
+        /**
+         * @title Button number
+         * @description The button number. See https://developer.apple.com/documentation/coregraphics/cgmousebutton
+         */
+        button: Mapping.Button;
+
+        /**
+         * @description Indicates if the command modifier key should be pressed.
+         */
+        command?: boolean;
+
+        /**
+         * @description Indicates if the shift modifier key should be pressed.
+         */
+        shift?: boolean;
+
+        /**
+         * @description Indicates if the option modifier key should be pressed.
+         */
+        option?: boolean;
+
+        /**
+         * @description Indicates if the control modifier key should be pressed.
+         */
+        control?: boolean;
+      };
+
       type Actions = {
         /**
          * @title Swipe left action

--- a/Documentation/Configuration.json
+++ b/Documentation/Configuration.json
@@ -261,6 +261,12 @@
           "description": "Actions to trigger for each gesture direction.",
           "title": "Gesture actions"
         },
+        "button": {
+          "$ref": "#/definitions/PhysicalButton",
+          "deprecated": true,
+          "description": "Deprecated. Use trigger instead.",
+          "title": "Button"
+        },
         "cooldownMs": {
           "$ref": "#/definitions/Int",
           "default": 500,

--- a/Documentation/Configuration.json
+++ b/Documentation/Configuration.json
@@ -261,12 +261,6 @@
           "description": "Actions to trigger for each gesture direction.",
           "title": "Gesture actions"
         },
-        "button": {
-          "$ref": "#/definitions/PhysicalButton",
-          "default": 2,
-          "description": "The button number to use for gestures. Default is 2 (middle button/scroll wheel).",
-          "title": "Button"
-        },
         "cooldownMs": {
           "$ref": "#/definitions/Int",
           "default": 500,
@@ -296,6 +290,11 @@
           "maximum": 200,
           "minimum": 20,
           "title": "Threshold"
+        },
+        "trigger": {
+          "$ref": "#/definitions/Scheme.Buttons.Gesture.Trigger",
+          "description": "Choose the mouse button and modifier keys used to activate gestures.",
+          "title": "Trigger"
         }
       },
       "type": "object"
@@ -341,6 +340,36 @@
         "launchpad"
       ],
       "type": "string"
+    },
+    "Scheme.Buttons.Gesture.Trigger": {
+      "additionalProperties": false,
+      "properties": {
+        "button": {
+          "$ref": "#/definitions/Scheme.Buttons.Mapping.Button",
+          "description": "The button number. See https://developer.apple.com/documentation/coregraphics/cgmousebutton",
+          "title": "Button number"
+        },
+        "command": {
+          "description": "Indicates if the command modifier key should be pressed.",
+          "type": "boolean"
+        },
+        "control": {
+          "description": "Indicates if the control modifier key should be pressed.",
+          "type": "boolean"
+        },
+        "option": {
+          "description": "Indicates if the option modifier key should be pressed.",
+          "type": "boolean"
+        },
+        "shift": {
+          "description": "Indicates if the shift modifier key should be pressed.",
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "button"
+      ],
+      "type": "object"
     },
     "Scheme.Buttons.Mapping": {
       "anyOf": [

--- a/LinearMouse/Device/VendorSpecific/Logitech/LogitechHIDPPDeviceMetadataProvider.swift
+++ b/LinearMouse/Device/VendorSpecific/Logitech/LogitechHIDPPDeviceMetadataProvider.swift
@@ -1926,7 +1926,7 @@ final class LogitechReprogrammableControlsMonitor {
                         withDisplay: display
                     )
 
-                    let logitechContext = ButtonActionsTransformer.LogitechEventContext(
+                    let logitechContext = LogitechEventContext(
                         device: device,
                         pid: mouseLocationPid,
                         display: display,
@@ -1936,15 +1936,15 @@ final class LogitechReprogrammableControlsMonitor {
                     )
 
                     let handledInternally = (transformer as? [EventTransformer])?.contains { transformer in
-                        if let transformer = transformer as? ButtonActionsTransformer {
-                            return transformer.handleLogitechControlEvent(logitechContext)
-                        }
-
                         if let transformer = transformer as? AutoScrollTransformer {
                             return transformer.handleLogitechControlEvent(logitechContext)
                         }
 
                         if let transformer = transformer as? GestureButtonTransformer {
+                            return transformer.handleLogitechControlEvent(logitechContext)
+                        }
+
+                        if let transformer = transformer as? ButtonActionsTransformer {
                             return transformer.handleLogitechControlEvent(logitechContext)
                         }
 
@@ -2238,9 +2238,16 @@ final class LogitechReprogrammableControlsMonitor {
             return Set(availableControls.map(\.controlID))
         }
 
+        let mouseLocation = NSEvent.mouseLocation
+        let mouseLocationWindowID = CGWindowID(NSWindow.windowNumber(
+            at: mouseLocation,
+            belowWindowWithWindowNumber: 0
+        ))
+        let mouseLocationPid = mouseLocationWindowID.ownerPid
+            ?? NSWorkspace.shared.frontmostApplication?.processIdentifier
         let scheme = ConfigurationState.shared.configuration.matchScheme(
             withDevice: device,
-            withPid: NSWorkspace.shared.frontmostApplication?.processIdentifier,
+            withPid: mouseLocationPid,
             withDisplay: ScreenManager.shared.currentScreenName
         )
 
@@ -2258,7 +2265,7 @@ final class LogitechReprogrammableControlsMonitor {
             }
 
         let autoScrollControlID: UInt16? = {
-            guard scheme.buttons.autoScroll.enabled ?? true,
+            guard scheme.buttons.autoScroll.enabled ?? false,
                   let logiButton = scheme.buttons.autoScroll.trigger?.button?.logitechControl,
                   matches(logiButton: logiButton, identity: identity) else {
                 return nil
@@ -2267,7 +2274,7 @@ final class LogitechReprogrammableControlsMonitor {
         }()
 
         let gestureControlID: UInt16? = {
-            guard scheme.buttons.gesture.enabled ?? true,
+            guard scheme.buttons.gesture.enabled ?? false,
                   let logiButton = scheme.buttons.gesture.trigger?.button?.logitechControl,
                   matches(logiButton: logiButton, identity: identity) else {
                 return nil

--- a/LinearMouse/Device/VendorSpecific/Logitech/LogitechHIDPPDeviceMetadataProvider.swift
+++ b/LinearMouse/Device/VendorSpecific/Logitech/LogitechHIDPPDeviceMetadataProvider.swift
@@ -49,9 +49,10 @@ struct LogitechHIDPPDeviceMetadataProvider: VendorSpecificDeviceMetadataProvider
         static let virtualGestureButtonControlIDs: Set<UInt16> = [0x00D7]
         static let gestureButtonTaskIDs: Set<UInt16> = [0x009C, 0x00A9, 0x00AD]
         static let virtualGestureButtonTaskIDs: Set<UInt16> = [0x00B4]
-        /// Back/forward control IDs that should never be diverted.
-        /// These are natively handled by the OS and diverting them would break compatibility.
-        static let nativeBackForwardControlIDs: Set<UInt16> = [
+        /// Control IDs that should never be diverted because they are natively handled by the OS.
+        /// Diverting these would break their default behavior (click, back/forward, etc.).
+        static let nativeControlIDs: Set<UInt16> = [
+            0x0050, 0x0051, 0x0052, // Left / right / middle mouse button
             0x0053, 0x0056, // Standard back/forward
             0x00CE, 0x00CF, // Alternate back/forward
             0x00D9, 0x00DB // Additional back/forward variants
@@ -1919,19 +1920,29 @@ final class LogitechReprogrammableControlsMonitor {
                         withDisplay: display
                     )
 
+                    let logitechContext = ButtonActionsTransformer.LogitechEventContext(
+                        device: device,
+                        pid: frontmostPid,
+                        display: display,
+                        controlIdentity: controlIdentity,
+                        isPressed: isPressed,
+                        modifierFlags: modifierFlags
+                    )
+
                     let handledInternally = (transformer as? [EventTransformer])?.contains { transformer in
-                        guard let transformer = transformer as? ButtonActionsTransformer else {
-                            return false
+                        if let transformer = transformer as? ButtonActionsTransformer {
+                            return transformer.handleLogitechControlEvent(logitechContext)
                         }
 
-                        return transformer.handleLogitechControlEvent(.init(
-                            device: device,
-                            pid: frontmostPid,
-                            display: display,
-                            controlIdentity: controlIdentity,
-                            isPressed: isPressed,
-                            modifierFlags: modifierFlags
-                        ))
+                        if let transformer = transformer as? AutoScrollTransformer {
+                            return transformer.handleLogitechControlEvent(logitechContext)
+                        }
+
+                        if let transformer = transformer as? GestureButtonTransformer {
+                            return transformer.handleLogitechControlEvent(logitechContext)
+                        }
+
+                        return false
                     } == true
 
                     guard !handledInternally else {
@@ -2140,7 +2151,7 @@ final class LogitechReprogrammableControlsMonitor {
             return false
         }
 
-        guard !LogitechHIDPPDeviceMetadataProvider.ReprogControlsV4.nativeBackForwardControlIDs
+        guard !LogitechHIDPPDeviceMetadataProvider.ReprogControlsV4.nativeControlIDs
             .contains(control.controlID) else {
             return false
         }
@@ -2241,14 +2252,24 @@ final class LogitechReprogrammableControlsMonitor {
             }
 
         let autoScrollControlID: UInt16? = {
-            guard let logiButton = scheme.buttons.autoScroll.trigger?.button?.logitechControl,
+            guard scheme.buttons.autoScroll.enabled ?? true,
+                  let logiButton = scheme.buttons.autoScroll.trigger?.button?.logitechControl,
                   matches(logiButton: logiButton, identity: identity) else {
                 return nil
             }
             return logiButton.controlIDValue
         }()
 
-        return Set(directMappings + [autoScrollControlID].compactMap(\.self))
+        let gestureControlID: UInt16? = {
+            guard scheme.buttons.gesture.enabled ?? true,
+                  let logiButton = scheme.buttons.gesture.trigger?.button?.logitechControl,
+                  matches(logiButton: logiButton, identity: identity) else {
+                return nil
+            }
+            return logiButton.controlIDValue
+        }()
+
+        return Set(directMappings + [autoScrollControlID, gestureControlID].compactMap(\.self))
             .intersection(availableControls.map(\.controlID))
     }
 

--- a/LinearMouse/Device/VendorSpecific/Logitech/LogitechHIDPPDeviceMetadataProvider.swift
+++ b/LinearMouse/Device/VendorSpecific/Logitech/LogitechHIDPPDeviceMetadataProvider.swift
@@ -1912,17 +1912,23 @@ final class LogitechReprogrammableControlsMonitor {
                         continue
                     }
 
-                    let frontmostPid = NSWorkspace.shared.frontmostApplication?.processIdentifier
+                    let mouseLocation = NSEvent.mouseLocation
+                    let mouseLocationWindowID = CGWindowID(NSWindow.windowNumber(
+                        at: mouseLocation,
+                        belowWindowWithWindowNumber: 0
+                    ))
+                    let mouseLocationPid = mouseLocationWindowID.ownerPid
+                        ?? NSWorkspace.shared.frontmostApplication?.processIdentifier
                     let display = ScreenManager.shared.currentScreenName
                     let transformer = EventTransformerManager.shared.get(
                         withDevice: device,
-                        withPid: frontmostPid,
+                        withPid: mouseLocationPid,
                         withDisplay: display
                     )
 
                     let logitechContext = ButtonActionsTransformer.LogitechEventContext(
                         device: device,
-                        pid: frontmostPid,
+                        pid: mouseLocationPid,
                         display: display,
                         controlIdentity: controlIdentity,
                         isPressed: isPressed,

--- a/LinearMouse/EventTap/GlobalEventTap.swift
+++ b/LinearMouse/EventTap/GlobalEventTap.swift
@@ -47,8 +47,8 @@ class GlobalEventTap {
 
         var eventTypes: [CGEventType] = EventType.all
         if SchemeState.shared.schemes.contains(where: { $0.pointer.redirectsToScroll ?? false }) ||
-            SchemeState.shared.schemes.contains(where: { $0.buttons.$autoScroll?.enabled ?? true }) ||
-            SchemeState.shared.schemes.contains(where: { $0.buttons.$gesture?.enabled ?? true }) {
+            SchemeState.shared.schemes.contains(where: { $0.buttons.$autoScroll?.enabled ?? false }) ||
+            SchemeState.shared.schemes.contains(where: { $0.buttons.$gesture?.enabled ?? false }) {
             eventTypes.append(EventType.mouseMoved)
         }
 

--- a/LinearMouse/EventTap/GlobalEventTap.swift
+++ b/LinearMouse/EventTap/GlobalEventTap.swift
@@ -47,7 +47,8 @@ class GlobalEventTap {
 
         var eventTypes: [CGEventType] = EventType.all
         if SchemeState.shared.schemes.contains(where: { $0.pointer.redirectsToScroll ?? false }) ||
-            SchemeState.shared.schemes.contains(where: { $0.buttons.$autoScroll?.enabled ?? false }) {
+            SchemeState.shared.schemes.contains(where: { $0.buttons.$autoScroll?.enabled ?? true }) ||
+            SchemeState.shared.schemes.contains(where: { $0.buttons.$gesture?.enabled ?? true }) {
             eventTypes.append(EventType.mouseMoved)
         }
 

--- a/LinearMouse/EventTransformer/AutoScrollTransformer.swift
+++ b/LinearMouse/EventTransformer/AutoScrollTransformer.swift
@@ -130,6 +130,10 @@ extension AutoScrollTransformer: EventTransformer {
         return CGMouseButton(rawValue: UInt32(buttonNumber)) ?? .center
     }
 
+    private var triggerIsLogitechControl: Bool {
+        trigger.button?.logitechControl != nil
+    }
+
     private func handleTriggerDown(_ event: CGEvent) -> CGEvent? {
         guard matchesTriggerButton(event) else {
             return event
@@ -235,8 +239,10 @@ extension AutoScrollTransformer: EventTransformer {
         case let .active(anchor, _, session):
             let point = pointerLocation(for: event)
             let resolvedSession: Session
+            let isDragOrLogitechMove = event.type == triggerMouseDraggedEventType
+                || (triggerIsLogitechControl && event.type == .mouseMoved)
             if session == .pendingToggleOrHold,
-               event.type == triggerMouseDraggedEventType,
+               isDragOrLogitechMove,
                exceedsDeadZone(from: anchor, to: point) {
                 resolvedSession = .hold
             } else {
@@ -815,6 +821,52 @@ private enum AccessibilityQueryResult<Value> {
 private struct ActivationProbe {
     let point: CGPoint
     let hit: ActivationHit
+}
+
+extension AutoScrollTransformer {
+    func handleLogitechControlEvent(_ context: ButtonActionsTransformer.LogitechEventContext) -> Bool {
+        guard let triggerLogitechControl = trigger.button?.logitechControl,
+              context.controlIdentity.matches(triggerLogitechControl) else {
+            return false
+        }
+
+        if context.isPressed {
+            // If already active in toggle mode, deactivate on re-press
+            if case let .active(_, _, session) = state, session == .toggle {
+                guard hasToggleMode else {
+                    return true
+                }
+                DispatchQueue.main.async { [self] in deactivate() }
+                return true
+            }
+
+            guard trigger.matches(modifierFlags: context.modifierFlags) else {
+                return false
+            }
+
+            let location = CGEvent(source: nil)?.unflippedLocation ?? .zero
+            DispatchQueue.main.async { [self] in activate(at: location, session: activationSession) }
+            return true
+        }
+        switch state {
+        case let .active(anchor, current, session):
+            switch session {
+            case .hold:
+                DispatchQueue.main.async { [self] in deactivate() }
+            case .pendingToggleOrHold:
+                if exceedsDeadZone(from: anchor, to: current) {
+                    DispatchQueue.main.async { [self] in deactivate() }
+                } else {
+                    state = .active(anchor: anchor, current: current, session: .toggle)
+                }
+            case .toggle:
+                break
+            }
+        default:
+            break
+        }
+        return true
+    }
 }
 
 extension AutoScrollTransformer: Deactivatable {

--- a/LinearMouse/EventTransformer/AutoScrollTransformer.swift
+++ b/LinearMouse/EventTransformer/AutoScrollTransformer.swift
@@ -824,38 +824,49 @@ private struct ActivationProbe {
 }
 
 extension AutoScrollTransformer {
-    func handleLogitechControlEvent(_ context: ButtonActionsTransformer.LogitechEventContext) -> Bool {
+    func handleLogitechControlEvent(_ context: LogitechEventContext) -> Bool {
         guard let triggerLogitechControl = trigger.button?.logitechControl,
               context.controlIdentity.matches(triggerLogitechControl) else {
             return false
         }
 
+        let mouseLocation = NSEvent.mouseLocation
+        DispatchQueue.main.async { [self] in
+            handleLogitechControlEventOnMain(context, mouseLocation: mouseLocation)
+        }
+        return true
+    }
+
+    private func handleLogitechControlEventOnMain(
+        _ context: LogitechEventContext,
+        mouseLocation: NSPoint
+    ) {
         if context.isPressed {
             // If already active in toggle mode, deactivate on re-press
             if case let .active(_, _, session) = state, session == .toggle {
                 guard hasToggleMode else {
-                    return true
+                    return
                 }
-                DispatchQueue.main.async { [self] in deactivate() }
-                return true
+                deactivate()
+                return
             }
 
             guard trigger.matches(modifierFlags: context.modifierFlags) else {
-                return false
+                return
             }
 
-            let location = CGEvent(source: nil)?.unflippedLocation ?? .zero
-            DispatchQueue.main.async { [self] in activate(at: location, session: activationSession) }
-            return true
+            let flippedY = (NSScreen.main?.frame.height ?? 0) - mouseLocation.y
+            activate(at: CGPoint(x: mouseLocation.x, y: flippedY), session: activationSession)
+            return
         }
         switch state {
         case let .active(anchor, current, session):
             switch session {
             case .hold:
-                DispatchQueue.main.async { [self] in deactivate() }
+                deactivate()
             case .pendingToggleOrHold:
                 if exceedsDeadZone(from: anchor, to: current) {
-                    DispatchQueue.main.async { [self] in deactivate() }
+                    deactivate()
                 } else {
                     state = .active(anchor: anchor, current: current, session: .toggle)
                 }
@@ -865,7 +876,6 @@ extension AutoScrollTransformer {
         default:
             break
         }
-        return true
     }
 }
 

--- a/LinearMouse/EventTransformer/AutoScrollTransformer.swift
+++ b/LinearMouse/EventTransformer/AutoScrollTransformer.swift
@@ -855,8 +855,7 @@ extension AutoScrollTransformer {
                 return
             }
 
-            let flippedY = (NSScreen.main?.frame.height ?? 0) - mouseLocation.y
-            activate(at: CGPoint(x: mouseLocation.x, y: flippedY), session: activationSession)
+            activate(at: CGPoint(x: mouseLocation.x, y: mouseLocation.y), session: activationSession)
             return
         }
         switch state {

--- a/LinearMouse/EventTransformer/ButtonActionsTransformer.swift
+++ b/LinearMouse/EventTransformer/ButtonActionsTransformer.swift
@@ -22,15 +22,6 @@ class ButtonActionsTransformer {
         Self.keySimulator
     }
 
-    struct LogitechEventContext {
-        let device: Device?
-        let pid: pid_t?
-        let display: String?
-        let controlIdentity: LogitechControlIdentity
-        let isPressed: Bool
-        let modifierFlags: CGEventFlags
-    }
-
     init(
         mappings: [Scheme.Buttons.Mapping],
         universalBackForward: Scheme.Buttons.UniversalBackForward? = nil

--- a/LinearMouse/EventTransformer/EventTransformerManager.swift
+++ b/LinearMouse/EventTransformer/EventTransformerManager.swift
@@ -212,11 +212,11 @@ class EventTransformerManager {
         }
 
         if let gesture = scheme.buttons.$gesture,
-           gesture.enabled ?? false,
-           let button = gesture.button,
-           let mouseButton = CGMouseButton(rawValue: UInt32(button)) {
+           gesture.enabled ?? true,
+           let trigger = gesture.trigger,
+           trigger.button != nil {
             eventTransformer.append(GestureButtonTransformer(
-                button: mouseButton,
+                trigger: trigger,
                 threshold: Double(gesture.threshold ?? 50),
                 deadZone: Double(gesture.deadZone ?? 40),
                 cooldownMs: gesture.cooldownMs ?? 500,
@@ -251,7 +251,7 @@ class EventTransformerManager {
         }
 
         guard let autoScroll,
-              autoScroll.enabled ?? false,
+              autoScroll.enabled ?? true,
               let trigger = autoScroll.trigger,
               trigger.valid else {
             sharedAutoScrollTransformer?.deactivate()

--- a/LinearMouse/EventTransformer/EventTransformerManager.swift
+++ b/LinearMouse/EventTransformer/EventTransformerManager.swift
@@ -212,7 +212,7 @@ class EventTransformerManager {
         }
 
         if let gesture = scheme.buttons.$gesture,
-           gesture.enabled ?? true,
+           gesture.enabled ?? false,
            let trigger = gesture.trigger,
            trigger.button != nil {
             eventTransformer.append(GestureButtonTransformer(
@@ -251,7 +251,7 @@ class EventTransformerManager {
         }
 
         guard let autoScroll,
-              autoScroll.enabled ?? true,
+              autoScroll.enabled ?? false,
               let trigger = autoScroll.trigger,
               trigger.valid else {
             sharedAutoScrollTransformer?.deactivate()

--- a/LinearMouse/EventTransformer/GestureButtonTransformer.swift
+++ b/LinearMouse/EventTransformer/GestureButtonTransformer.swift
@@ -11,7 +11,8 @@ class GestureButtonTransformer {
     static let log = OSLog(subsystem: Bundle.main.bundleIdentifier!, category: "GestureButton")
 
     // Configuration
-    private let button: CGMouseButton
+    private let trigger: Scheme.Buttons.Mapping
+    private let triggerMouseButton: CGMouseButton
     private let threshold: Double
     private let deadZone: Double
     private let cooldownMs: Int
@@ -28,25 +29,20 @@ class GestureButtonTransformer {
     private var state: State = .idle
 
     init(
-        button: CGMouseButton,
+        trigger: Scheme.Buttons.Mapping,
         threshold: Double,
         deadZone: Double,
         cooldownMs: Int,
         actions: Scheme.Buttons.Gesture.Actions
     ) {
-        self.button = button
+        self.trigger = trigger
+        let defaultButton = UInt32(CGMouseButton.center.rawValue)
+        let buttonNumber = trigger.button?.syntheticMouseButtonNumber ?? Int(defaultButton)
+        triggerMouseButton = CGMouseButton(rawValue: UInt32(buttonNumber)) ?? .center
         self.threshold = threshold
         self.deadZone = deadZone
         self.cooldownMs = cooldownMs
         self.actions = actions
-
-//        os_log(
-//            "GestureButtonTransformer initialized - button: %d, threshold: %.1f",
-//            log: Self.log,
-//            type: .info,
-//            button.rawValue,
-//            threshold
-//        )
     }
 }
 
@@ -56,7 +52,7 @@ extension GestureButtonTransformer: EventTransformer {
         if case let .cooldown(until) = state {
             if DispatchTime.now().uptimeNanoseconds < until {
                 // Still in cooldown - consume our button events
-                if isOurButtonEvent(event) {
+                if matchesTriggerButton(event) {
 //                    os_log("Event consumed during cooldown", log: Self.log, type: .debug)
                     return nil
                 }
@@ -70,7 +66,7 @@ extension GestureButtonTransformer: EventTransformer {
         switch event.type {
         case mouseDownEventType:
             return handleButtonDown(event)
-        case mouseDraggedEventType:
+        case mouseDraggedEventType, .mouseMoved:
             return handleDragged(event)
         case mouseUpEventType:
             return handleButtonUp(event)
@@ -80,27 +76,33 @@ extension GestureButtonTransformer: EventTransformer {
     }
 
     private var mouseDownEventType: CGEventType {
-        button.fixedCGEventType(of: .otherMouseDown)
+        triggerMouseButton.fixedCGEventType(of: .otherMouseDown)
     }
 
     private var mouseUpEventType: CGEventType {
-        button.fixedCGEventType(of: .otherMouseUp)
+        triggerMouseButton.fixedCGEventType(of: .otherMouseUp)
     }
 
     private var mouseDraggedEventType: CGEventType {
-        button.fixedCGEventType(of: .otherMouseDragged)
+        triggerMouseButton.fixedCGEventType(of: .otherMouseDragged)
     }
 
-    private func isOurButtonEvent(_ event: CGEvent) -> Bool {
-        let mouseEventView = MouseEventView(event)
-        guard let eventButton = mouseEventView.mouseButton else {
+    private func matchesTriggerButton(_ event: CGEvent) -> Bool {
+        guard let eventButton = MouseEventView(event).mouseButton else {
             return false
         }
-        return eventButton == button
+        return eventButton == triggerMouseButton
+    }
+
+    private func matchesActivationTrigger(_ event: CGEvent) -> Bool {
+        guard matchesTriggerButton(event) else {
+            return false
+        }
+        return trigger.matches(modifierFlags: event.flags)
     }
 
     private func handleButtonDown(_ event: CGEvent) -> CGEvent? {
-        guard isOurButtonEvent(event) else {
+        guard matchesActivationTrigger(event) else {
             return event
         }
 
@@ -117,8 +119,16 @@ extension GestureButtonTransformer: EventTransformer {
             return event
         }
 
-        guard isOurButtonEvent(event) else {
-            return event
+        let isMouseMoved = event.type == .mouseMoved
+
+        // For drag events, verify button match.
+        // mouseMoved events don't carry a button number but are used to track
+        // movement when the trigger is a Logitech HID++ control (which generates
+        // synthetic button events that don't produce OS-level drag events).
+        if !isMouseMoved {
+            guard matchesTriggerButton(event) else {
+                return event
+            }
         }
 
         // Accumulate deltas
@@ -156,19 +166,19 @@ extension GestureButtonTransformer: EventTransformer {
                 state = .idle
             }
 
-            // Consume the drag event
+            // Consume the event
             return nil
         }
 
         // Update state with new deltas
         state = .tracking(startTime: startTime, deltaX: deltaX, deltaY: deltaY)
 
-        // Consume the drag event while tracking
-        return nil
+        // Consume drag events while tracking; pass through mouseMoved events
+        return isMouseMoved ? event : nil
     }
 
     private func handleButtonUp(_ event: CGEvent) -> CGEvent? {
-        guard isOurButtonEvent(event) else {
+        guard matchesTriggerButton(event) else {
             return event
         }
 
@@ -264,6 +274,38 @@ extension GestureButtonTransformer: EventTransformer {
         case .launchpad:
             launchpad()
         }
+    }
+}
+
+extension GestureButtonTransformer {
+    func handleLogitechControlEvent(_ context: ButtonActionsTransformer.LogitechEventContext) -> Bool {
+        guard let triggerLogitechControl = trigger.button?.logitechControl,
+              context.controlIdentity.matches(triggerLogitechControl),
+              trigger.matches(modifierFlags: context.modifierFlags) else {
+            return false
+        }
+
+        // Check cooldown
+        if case let .cooldown(until) = state {
+            if DispatchTime.now().uptimeNanoseconds < until {
+                return true
+            }
+            state = .idle
+        }
+
+        if context.isPressed {
+            state = .tracking(startTime: DispatchTime.now().uptimeNanoseconds, deltaX: 0, deltaY: 0)
+            os_log("Started tracking gesture (Logitech control)", log: Self.log, type: .info)
+        } else {
+            if case .tracking = state {
+                state = .idle
+            }
+            if case .cooldown = state {
+                return true
+            }
+        }
+
+        return true
     }
 }
 

--- a/LinearMouse/EventTransformer/GestureButtonTransformer.swift
+++ b/LinearMouse/EventTransformer/GestureButtonTransformer.swift
@@ -278,34 +278,43 @@ extension GestureButtonTransformer: EventTransformer {
 }
 
 extension GestureButtonTransformer {
-    func handleLogitechControlEvent(_ context: ButtonActionsTransformer.LogitechEventContext) -> Bool {
+    func handleLogitechControlEvent(_ context: LogitechEventContext) -> Bool {
         guard let triggerLogitechControl = trigger.button?.logitechControl,
-              context.controlIdentity.matches(triggerLogitechControl),
-              trigger.matches(modifierFlags: context.modifierFlags) else {
+              context.controlIdentity.matches(triggerLogitechControl) else {
             return false
         }
 
+        DispatchQueue.main.async { [self] in
+            handleLogitechControlEventOnMain(context)
+        }
+        return true
+    }
+
+    private func handleLogitechControlEventOnMain(_ context: LogitechEventContext) {
         // Check cooldown
         if case let .cooldown(until) = state {
             if DispatchTime.now().uptimeNanoseconds < until {
-                return true
+                return
             }
             state = .idle
         }
 
         if context.isPressed {
+            guard trigger.matches(modifierFlags: context.modifierFlags) else {
+                return
+            }
             state = .tracking(startTime: DispatchTime.now().uptimeNanoseconds, deltaX: 0, deltaY: 0)
             os_log("Started tracking gesture (Logitech control)", log: Self.log, type: .info)
         } else {
-            if case .tracking = state {
+            switch state {
+            case .tracking:
                 state = .idle
-            }
-            if case .cooldown = state {
-                return true
+            case .cooldown:
+                break
+            default:
+                break
             }
         }
-
-        return true
     }
 }
 

--- a/LinearMouse/EventTransformer/LogitechEventContext.swift
+++ b/LinearMouse/EventTransformer/LogitechEventContext.swift
@@ -1,0 +1,13 @@
+// MIT License
+// Copyright (c) 2021-2026 LinearMouse
+
+import Foundation
+
+struct LogitechEventContext {
+    let device: Device?
+    let pid: pid_t?
+    let display: String?
+    let controlIdentity: LogitechControlIdentity
+    let isPressed: Bool
+    let modifierFlags: CGEventFlags
+}

--- a/LinearMouse/Localizable.xcstrings
+++ b/LinearMouse/Localizable.xcstrings
@@ -11087,6 +11087,7 @@
     },
     "Button" : {
       "comment" : "Generic singular UI label for choosing a mouse button trigger.",
+      "extractionState" : "stale",
       "localizations" : {
         "af" : {
           "stringUnit" : {
@@ -30253,6 +30254,7 @@
       }
     },
     "Middle Button" : {
+      "extractionState" : "stale",
       "localizations" : {
         "af" : {
           "stringUnit" : {

--- a/LinearMouse/Model/Configuration/Scheme/Buttons/Gesture/Gesture.swift
+++ b/LinearMouse/Model/Configuration/Scheme/Buttons/Gesture/Gesture.swift
@@ -4,9 +4,9 @@
 import Foundation
 
 extension Scheme.Buttons {
-    struct Gesture: Codable, Equatable, ImplicitInitable {
+    struct Gesture: Equatable, ImplicitInitable {
         var enabled: Bool?
-        var button: Int?
+        var trigger: Mapping?
         var threshold: Int?
         var deadZone: Int?
         var cooldownMs: Int?
@@ -33,5 +33,44 @@ extension Scheme.Buttons {
             case showDesktop
             case launchpad
         }
+    }
+}
+
+extension Scheme.Buttons.Gesture: Codable {
+    private enum CodingKeys: String, CodingKey {
+        case enabled
+        case trigger
+        case button
+        case threshold
+        case deadZone
+        case cooldownMs
+        case actions
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        enabled = try container.decodeIfPresent(Bool.self, forKey: .enabled)
+        trigger = try container.decodeIfPresent(Scheme.Buttons.Mapping.self, forKey: .trigger)
+        threshold = try container.decodeIfPresent(Int.self, forKey: .threshold)
+        deadZone = try container.decodeIfPresent(Int.self, forKey: .deadZone)
+        cooldownMs = try container.decodeIfPresent(Int.self, forKey: .cooldownMs)
+        _actions = try container.decodeIfPresent(ImplicitOptional<Actions>.self, forKey: .actions) ?? .init()
+
+        // Migrate legacy "button" field to "trigger"
+        if trigger == nil, let button = try container.decodeIfPresent(Int.self, forKey: .button) {
+            var mapping = Scheme.Buttons.Mapping()
+            mapping.button = .mouse(button)
+            trigger = mapping
+        }
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(enabled, forKey: .enabled)
+        try container.encodeIfPresent(trigger, forKey: .trigger)
+        try container.encodeIfPresent(threshold, forKey: .threshold)
+        try container.encodeIfPresent(deadZone, forKey: .deadZone)
+        try container.encodeIfPresent(cooldownMs, forKey: .cooldownMs)
+        try container.encodeIfPresent($actions, forKey: .actions)
     }
 }

--- a/LinearMouse/UI/ButtonsSettings/ButtonsSettingsState.swift
+++ b/LinearMouse/UI/ButtonsSettings/ButtonsSettingsState.swift
@@ -114,7 +114,7 @@ extension ButtonsSettingsState {
 
     var autoScrollEnabled: Bool {
         get {
-            mergedScheme.buttons.autoScroll.enabled ?? false
+            mergedScheme.buttons.autoScroll.enabled ?? true
         }
         set {
             guard newValue != autoScrollEnabled else {
@@ -252,32 +252,76 @@ extension ButtonsSettingsState {
         mappings = (mappings + [mapping]).sorted()
     }
 
+    private var defaultGestureTrigger: Scheme.Buttons.Mapping {
+        var mapping = Scheme.Buttons.Mapping()
+        mapping.button = .mouse(Int(CGMouseButton.center.rawValue))
+        return mapping
+    }
+
     var gestureEnabled: Bool {
         get {
-            mergedScheme.buttons.gesture.enabled ?? false
+            mergedScheme.buttons.gesture.enabled ?? true
         }
         set {
+            guard newValue != gestureEnabled else {
+                return
+            }
+
             if newValue {
                 scheme.buttons.gesture.enabled = true
-                scheme.buttons.gesture.button = 2
-                scheme.buttons.gesture.threshold = 50
-                scheme.buttons.gesture.actions.left = .spaceLeft
-                scheme.buttons.gesture.actions.right = .spaceRight
-                scheme.buttons.gesture.actions.up = .missionControl
-                scheme.buttons.gesture.actions.down = .appExpose
+                if scheme.buttons.gesture.trigger == nil {
+                    scheme.buttons.gesture.trigger = defaultGestureTrigger
+                }
+                if scheme.buttons.gesture.threshold == nil {
+                    scheme.buttons.gesture.threshold = 50
+                }
+                if scheme.buttons.gesture.actions.left == nil {
+                    scheme.buttons.gesture.actions.left = .spaceLeft
+                }
+                if scheme.buttons.gesture.actions.right == nil {
+                    scheme.buttons.gesture.actions.right = .spaceRight
+                }
+                if scheme.buttons.gesture.actions.up == nil {
+                    scheme.buttons.gesture.actions.up = .missionControl
+                }
+                if scheme.buttons.gesture.actions.down == nil {
+                    scheme.buttons.gesture.actions.down = .appExpose
+                }
             } else {
-                scheme.buttons.$gesture = nil
+                scheme.buttons.gesture.enabled = false
             }
+
+            GlobalEventTap.shared.stop()
+            GlobalEventTap.shared.start()
         }
     }
 
-    var gestureButton: Int {
+    var gestureTrigger: Scheme.Buttons.Mapping {
         get {
-            mergedScheme.buttons.gesture.button ?? 2
+            mergedScheme.buttons.gesture.trigger ?? defaultGestureTrigger
         }
         set {
-            scheme.buttons.gesture.button = newValue
+            var trigger = newValue
+            trigger.action = nil
+            trigger.repeat = nil
+            trigger.scroll = nil
+            scheme.buttons.gesture.trigger = trigger
         }
+    }
+
+    var gestureTriggerBinding: Binding<Scheme.Buttons.Mapping> {
+        Binding(
+            get: { [self] in
+                gestureTrigger
+            },
+            set: { [self] in
+                gestureTrigger = $0
+            }
+        )
+    }
+
+    var gestureTriggerValid: Bool {
+        gestureTrigger.valid
     }
 
     var gestureThreshold: Int {

--- a/LinearMouse/UI/ButtonsSettings/ButtonsSettingsState.swift
+++ b/LinearMouse/UI/ButtonsSettings/ButtonsSettingsState.swift
@@ -114,7 +114,7 @@ extension ButtonsSettingsState {
 
     var autoScrollEnabled: Bool {
         get {
-            mergedScheme.buttons.autoScroll.enabled ?? true
+            mergedScheme.buttons.autoScroll.enabled ?? false
         }
         set {
             guard newValue != autoScrollEnabled else {
@@ -260,7 +260,7 @@ extension ButtonsSettingsState {
 
     var gestureEnabled: Bool {
         get {
-            mergedScheme.buttons.gesture.enabled ?? true
+            mergedScheme.buttons.gesture.enabled ?? false
         }
         set {
             guard newValue != gestureEnabled else {

--- a/LinearMouse/UI/ButtonsSettings/GestureButtonSection/GestureButtonSection.swift
+++ b/LinearMouse/UI/ButtonsSettings/GestureButtonSection/GestureButtonSection.swift
@@ -23,12 +23,21 @@ struct GestureButtonSection: View {
                 }
 
                 if state.gestureEnabled {
-                    Picker("Button", selection: $state.gestureButton) {
-                        Text("Middle Button").tag(2)
-//                    Text("Back Button").tag(3)
-//                    Text("Forward Button").tag(4)
+                    VStack(alignment: .leading, spacing: 8) {
+                        Text("Trigger")
+                            .font(.headline)
+
+                        ButtonMappingButtonRecorder(
+                            mapping: state.gestureTriggerBinding
+                        )
+
+                        if !state.gestureTriggerValid {
+                            Text("Choose a mouse button trigger. Left click without modifier keys is not allowed.")
+                                .foregroundColor(.red)
+                                .controlSize(.small)
+                                .fixedSize(horizontal: false, vertical: true)
+                        }
                     }
-                    .modifier(PickerViewModifier())
 
                     VStack(alignment: .leading, spacing: 4) {
                         HStack {

--- a/LinearMouseUnitTests/Model/Scheme/Buttons/GestureTests.swift
+++ b/LinearMouseUnitTests/Model/Scheme/Buttons/GestureTests.swift
@@ -1,0 +1,136 @@
+// MIT License
+// Copyright (c) 2021-2026 LinearMouse
+
+@testable import LinearMouse
+import XCTest
+
+final class GestureTests: XCTestCase {
+    // MARK: - Legacy "button" → "trigger" migration
+
+    func testDecodeLegacyButtonField() throws {
+        let gesture = try JSONDecoder().decode(
+            Scheme.Buttons.Gesture.self,
+            from: XCTUnwrap(#"{"button":2,"threshold":60}"#.data(using: .utf8))
+        )
+
+        XCTAssertEqual(gesture.trigger?.button, .mouse(2))
+        XCTAssertEqual(gesture.threshold, 60)
+    }
+
+    func testDecodeLegacyButtonFieldWithEnabledTrue() throws {
+        let gesture = try JSONDecoder().decode(
+            Scheme.Buttons.Gesture.self,
+            from: XCTUnwrap(#"{"enabled":true,"button":2}"#.data(using: .utf8))
+        )
+
+        XCTAssertEqual(gesture.trigger?.button, .mouse(2))
+    }
+
+    func testDecodeLegacyButtonFieldWithEnabledFalse() throws {
+        let gesture = try JSONDecoder().decode(
+            Scheme.Buttons.Gesture.self,
+            from: XCTUnwrap(#"{"enabled":false,"button":2}"#.data(using: .utf8))
+        )
+
+        XCTAssertEqual(gesture.enabled, false)
+        XCTAssertEqual(gesture.trigger?.button, .mouse(2), "button should still migrate even when disabled")
+    }
+
+    func testDecodeLegacyEnabledFalseWithTrigger() throws {
+        let gesture = try JSONDecoder().decode(
+            Scheme.Buttons.Gesture.self,
+            from: XCTUnwrap(
+                #"{"enabled":false,"trigger":{"button":2}}"#.data(using: .utf8)
+            )
+        )
+
+        XCTAssertEqual(gesture.enabled, false)
+        XCTAssertNotNil(gesture.trigger, "trigger should be preserved even when disabled")
+    }
+
+    func testDecodeTriggerTakesPriorityOverLegacyButton() throws {
+        let gesture = try JSONDecoder().decode(
+            Scheme.Buttons.Gesture.self,
+            from: XCTUnwrap(
+                #"{"button":3,"trigger":{"button":4}}"#.data(using: .utf8)
+            )
+        )
+
+        XCTAssertEqual(gesture.trigger?.button, .mouse(4), "trigger should take priority over legacy button")
+    }
+
+    func testDecodeNeitherButtonNorTrigger() throws {
+        let gesture = try JSONDecoder().decode(
+            Scheme.Buttons.Gesture.self,
+            from: XCTUnwrap(#"{"threshold":80}"#.data(using: .utf8))
+        )
+
+        XCTAssertNil(gesture.trigger)
+        XCTAssertEqual(gesture.threshold, 80)
+    }
+
+    // MARK: - Encoding
+
+    func testEncodeWritesEnabledButNotLegacyButton() throws {
+        var gesture = Scheme.Buttons.Gesture()
+        gesture.enabled = true
+        var mapping = Scheme.Buttons.Mapping()
+        mapping.button = .mouse(2)
+        gesture.trigger = mapping
+        gesture.threshold = 50
+
+        let data = try JSONEncoder().encode(gesture)
+        let jsonObject = try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: Any])
+
+        XCTAssertEqual(jsonObject["enabled"] as? Bool, true)
+        XCTAssertNil(jsonObject["button"], "legacy button should not be encoded")
+        XCTAssertNotNil(jsonObject["trigger"])
+        XCTAssertEqual(jsonObject["threshold"] as? Int, 50)
+    }
+
+    // MARK: - Round-trip
+
+    func testRoundTrip() throws {
+        var gesture = Scheme.Buttons.Gesture()
+        var mapping = Scheme.Buttons.Mapping()
+        mapping.button = .mouse(3)
+        mapping.shift = true
+        gesture.trigger = mapping
+        gesture.threshold = 70
+        gesture.deadZone = 30
+        gesture.cooldownMs = 300
+        gesture.actions.left = .spaceLeft
+        gesture.actions.right = .spaceRight
+
+        let data = try JSONEncoder().encode(gesture)
+        let decoded = try JSONDecoder().decode(Scheme.Buttons.Gesture.self, from: data)
+
+        XCTAssertEqual(decoded.trigger?.button, .mouse(3))
+        XCTAssertEqual(decoded.trigger?.modifierFlags.contains(.maskShift), true)
+        XCTAssertEqual(decoded.threshold, 70)
+        XCTAssertEqual(decoded.deadZone, 30)
+        XCTAssertEqual(decoded.cooldownMs, 300)
+        XCTAssertEqual(decoded.actions.left, .spaceLeft)
+        XCTAssertEqual(decoded.actions.right, .spaceRight)
+    }
+
+    func testLegacyRoundTripMigrates() throws {
+        // Decode from legacy format
+        let gesture = try JSONDecoder().decode(
+            Scheme.Buttons.Gesture.self,
+            from: XCTUnwrap(#"{"enabled":true,"button":2,"threshold":50}"#.data(using: .utf8))
+        )
+
+        // Encode (should write enabled+trigger, not legacy button)
+        let data = try JSONEncoder().encode(gesture)
+        let jsonObject = try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: Any])
+        XCTAssertEqual(jsonObject["enabled"] as? Bool, true)
+        XCTAssertNil(jsonObject["button"])
+        XCTAssertNotNil(jsonObject["trigger"])
+
+        // Re-decode
+        let decoded = try JSONDecoder().decode(Scheme.Buttons.Gesture.self, from: data)
+        XCTAssertEqual(decoded.trigger?.button, .mouse(2))
+        XCTAssertEqual(decoded.threshold, 50)
+    }
+}


### PR DESCRIPTION
## Summary

- **Gesture trigger refactor**: Replace hardcoded middle-button Picker with a recording interface (`ButtonMappingButtonRecorder`) supporting any mouse button + modifier key combination. Migrates `button: Int` to `trigger: Mapping` with backwards-compatible Codable (legacy `button` field auto-migrates).
- **Logitech HID++ support**: Logitech reprogrammable control buttons now work as gesture and auto-scroll triggers via direct HID++ event routing. Adds gesture control IDs to the diversion whitelist.
- **Native control ID exclusion**: Left/right/middle mouse button CIDs (0x0050–0x0052) are excluded from HID++ diversion alongside back/forward, preventing breakage of OS-handled buttons.
- **Multi-display fix**: Logitech control event handler now resolves PID from the window under the mouse cursor (matching `GlobalEventTap` behavior) instead of the frontmost application, fixing gesture/auto-scroll triggers when focus and cursor are on different displays.
- **Thread safety**: Logitech `handleLogitechControlEvent` in both `AutoScrollTransformer` and `GestureButtonTransformer` now dispatches all state mutations to the main thread, fixing a data race with the CGEvent tap callback.
- **Modifier check fix**: `GestureButtonTransformer` Logitech handler only checks modifier flags on button press (not release), preventing stuck tracking state when modifier is released before the button.
- **Schema backwards compat**: Deprecated `button` field retained in JSON schema so old configs validate. `enabled` field preserved with `?? false` default.
- **Code quality**: `LogitechEventContext` promoted to standalone type. Logitech dispatch order aligned with transformer construction order. `desiredDivertedControlIDs` uses `mouseLocationPid`.
- **Disable preserves config**: Disabling gesture sets `enabled = false` instead of wiping the configuration.

## Test plan

- [x] 142 unit tests pass (including 9 new Gesture Codable migration tests)
- [x] Verify gesture trigger works with middle button, side buttons, and modifier combos
- [x] Verify Logitech reprogrammable control button as gesture trigger (single and multi-display)
- [x] Verify Logitech control button as auto-scroll trigger
- [x] Verify native mouse buttons (left/right/middle/back/forward) are not broken by HID++ diversion
- [ ] Verify legacy configs with `"button": 2` migrate correctly
- [ ] Verify disabling and re-enabling gesture preserves trigger/threshold/actions