### PR TITLE
Fix gesture button not releasing trigger, causing stuck drag

### DIFF
--- a/LinearMouse/EventTransformer/ButtonActionsTransformer.swift
+++ b/LinearMouse/EventTransformer/ButtonActionsTransformer.swift
@@ -81,6 +81,10 @@ extension ButtonActionsTransformer: EventTransformer, LogitechControlEventHandli
             return event
         }
 
+        if event.isGestureCleanupRelease {
+            return event
+        }
+
         guard !SettingsState.shared.recording else {
             return event
         }

--- a/LinearMouse/EventTransformer/GestureButtonTransformer.swift
+++ b/LinearMouse/EventTransformer/GestureButtonTransformer.swift
@@ -258,7 +258,6 @@ extension GestureButtonTransformer: EventTransformer {
         return deltaY > 0 ? (actions.down ?? .appExpose) : (actions.up ?? .missionControl)
     }
 
-
     private func executeGesture(_ action: Scheme.Buttons.Gesture.GestureAction) throws {
         switch action {
         case .none:

--- a/LinearMouse/EventTransformer/GestureButtonTransformer.swift
+++ b/LinearMouse/EventTransformer/GestureButtonTransformer.swift
@@ -23,7 +23,7 @@ class GestureButtonTransformer {
         case idle
         case tracking(startTime: UInt64, deltaX: Double, deltaY: Double)
         case triggered
-        case cooldown(until: UInt64)
+        case cooldown(until: UInt64, released: Bool)
     }
 
     private var state: State = .idle
@@ -48,22 +48,18 @@ class GestureButtonTransformer {
 
 extension GestureButtonTransformer: EventTransformer {
     func transform(_ event: CGEvent) -> CGEvent? {
-        if event.isLinearMouseSyntheticEvent {
-            return event
-        }
-
         // Check if we're in cooldown
-        if case let .cooldown(until) = state {
+        if case let .cooldown(until, released) = state {
             if DispatchTime.now().uptimeNanoseconds < until {
                 // Still in cooldown - consume our button events
                 if matchesTriggerButton(event) {
-                    if event.type == mouseUpEventType {
+                    if event.type == mouseUpEventType, !released {
                         os_log("Releasing trigger button during cooldown", log: Self.log, type: .debug)
-                        releaseTriggerButton(from: event)
-                        state = .idle
-                    } else {
-                        os_log("Event consumed during cooldown", log: Self.log, type: .debug)
+                        state = .cooldown(until: until, released: true)
+                        event.isGestureCleanupRelease = true
+                        return event
                     }
+                    os_log("Event consumed during cooldown", log: Self.log, type: .debug)
                     return nil
                 }
                 return event
@@ -168,7 +164,7 @@ extension GestureButtonTransformer: EventTransformer {
 
                 // Enter cooldown
                 let cooldownNanos = UInt64(cooldownMs) * 1_000_000
-                state = .cooldown(until: DispatchTime.now().uptimeNanoseconds + cooldownNanos)
+                state = .cooldown(until: DispatchTime.now().uptimeNanoseconds + cooldownNanos, released: false)
 
                 os_log("Entering cooldown for %d ms", log: Self.log, type: .info, cooldownMs)
             } catch {
@@ -200,12 +196,12 @@ extension GestureButtonTransformer: EventTransformer {
             return event
         }
 
-        // If we triggered, stay in cooldown and consume the event
+        // If we triggered, enter cooldown and pass the release through
         if case .triggered = state {
-            releaseTriggerButton(from: event)
             let cooldownNanos = UInt64(cooldownMs) * 1_000_000
-            state = .cooldown(until: DispatchTime.now().uptimeNanoseconds + cooldownNanos)
-            return nil
+            state = .cooldown(until: DispatchTime.now().uptimeNanoseconds + cooldownNanos, released: true)
+            event.isGestureCleanupRelease = true
+            return event
         }
 
         return event
@@ -262,19 +258,6 @@ extension GestureButtonTransformer: EventTransformer {
         return deltaY > 0 ? (actions.down ?? .appExpose) : (actions.up ?? .missionControl)
     }
 
-    private func releaseTriggerButton(from event: CGEvent) {
-        guard let mouseUpEvent = CGEvent(
-            mouseEventSource: nil,
-            mouseType: mouseUpEventType,
-            mouseCursorPosition: event.location,
-            mouseButton: triggerMouseButton
-        ) else {
-            return
-        }
-        mouseUpEvent.flags = event.flags
-        mouseUpEvent.isLinearMouseSyntheticEvent = true
-        mouseUpEvent.post(tap: .cgSessionEventTap)
-    }
 
     private func executeGesture(_ action: Scheme.Buttons.Gesture.GestureAction) throws {
         switch action {
@@ -309,7 +292,7 @@ extension GestureButtonTransformer: LogitechControlEventHandling {
             return false
         }
 
-        if case let .cooldown(until) = state {
+        if case let .cooldown(until, _) = state {
             if DispatchTime.now().uptimeNanoseconds < until {
                 return true
             }

--- a/LinearMouse/EventTransformer/GestureButtonTransformer.swift
+++ b/LinearMouse/EventTransformer/GestureButtonTransformer.swift
@@ -48,12 +48,22 @@ class GestureButtonTransformer {
 
 extension GestureButtonTransformer: EventTransformer {
     func transform(_ event: CGEvent) -> CGEvent? {
+        if event.isLinearMouseSyntheticEvent {
+            return event
+        }
+
         // Check if we're in cooldown
         if case let .cooldown(until) = state {
             if DispatchTime.now().uptimeNanoseconds < until {
                 // Still in cooldown - consume our button events
                 if matchesTriggerButton(event) {
-//                    os_log("Event consumed during cooldown", log: Self.log, type: .debug)
+                    if event.type == mouseUpEventType {
+                        os_log("Releasing trigger button during cooldown", log: Self.log, type: .debug)
+                        releaseTriggerButton(from: event)
+                        state = .idle
+                    } else {
+                        os_log("Event consumed during cooldown", log: Self.log, type: .debug)
+                    }
                     return nil
                 }
                 return event
@@ -192,6 +202,7 @@ extension GestureButtonTransformer: EventTransformer {
 
         // If we triggered, stay in cooldown and consume the event
         if case .triggered = state {
+            releaseTriggerButton(from: event)
             let cooldownNanos = UInt64(cooldownMs) * 1_000_000
             state = .cooldown(until: DispatchTime.now().uptimeNanoseconds + cooldownNanos)
             return nil
@@ -249,6 +260,20 @@ extension GestureButtonTransformer: EventTransformer {
         }
         // Use defaults if actions not configured
         return deltaY > 0 ? (actions.down ?? .appExpose) : (actions.up ?? .missionControl)
+    }
+
+    private func releaseTriggerButton(from event: CGEvent) {
+        guard let mouseUpEvent = CGEvent(
+            mouseEventSource: nil,
+            mouseType: mouseUpEventType,
+            mouseCursorPosition: event.location,
+            mouseButton: triggerMouseButton
+        ) else {
+            return
+        }
+        mouseUpEvent.flags = event.flags
+        mouseUpEvent.isLinearMouseSyntheticEvent = true
+        mouseUpEvent.post(tap: .cgSessionEventTap)
     }
 
     private func executeGesture(_ action: Scheme.Buttons.Gesture.GestureAction) throws {

--- a/LinearMouse/EventTransformer/UniversalBackForwardTransformer.swift
+++ b/LinearMouse/EventTransformer/UniversalBackForwardTransformer.swift
@@ -113,6 +113,10 @@ class UniversalBackForwardTransformer: EventTransformer {
     }
 
     func transform(_ event: CGEvent) -> CGEvent? {
+        if event.isGestureCleanupRelease {
+            return event
+        }
+
         let view = MouseEventView(event)
         guard let mouseButton = view.mouseButton else {
             return event

--- a/LinearMouse/Utilities/CGEvent+LinearMouseSynthetic.swift
+++ b/LinearMouse/Utilities/CGEvent+LinearMouseSynthetic.swift
@@ -117,6 +117,7 @@ extension LogitechControlIdentity {
 
 extension CGEvent {
     private static let linearMouseSyntheticEventUserData: Int64 = 0x534D_4F4F_5448
+    private static let gestureCleanupReleaseUserData: Int64 = 0x4745_5354_5552
 
     var isLinearMouseSyntheticEvent: Bool {
         get {
@@ -126,6 +127,18 @@ extension CGEvent {
             setIntegerValueField(
                 .eventSourceUserData,
                 value: newValue ? Self.linearMouseSyntheticEventUserData : 0
+            )
+        }
+    }
+
+    var isGestureCleanupRelease: Bool {
+        get {
+            getIntegerValueField(.eventSourceUserData) == Self.gestureCleanupReleaseUserData
+        }
+        set {
+            setIntegerValueField(
+                .eventSourceUserData,
+                value: newValue ? Self.gestureCleanupReleaseUserData : 0
             )
         }
     }


### PR DESCRIPTION
## Problem

Fixes #1138

After a gesture fires (e.g., Mission Control swipe), the trigger button's `mouseUp` event is consumed during cooldown but no release is ever posted. This leaves macOS believing the button is permanently pressed, causing:

- **Stuck dragging** in apps like Todoist
- **Persistent right-click menus** if right-click is the trigger  
- **Continuous scrolling** or other unwanted behavior
- Quitting LinearMouse immediately resolves the issue

Reproduced with Logitech MX Master 3 on macOS 26.x, but affects any mouse using the gesture button feature.

## Root Cause

The state machine in `GestureButtonTransformer` has an asymmetry between mouseDown and mouseUp handling:

1. `handleButtonDown` **passes mouseDown through** to the app → app sees "button pressed"
2. `handleDragged` consumes drag events while tracking gesture movement
3. Gesture threshold met → gesture executes → state enters `.cooldown`
4. User releases button → **cooldown guard consumes mouseUp** (`return nil`)
5. `handleButtonUp` is **never reached**
6. App never sees the button release → **button stuck**

## Fix

Tag and return the **original** mouseUp event from `transform()` instead of consuming it or creating a new event.

### Key design decisions

**Tag original event, don't create a new one:** The initial approach (commit `22fe756`) used `releaseTriggerButton()` to create a new `CGEvent` and post it via `CGEvent.post()`. Review feedback identified two problems: (1) the `isLinearMouseSyntheticEvent` guard needed to prevent re-entrance was too broad, and (2) creating new events risks the `Unmanaged.passUnretained` use-after-free fixed in #1143. This commit tags the original event (which the framework already retains) with `isGestureCleanupRelease` and returns it directly — no re-entrance possible, no ownership issues.

**Preserve cooldown on release:** The cooldown state now tracks `released: Bool` instead of resetting to `.idle` on mouseUp. This preserves the full cooldown window so rapid re-presses are still suppressed.

**Dedicated cleanup flag:** The returned mouseUp flows through the transformer pipeline into `ButtonActionsTransformer` and `UniversalBackForwardTransformer`. Without protection, a completed gesture on a shared trigger button would also fire the mapped action on release. A dedicated `isGestureCleanupRelease` flag (separate from the generic `isLinearMouseSyntheticEvent`) lets those transformers pass the event through without firing actions.

## Changes

- **`GestureButtonTransformer.swift`**: Remove `isLinearMouseSyntheticEvent` guard. Return original mouseUp tagged with `isGestureCleanupRelease` instead of creating a new event. Track `released` in cooldown state. Remove `releaseTriggerButton()` method.
- **`CGEvent+LinearMouseSynthetic.swift`**: Add `isGestureCleanupRelease` flag with dedicated sentinel value (`0x4745_5354_5552`).
- **`ButtonActionsTransformer.swift`**: Pass through gesture cleanup releases without firing mapped actions.
- **`UniversalBackForwardTransformer.swift`**: Pass through gesture cleanup releases without consuming them.

## Evidence

### Before (broken) — drag fails after gesture

https://github.com/user-attachments/assets/be2c675c-2a81-49cb-9806-0cd7111b37d1

### After (fix) — drag works after gesture

https://github.com/user-attachments/assets/0c095708-2779-4118-969b-848ca28cc150

## Pre-existing issues (not regressions)

These are pre-existing issues with the "shared trigger" case (same button used for both gesture trigger and button mapping) that predate this PR:

- **Modifier-hold cleanup on gesture completion:** When a gesture fires on a button that also has a modifier-hold mapping, `keySimulator.up()` is never called because the mouseUp was consumed during cooldown (even before this PR). This leaves modifier keys stuck.

- **Repeat timer cleanup:** Similarly, repeat-enabled mappings sharing the gesture trigger don't get their timer invalidated on gesture completion.

- **UniversalBackForward conflict on mouseDown:** If a back/forward button is used as a gesture trigger with `universalBackForward` enabled, the mouseDown still fires a navigation swipe immediately (before gesture tracking begins).

- **Dead `.triggered` state:** The `.triggered` state is set and immediately overwritten by `.cooldown` in the same synchronous call, so `handleButtonUp` never observes it. Could be removed as cleanup.

## Test plan

- [x] Enable gesture button with middle button as trigger
- [x] Perform a gesture (hold trigger + swipe up for Mission Control)
- [x] Verify trigger button is released after the gesture completes
- [x] Verify drag operations work in apps after performing a gesture
- [x] Verify gestures still fire correctly after multiple uses (no use-after-free)
- [x] Verify cooldown still prevents accidental re-triggers
- [x] Verify normal click behavior when gesture doesn't fire (release before threshold)
- [ ] Test with Logitech MX Master 3 using HID++ diverted gesture button
- [ ] If using a Kensington Slimblade or generic side-button mouse, verify gesture triggers still work (synthetic button source)