### PR TITLE
Fix event tap use-after-free when callback returns a copied CGEvent

### DIFF
--- a/LinearMouse/EventTap/EventTap.swift
+++ b/LinearMouse/EventTap/EventTap.swift
@@ -46,13 +46,19 @@ extension EventTap {
             return Unmanaged.passUnretained(event)
 
         default:
+            let originalEvent = event
+
             // If the callback returns nil, ignore the event.
             guard let event = callback(proxy, event) else {
                 return nil
             }
 
-            // Or, return the event reference.
-            return Unmanaged.passUnretained(event)
+            // If the callback returns a different event (e.g. a copy),
+            // use passRetained to transfer ownership to the caller.
+            if event === originalEvent {
+                return Unmanaged.passUnretained(event)
+            }
+            return Unmanaged.passRetained(event)
         }
     }
 
@@ -94,9 +100,24 @@ extension EventTap {
         let cfRunLoop = runLoop.getCFRunLoop()
         CFRunLoopAddSource(cfRunLoop, runLoopSource, .commonModes)
 
+        // Periodically check if the tap is still enabled and re-enable it if needed.
+        // This recovers from cases where the system silently disables the tap
+        // (e.g. due to an invalid event or other transient errors).
+        let healthCheckTimer = Timer(timeInterval: 5, repeats: true) { _ in
+            guard CFMachPortIsValid(tap) else {
+                return
+            }
+            if !CGEvent.tapIsEnabled(tap: tap) {
+                os_log("EventTap found disabled, re-enabling", log: log, type: .error)
+                CGEvent.tapEnable(tap: tap, enable: true)
+            }
+        }
+        runLoop.add(healthCheckTimer, forMode: .common)
+
         return ObservationToken {
             // The lifetime of contextHolder needs to be extended until the observation token is cancelled.
             withExtendedLifetime(contextHolder) {
+                healthCheckTimer.invalidate()
                 CGEvent.tapEnable(tap: tap, enable: false)
                 CFRunLoopRemoveSource(cfRunLoop, runLoopSource, .commonModes)
                 CFMachPortInvalidate(tap)


### PR DESCRIPTION
## Summary

- Fix use-after-free in `EventTap.callbackInvoker` when a transformer returns a copy of the CGEvent instead of the original. `Unmanaged.passUnretained` caused ARC to deallocate the copy before the system could use it, resulting in "Invalid event returned by callback" and the event tap being silently disabled.
- Use `passRetained` when the returned event is a different object (detected via `===`), transferring ownership to the caller per the `CGEventTapCallBack` contract. Keep `passUnretained` for the original event to avoid leaks.
- Add a periodic health check (every 5s) that re-enables the event tap if it is found disabled, as a defensive recovery mechanism.

## Context

When horizontal smoothed scrolling is enabled and a scroll event contains both horizontal and vertical deltas (e.g. M720 Triathlon scroll wheel tilted during fast scrolling), `SmoothedScrollingTransformer` intercepts the horizontal component and returns a `CGEvent.copy()` with the horizontal delta zeroed out. This copy was returned via `passUnretained`, leading to a dangling pointer that macOS detected as invalid, disabling the event tap and breaking all event processing (reverse scrolling, linear scrolling, etc.) until app restart.

## Test plan

- [ ] Fast scroll with a Logitech mouse while slightly tilting the scroll wheel — verify reverse scrolling continues to work
- [ ] Verify horizontal smoothed scrolling still works correctly
- [ ] Verify no memory leaks with Instruments (Leaks template) during extended scrolling
- [ ] Verify event tap recovers after simulated timeout disable