### PR TITLE
Improve Logitech control button reliability and init performance

### DIFF
--- a/LinearMouse/Device/Device.swift
+++ b/LinearMouse/Device/Device.swift
@@ -138,6 +138,10 @@ class Device {
     var hasLogitechControlsMonitor: Bool {
         logitechReprogrammableControlsMonitor != nil
     }
+
+    func requestLogitechControlsForcedReconfiguration() {
+        logitechReprogrammableControlsMonitor?.requestForcedReconfiguration()
+    }
 }
 
 extension Device {

--- a/LinearMouse/Device/DeviceManager.swift
+++ b/LinearMouse/Device/DeviceManager.swift
@@ -416,6 +416,7 @@ class DeviceManager: ObservableObject {
             return
         }
 
+        let previousIdentities = receiverPairedDeviceIdentities[locationID] ?? []
         receiverPairedDeviceIdentities[locationID] = identities
 
         let identitiesDescription = identities.map { identity in
@@ -432,10 +433,15 @@ class DeviceManager: ObservableObject {
             identitiesDescription
         )
 
-        // Notify Logitech control monitors on devices sharing this locationID
-        // to re-divert controls, as device firmware resets diversion on reconnect.
-        for (_, device) in pointerDeviceToDevice where device.pointerDevice.locationID == locationID {
-            device.requestLogitechControlsForcedReconfiguration()
+        // Only trigger forced reconfiguration when a device has actually reconnected
+        // (a slot appeared that wasn't in the previous identity set), since device
+        // firmware resets diversion state on reconnect.
+        let previousSlots = Set(previousIdentities.map(\.slot))
+        let hasReconnectedDevice = identities.contains { !previousSlots.contains($0.slot) }
+        if hasReconnectedDevice {
+            for (_, device) in pointerDeviceToDevice where device.pointerDevice.locationID == locationID {
+                device.requestLogitechControlsForcedReconfiguration()
+            }
         }
     }
 

--- a/LinearMouse/Device/DeviceManager.swift
+++ b/LinearMouse/Device/DeviceManager.swift
@@ -431,6 +431,12 @@ class DeviceManager: ObservableObject {
             locationID,
             identitiesDescription
         )
+
+        // Notify Logitech control monitors on devices sharing this locationID
+        // to re-divert controls, as device firmware resets diversion on reconnect.
+        for (_, device) in pointerDeviceToDevice where device.pointerDevice.locationID == locationID {
+            device.requestLogitechControlsForcedReconfiguration()
+        }
     }
 
     private func refreshVisibleDevices() {

--- a/LinearMouse/Device/VendorSpecific/Logitech/LogitechHIDPPDeviceMetadataProvider.swift
+++ b/LinearMouse/Device/VendorSpecific/Logitech/LogitechHIDPPDeviceMetadataProvider.swift
@@ -897,22 +897,12 @@ final class LogitechReceiverChannel: VendorSpecificDeviceContext {
         let orderedSlots = connectedSlotNumbers + remainingSlots
 
         var pairedSlots = [LogitechHIDPPDeviceMetadataProvider.ReceiverSlotInfo]()
-        var connectedSlotsFound = 0
         for slot in orderedSlots {
             guard let slotInfo = discoverSlotInfo(slot, connectionSnapshot: connectionSnapshots[slot]) else {
-                // Skip remaining unconnected slots if we already found all connected devices
-                if let connectedDeviceCount,
-                   connectedSlotsFound >= connectedDeviceCount,
-                   !connectedSlotNumbers.contains(slot) {
-                    break
-                }
                 continue
             }
 
             pairedSlots.append(slotInfo)
-            if connectedSlotNumbers.contains(slot) {
-                connectedSlotsFound += 1
-            }
 
             os_log(
                 "Receiver slot %u raw candidate: name=%{public}@ kind=%{public}u battery=%{public}@",
@@ -2165,11 +2155,19 @@ final class LogitechReprogrammableControlsMonitor {
         let connectedSlots = Set(discovery.connectionSnapshots.compactMap { slot, snapshot in
             snapshot.isConnected ? slot : nil
         })
-        let candidateSlots: [UInt8] = discovery.identities.isEmpty
-            ? Array(connectedSlots.sorted())
-            : discovery.identities
-            .map(\.slot)
-            .filter { connectedSlots.contains($0) }
+        // Prefer connected slots; fall back to identity slots or all 1...6
+        // when connection snapshots are unavailable.
+        let identitySlots = Array(Set(discovery.identities.map(\.slot))).sorted()
+        let candidateSlots: [UInt8]
+        if !connectedSlots.isEmpty {
+            candidateSlots = identitySlots.isEmpty
+                ? Array(connectedSlots.sorted())
+                : identitySlots.filter { connectedSlots.contains($0) }
+        } else if !identitySlots.isEmpty {
+            candidateSlots = identitySlots
+        } else {
+            candidateSlots = Array(UInt8(1) ... UInt8(6))
+        }
 
         let scannedTargets = candidateSlots.compactMap { slot in
             buildMonitorTarget(

--- a/LinearMouse/Device/VendorSpecific/Logitech/LogitechHIDPPDeviceMetadataProvider.swift
+++ b/LinearMouse/Device/VendorSpecific/Logitech/LogitechHIDPPDeviceMetadataProvider.swift
@@ -2542,6 +2542,9 @@ final class LogitechReprogrammableControlsMonitor {
         maxAttempts: Int = 3,
         retryDelay: TimeInterval = 0.05
     ) -> Bool {
+        guard maxAttempts >= 1 else {
+            return false
+        }
         for attempt in 1 ... maxAttempts {
             if setDiverted(enabled, for: controlID, using: transport, featureIndex: featureIndex) {
                 return true

--- a/LinearMouse/Device/VendorSpecific/Logitech/LogitechHIDPPDeviceMetadataProvider.swift
+++ b/LinearMouse/Device/VendorSpecific/Logitech/LogitechHIDPPDeviceMetadataProvider.swift
@@ -897,11 +897,12 @@ final class LogitechReceiverChannel: VendorSpecificDeviceContext {
         let orderedSlots = connectedSlotNumbers + remainingSlots
 
         var pairedSlots = [LogitechHIDPPDeviceMetadataProvider.ReceiverSlotInfo]()
+        var connectedSlotsFound = 0
         for slot in orderedSlots {
             guard let slotInfo = discoverSlotInfo(slot, connectionSnapshot: connectionSnapshots[slot]) else {
                 // Skip remaining unconnected slots if we already found all connected devices
                 if let connectedDeviceCount,
-                   pairedSlots.count >= connectedDeviceCount,
+                   connectedSlotsFound >= connectedDeviceCount,
                    !connectedSlotNumbers.contains(slot) {
                     break
                 }
@@ -909,6 +910,9 @@ final class LogitechReceiverChannel: VendorSpecificDeviceContext {
             }
 
             pairedSlots.append(slotInfo)
+            if connectedSlotNumbers.contains(slot) {
+                connectedSlotsFound += 1
+            }
 
             os_log(
                 "Receiver slot %u raw candidate: name=%{public}@ kind=%{public}u battery=%{public}@",
@@ -1000,8 +1004,9 @@ final class LogitechReceiverChannel: VendorSpecificDeviceContext {
             guard let report = waitForInputReport(timeout: 0.05, matching: { response in
                 LogitechHIDPPDeviceMetadataProvider.parseReceiverConnectionNotification(Array(response)) != nil
             }) else {
-                // No more notifications pending — if we already have enough snapshots, exit early
-                if let expectedCount, snapshots.count >= expectedCount {
+                // No more notifications pending — if we already have enough connected snapshots, exit early
+                if let expectedCount,
+                   snapshots.values.filter(\.isConnected).count >= expectedCount {
                     break
                 }
                 continue
@@ -1014,8 +1019,9 @@ final class LogitechReceiverChannel: VendorSpecificDeviceContext {
 
             snapshots[notification.slot] = notification.snapshot
 
-            // Exit early once we have all expected device snapshots
-            if let expectedCount, snapshots.count >= expectedCount {
+            // Exit early once we have all expected connected device snapshots
+            if let expectedCount,
+               snapshots.values.filter(\.isConnected).count >= expectedCount {
                 break
             }
         }
@@ -2161,7 +2167,9 @@ final class LogitechReprogrammableControlsMonitor {
         })
         let candidateSlots: [UInt8] = discovery.identities.isEmpty
             ? Array(connectedSlots.sorted())
-            : discovery.identities.map(\.slot)
+            : discovery.identities
+            .map(\.slot)
+            .filter { connectedSlots.contains($0) }
 
         let scannedTargets = candidateSlots.compactMap { slot in
             buildMonitorTarget(

--- a/LinearMouse/Device/VendorSpecific/Logitech/LogitechHIDPPDeviceMetadataProvider.swift
+++ b/LinearMouse/Device/VendorSpecific/Logitech/LogitechHIDPPDeviceMetadataProvider.swift
@@ -866,7 +866,7 @@ final class LogitechReceiverChannel: VendorSpecificDeviceContext {
         let connectedDeviceCount = readConnectionState().flatMap { response in
             LogitechHIDPPDeviceMetadataProvider.parseConnectedDeviceCount(response)
         }
-        let connectionSnapshots = discoverConnectionSnapshots()
+        let connectionSnapshots = discoverConnectionSnapshots(expectedCount: connectedDeviceCount)
         let snapshotSummary = connectionSnapshots.keys
             .sorted()
             .compactMap { slot -> String? in
@@ -888,15 +888,23 @@ final class LogitechReceiverChannel: VendorSpecificDeviceContext {
             snapshotSummary
         )
 
+        // Prioritize slots known to be connected, then scan remaining slots
+        let connectedSlotNumbers = connectionSnapshots
+            .filter(\.value.isConnected)
+            .map(\.key)
+            .sorted()
+        let remainingSlots = (UInt8(1) ... UInt8(6)).filter { !connectedSlotNumbers.contains($0) }
+        let orderedSlots = connectedSlotNumbers + remainingSlots
+
         var pairedSlots = [LogitechHIDPPDeviceMetadataProvider.ReceiverSlotInfo]()
-        for slot in UInt8(1) ... UInt8(6) {
+        for slot in orderedSlots {
             guard let slotInfo = discoverSlotInfo(slot, connectionSnapshot: connectionSnapshots[slot]) else {
-                os_log(
-                    "Receiver slot %u has no pairing or name response",
-                    log: LogitechHIDPPDeviceMetadataProvider.log,
-                    type: .info,
-                    slot
-                )
+                // Skip remaining unconnected slots if we already found all connected devices
+                if let connectedDeviceCount,
+                   pairedSlots.count >= connectedDeviceCount,
+                   !connectedSlotNumbers.contains(slot) {
+                    break
+                }
                 continue
             }
 
@@ -979,8 +987,9 @@ final class LogitechReceiverChannel: VendorSpecificDeviceContext {
         )
     }
 
-    private func discoverConnectionSnapshots()
-        -> [UInt8: LogitechHIDPPDeviceMetadataProvider.ReceiverConnectionSnapshot] {
+    private func discoverConnectionSnapshots(
+        expectedCount: Int? = nil
+    ) -> [UInt8: LogitechHIDPPDeviceMetadataProvider.ReceiverConnectionSnapshot] {
         guard triggerConnectionNotifications() else {
             return [:]
         }
@@ -991,6 +1000,10 @@ final class LogitechReceiverChannel: VendorSpecificDeviceContext {
             guard let report = waitForInputReport(timeout: 0.05, matching: { response in
                 LogitechHIDPPDeviceMetadataProvider.parseReceiverConnectionNotification(Array(response)) != nil
             }) else {
+                // No more notifications pending — if we already have enough snapshots, exit early
+                if let expectedCount, snapshots.count >= expectedCount {
+                    break
+                }
                 continue
             }
 
@@ -1000,6 +1013,11 @@ final class LogitechReceiverChannel: VendorSpecificDeviceContext {
             }
 
             snapshots[notification.slot] = notification.snapshot
+
+            // Exit early once we have all expected device snapshots
+            if let expectedCount, snapshots.count >= expectedCount {
+                break
+            }
         }
 
         return snapshots
@@ -1605,6 +1623,7 @@ final class LogitechReprogrammableControlsMonitor {
     private var running = false
     private var pressedButtons = Set<Int>()
     private var needsReconfiguration = false
+    private var needsForcedReconfiguration = false
 
     init(device: Device) {
         self.device = device
@@ -1757,7 +1776,8 @@ final class LogitechReprogrammableControlsMonitor {
                     result[control.controlID] = reportingInfo
                 }
             let activeControlIDs = monitoredControls.compactMap { control -> UInt16? in
-                guard setDiverted(true, for: control.controlID, using: transport, featureIndex: featureIndex) else {
+                guard setDivertedWithRetry(true, for: control.controlID, using: transport, featureIndex: featureIndex)
+                else {
                     os_log(
                         "Failed to enable Logitech control diversion: locationID=%{public}d slot=%{public}u cid=0x%{public}04X",
                         log: Self.log,
@@ -1850,16 +1870,36 @@ final class LogitechReprogrammableControlsMonitor {
             }
 
             while shouldContinueRunning() {
-                if consumeReconfigurationRequest() {
-                    os_log(
-                        "Restart Logitech control monitor to refresh diverted controls: locationID=%{public}d slot=%{public}u device=%{public}@",
-                        log: Self.log,
-                        type: .info,
-                        locationID,
-                        slot,
-                        targetName
+                let reconfigResult = consumeReconfigurationRequest()
+                if reconfigResult.needed {
+                    if reconfigResult.forced {
+                        os_log(
+                            "Restart Logitech control monitor (forced, e.g. device reconnect): locationID=%{public}d slot=%{public}u device=%{public}@",
+                            log: Self.log,
+                            type: .info,
+                            locationID,
+                            slot,
+                            targetName
+                        )
+                        break
+                    }
+
+                    let newDesiredControlIDs = desiredDivertedControlIDs(
+                        availableControls: allControls, identity: targetIdentity
                     )
-                    break
+                    let newIsRecording = SettingsState.shared.recording
+
+                    if newDesiredControlIDs != desiredControlIDs || newIsRecording != isRecording {
+                        os_log(
+                            "Restart Logitech control monitor to refresh diverted controls: locationID=%{public}d slot=%{public}u device=%{public}@",
+                            log: Self.log,
+                            type: .info,
+                            locationID,
+                            slot,
+                            targetName
+                        )
+                        break
+                    }
                 }
 
                 guard let report = monitorTarget.notificationEndpoint.waitForHIDPPNotification(
@@ -1966,7 +2006,7 @@ final class LogitechReprogrammableControlsMonitor {
 
     private func waitForReconfigurationOrStop() -> Bool {
         while shouldContinueRunning() {
-            if consumeReconfigurationRequest() {
+            if consumeReconfigurationRequest().needed {
                 return true
             }
 
@@ -2054,9 +2094,48 @@ final class LogitechReprogrammableControlsMonitor {
         return endpoint
     }
 
-    private func resolveTargetDevice(using receiverChannel: LogitechReceiverChannel) -> TargetDevice? {
+    private func resolveTargetDevice(
+        using receiverChannel: LogitechReceiverChannel,
+        discovery: LogitechHIDPPDeviceMetadataProvider.ReceiverPointingDeviceDiscovery
+    ) -> TargetDevice? {
+        let desiredProductID = device.pointerDevice.productID
+        let desiredSerial = device.pointerDevice
+            .serialNumber?
+            .lowercased()
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        let desiredName = (device.pointerDevice.product ?? device.pointerDevice.name)
+            .lowercased()
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+
+        // Try to match device to a slot using discovery results directly,
+        // avoiding a second full slot scan.
+        let matched: ReceiverLogicalDeviceIdentity? =
+            // Match by serial number
+            discovery.identities.first {
+                guard let serial = $0.serialNumber?.lowercased().trimmingCharacters(in: .whitespacesAndNewlines),
+                      let desired = desiredSerial, !desired.isEmpty else {
+                    return false
+                }
+                return serial == desired
+            }
+            // Match by product ID
+            ?? discovery.identities.first {
+                guard let pid = $0.productID, let desired = desiredProductID else {
+                    return false
+                }
+                return pid == desired
+            }
+            // Match by name
+            ?? discovery.identities.first {
+                $0.name.lowercased().trimmingCharacters(in: .whitespacesAndNewlines) == desiredName
+            }
+
+        if let matched {
+            return TargetDevice(slot: matched.slot, identity: matched)
+        }
+
+        // Fallback: use the original slot matching via HID++ pairing info
         if let slot = provider.receiverSlot(for: device.pointerDevice, using: receiverChannel) {
-            let discovery = provider.receiverPointingDeviceDiscovery(for: device.pointerDevice, using: receiverChannel)
             let identity = discovery.identities.first { $0.slot == slot }
             return TargetDevice(slot: slot, identity: identity)
         }
@@ -2067,7 +2146,7 @@ final class LogitechReprogrammableControlsMonitor {
     private func resolveMonitorTarget(using receiverChannel: LogitechReceiverChannel) -> MonitorTarget? {
         let discovery = provider.receiverPointingDeviceDiscovery(for: device.pointerDevice, using: receiverChannel)
 
-        if let targetDevice = resolveTargetDevice(using: receiverChannel),
+        if let targetDevice = resolveTargetDevice(using: receiverChannel, discovery: discovery),
            let target = buildMonitorTarget(
                slot: targetDevice.slot,
                identity: targetDevice.identity,
@@ -2076,7 +2155,15 @@ final class LogitechReprogrammableControlsMonitor {
             return target
         }
 
-        let scannedTargets = (UInt8(1) ... UInt8(6)).compactMap { slot in
+        // Only scan connected slots instead of all 6
+        let connectedSlots = Set(discovery.connectionSnapshots.compactMap { slot, snapshot in
+            snapshot.isConnected ? slot : nil
+        })
+        let candidateSlots: [UInt8] = discovery.identities.isEmpty
+            ? Array(connectedSlots.sorted())
+            : discovery.identities.map(\.slot)
+
+        let scannedTargets = candidateSlots.compactMap { slot in
             buildMonitorTarget(
                 slot: slot,
                 identity: discovery.identities.first { $0.slot == slot },
@@ -2212,22 +2299,31 @@ final class LogitechReprogrammableControlsMonitor {
             .store(in: &subscriptions)
     }
 
-    private func requestReconfiguration() {
+    func requestReconfiguration() {
         stateLock.lock()
         needsReconfiguration = true
         stateLock.unlock()
     }
 
-    private func consumeReconfigurationRequest() -> Bool {
+    func requestForcedReconfiguration() {
+        stateLock.lock()
+        needsReconfiguration = true
+        needsForcedReconfiguration = true
+        stateLock.unlock()
+    }
+
+    private func consumeReconfigurationRequest() -> (needed: Bool, forced: Bool) {
         stateLock.lock()
         defer { stateLock.unlock() }
 
         guard needsReconfiguration else {
-            return false
+            return (false, false)
         }
 
+        let forced = needsForcedReconfiguration
         needsReconfiguration = false
-        return true
+        needsForcedReconfiguration = false
+        return (true, forced)
     }
 
     private func desiredDivertedControlIDs(
@@ -2406,9 +2502,57 @@ final class LogitechReprogrammableControlsMonitor {
                 controlID,
                 response.payload.map { String(format: "%02X", $0) }.joined(separator: " ")
             )
+
+            // Read back the reporting state to verify diversion actually took effect
+            guard let verifyReporting = readReportingInfo(
+                for: controlID, using: transport, featureIndex: featureIndex
+            ) else {
+                os_log(
+                    "Logitech setCidReporting verification failed (read-back error): cid=0x%{public}04X",
+                    log: Self.log, type: .error, controlID
+                )
+                return false
+            }
+            let actuallyDiverted = verifyReporting.flags.contains(.diverted)
+            guard actuallyDiverted == enabled else {
+                os_log(
+                    "Logitech setCidReporting verification mismatch: cid=0x%{public}04X wanted=%{public}@ actual=%{public}@",
+                    log: Self.log, type: .error, controlID,
+                    enabled ? "diverted" : "native",
+                    actuallyDiverted ? "diverted" : "native"
+                )
+                return false
+            }
         }
 
         return true
+    }
+
+    private func setDivertedWithRetry(
+        _ enabled: Bool,
+        for controlID: UInt16,
+        using transport: LogitechHIDPPTransport,
+        featureIndex: UInt8,
+        maxAttempts: Int = 3,
+        retryDelay: TimeInterval = 0.05
+    ) -> Bool {
+        for attempt in 1 ... maxAttempts {
+            if setDiverted(enabled, for: controlID, using: transport, featureIndex: featureIndex) {
+                return true
+            }
+
+            guard attempt < maxAttempts, shouldContinueRunning() else {
+                break
+            }
+
+            os_log(
+                "Logitech setCidReporting retry %{public}d/%{public}d: cid=0x%{public}04X",
+                log: Self.log, type: .info,
+                attempt, maxAttempts, controlID
+            )
+            Thread.sleep(forTimeInterval: retryDelay)
+        }
+        return false
     }
 
     private func restoreReportingState(


### PR DESCRIPTION
## Summary

- Fix intermittent Logitech control button binding failures by verifying HID++ diversion state, adding retry logic, and re-diverting on device reconnect
- Reduce unnecessary control monitor restarts on app switch when diverted controls haven't changed
- Speed up receiver initialization by eliminating redundant slot discovery and early-exiting snapshot collection

## Reliability fixes

**Verify diversion took effect:** When `setCidReporting` response does not echo the control ID (all-zero payload observed with USB Receiver-routed devices), read back the reporting state to confirm diversion was actually applied. Previously the code returned success unconditionally.

**Retry on failure:** Wrap `setDiverted` with up to 3 retry attempts (50ms delay between retries) to handle transient HID++ communication glitches.

**Re-divert on reconnect:** When `ReceiverMonitor` detects a device reconnect (e.g. mouse wakes from sleep), trigger a forced reconfiguration on the control monitor. Previously, diversion state was silently lost until an unrelated event (like an app switch) happened to restart the monitor.

**Skip no-op restarts:** On app switch, compare the new desired control IDs with the currently diverted set. Only perform the expensive un-divert/re-divert cycle when controls actually changed. This reduces the window where button events can be dropped during app switching.

## Initialization performance

**Eliminate duplicate discovery:** `resolveMonitorTarget` previously triggered up to 3 full slot discovery passes. Now it performs a single discovery and reuses the result for target device matching and fallback scanning.

**Early-exit snapshot collection:** `discoverConnectionSnapshots` previously blocked for a full 0.5s. Now it accepts the expected device count and exits as soon as all snapshots are collected.

**Prioritize connected slots:** Slot scanning now processes connected slots first and skips remaining empty slots once all connected devices are found, avoiding unnecessary HID++ round-trips for unused slots.

**Scope fallback scanning:** The fallback path now only scans slots with known connected/paired devices instead of blindly iterating slots 1–6.

For a typical single-mouse-on-USB-Receiver setup, initialization drops from ~7–10s to ~0.5–1s.

## Test plan

- [ ] Verify Logitech control button gestures work after app launch
- [ ] Turn mouse off and back on — verify gestures resume without needing to relaunch
- [ ] Rapidly switch between apps while using gestures — verify no dropped events
- [ ] Test with multiple devices paired to a single receiver
- [ ] Check logs for `setCidReporting retry` and `verification mismatch` messages during normal use