### PR TITLE
Keep mouse event handling off the main thread

### DIFF
--- a/LinearMouse/Device/VendorSpecific/Logitech/LogitechHIDPPDeviceMetadataProvider.swift
+++ b/LinearMouse/Device/VendorSpecific/Logitech/LogitechHIDPPDeviceMetadataProvider.swift
@@ -1955,7 +1955,7 @@ final class LogitechReprogrammableControlsMonitor {
                     ))
                     let mouseLocationPid = mouseLocationWindowID.ownerPid
                         ?? NSWorkspace.shared.frontmostApplication?.processIdentifier
-                    let display = ScreenManager.shared.atomicCurrentScreenName
+                    let display = ScreenManager.shared.currentScreenNameSnapshot
 
                     let logitechContext = LogitechEventContext(
                         device: device,
@@ -2333,7 +2333,7 @@ final class LogitechReprogrammableControlsMonitor {
         let scheme = ConfigurationState.shared.configuration.matchScheme(
             withDevice: device,
             withPid: mouseLocationPid,
-            withDisplay: ScreenManager.shared.atomicCurrentScreenName
+            withDisplay: ScreenManager.shared.currentScreenNameSnapshot
         )
 
         let directMappings: [UInt16] = (scheme.buttons.mappings ?? [])

--- a/LinearMouse/Device/VendorSpecific/Logitech/LogitechHIDPPDeviceMetadataProvider.swift
+++ b/LinearMouse/Device/VendorSpecific/Logitech/LogitechHIDPPDeviceMetadataProvider.swift
@@ -1956,11 +1956,6 @@ final class LogitechReprogrammableControlsMonitor {
                     let mouseLocationPid = mouseLocationWindowID.ownerPid
                         ?? NSWorkspace.shared.frontmostApplication?.processIdentifier
                     let display = ScreenManager.shared.atomicCurrentScreenName
-                    let transformer = EventTransformerManager.shared.get(
-                        withDevice: device,
-                        withPid: mouseLocationPid,
-                        withDisplay: display
-                    )
 
                     let logitechContext = LogitechEventContext(
                         device: device,
@@ -1971,21 +1966,9 @@ final class LogitechReprogrammableControlsMonitor {
                         modifierFlags: modifierFlags
                     )
 
-                    let handledInternally = (transformer as? [EventTransformer])?.contains { transformer in
-                        if let transformer = transformer as? AutoScrollTransformer {
-                            return transformer.handleLogitechControlEvent(logitechContext)
-                        }
-
-                        if let transformer = transformer as? GestureButtonTransformer {
-                            return transformer.handleLogitechControlEvent(logitechContext)
-                        }
-
-                        if let transformer = transformer as? ButtonActionsTransformer {
-                            return transformer.handleLogitechControlEvent(logitechContext)
-                        }
-
-                        return false
-                    } == true
+                    let handledInternally = EventThread.shared.performAndWait {
+                        EventTransformerManager.shared.handleLogitechControlEvent(logitechContext)
+                    } ?? false
 
                     guard !handledInternally else {
                         continue

--- a/LinearMouse/Device/VendorSpecific/Logitech/LogitechHIDPPDeviceMetadataProvider.swift
+++ b/LinearMouse/Device/VendorSpecific/Logitech/LogitechHIDPPDeviceMetadataProvider.swift
@@ -1948,7 +1948,7 @@ final class LogitechReprogrammableControlsMonitor {
                         continue
                     }
 
-                    let mouseLocation = NSEvent.mouseLocation
+                    let mouseLocation = CGEvent(source: nil)?.location ?? .zero
                     let mouseLocationWindowID = CGWindowID(NSWindow.windowNumber(
                         at: mouseLocation,
                         belowWindowWithWindowNumber: 0
@@ -1961,6 +1961,7 @@ final class LogitechReprogrammableControlsMonitor {
                         device: device,
                         pid: mouseLocationPid,
                         display: display,
+                        mouseLocation: mouseLocation,
                         controlIdentity: controlIdentity,
                         isPressed: isPressed,
                         modifierFlags: modifierFlags

--- a/LinearMouse/Device/VendorSpecific/Logitech/LogitechHIDPPDeviceMetadataProvider.swift
+++ b/LinearMouse/Device/VendorSpecific/Logitech/LogitechHIDPPDeviceMetadataProvider.swift
@@ -1955,7 +1955,7 @@ final class LogitechReprogrammableControlsMonitor {
                     ))
                     let mouseLocationPid = mouseLocationWindowID.ownerPid
                         ?? NSWorkspace.shared.frontmostApplication?.processIdentifier
-                    let display = ScreenManager.shared.currentScreenName
+                    let display = ScreenManager.shared.atomicCurrentScreenName
                     let transformer = EventTransformerManager.shared.get(
                         withDevice: device,
                         withPid: mouseLocationPid,
@@ -2350,7 +2350,7 @@ final class LogitechReprogrammableControlsMonitor {
         let scheme = ConfigurationState.shared.configuration.matchScheme(
             withDevice: device,
             withPid: mouseLocationPid,
-            withDisplay: ScreenManager.shared.currentScreenName
+            withDisplay: ScreenManager.shared.atomicCurrentScreenName
         )
 
         let directMappings: [UInt16] = (scheme.buttons.mappings ?? [])

--- a/LinearMouse/EventTap/EventTap.swift
+++ b/LinearMouse/EventTap/EventTap.swift
@@ -117,7 +117,13 @@ extension EventTap {
         return ObservationToken {
             // The lifetime of contextHolder needs to be extended until the observation token is cancelled.
             withExtendedLifetime(contextHolder) {
-                healthCheckTimer.invalidate()
+                // Timer.invalidate() must be called from the thread where the timer was installed.
+                // Dispatch it to the target RunLoop; the remaining teardown calls are thread-safe.
+                CFRunLoopPerformBlock(cfRunLoop, CFRunLoopMode.commonModes.rawValue) {
+                    healthCheckTimer.invalidate()
+                }
+                CFRunLoopWakeUp(cfRunLoop)
+
                 CGEvent.tapEnable(tap: tap, enable: false)
                 CFRunLoopRemoveSource(cfRunLoop, runLoopSource, .commonModes)
                 CFMachPortInvalidate(tap)

--- a/LinearMouse/EventTap/EventThread.swift
+++ b/LinearMouse/EventTap/EventThread.swift
@@ -146,9 +146,12 @@ final class EventThread {
             return scheduleTimerOnCurrentThread(interval: interval, repeats: repeats, handler: handler)
         }
 
-        return performAndWait {
+        guard let timer = performAndWait({
             self.scheduleTimerOnCurrentThread(interval: interval, repeats: repeats, handler: handler)
+        }) else {
+            return nil
         }
+        return timer
     }
 
     private func scheduleTimerOnCurrentThread(

--- a/LinearMouse/EventTap/EventThread.swift
+++ b/LinearMouse/EventTap/EventThread.swift
@@ -4,6 +4,10 @@
 import Foundation
 import os.log
 
+private final class EventThreadResultBox<Value> {
+    var value: Value?
+}
+
 /// Manages a dedicated background thread with its own RunLoop for CGEvent processing.
 ///
 /// All event transformer state access (transform, tick, deactivate) must happen on this thread.
@@ -52,8 +56,8 @@ final class EventThread {
         }
         thread.name = "com.linearmouse.event-thread"
         thread.qualityOfService = .userInteractive
-        thread.start()
         self.thread = thread
+        thread.start()
 
         runLoopReady.wait()
     }
@@ -86,8 +90,8 @@ final class EventThread {
         }
         CFRunLoopWakeUp(cfRunLoop)
 
-        // Wait for the event thread to finish. The onWillStop callback only uses
-        // DispatchQueue.main.async (non-blocking) and NSLock (no deadlock risk).
+        // Wait for the event thread to finish. The teardown callback only posts
+        // non-blocking work back to the main queue.
         done.wait()
     }
 
@@ -103,6 +107,28 @@ final class EventThread {
         CFRunLoopPerformBlock(cfRunLoop, CFRunLoopMode.commonModes.rawValue, block)
         CFRunLoopWakeUp(cfRunLoop)
         return true
+    }
+
+    /// Execute a block on the event thread and wait for the result.
+    /// Returns `nil` if the event thread is not running.
+    func performAndWait<T>(_ block: @escaping () -> T) -> T? {
+        if isCurrent {
+            return block()
+        }
+
+        guard let cfRunLoop = runLoop?.getCFRunLoop() else {
+            return nil
+        }
+
+        let done = DispatchSemaphore(value: 0)
+        let result = EventThreadResultBox<T>()
+        CFRunLoopPerformBlock(cfRunLoop, CFRunLoopMode.commonModes.rawValue) {
+            result.value = block()
+            done.signal()
+        }
+        CFRunLoopWakeUp(cfRunLoop)
+        done.wait()
+        return result.value
     }
 
     // MARK: - Timer

--- a/LinearMouse/EventTap/EventThread.swift
+++ b/LinearMouse/EventTap/EventThread.swift
@@ -68,6 +68,8 @@ final class EventThread {
     /// then returns. This makes `stop(); start()` safe — the old thread is fully
     /// torn down before a new one is created.
     func stop() {
+        precondition(!isCurrent, "EventThread.stop() must not be called from the event thread")
+
         guard let cfRunLoop = runLoop?.getCFRunLoop() else {
             return
         }
@@ -140,6 +142,8 @@ final class EventThread {
         repeats: Bool,
         handler: @escaping () -> Void
     ) -> EventThreadTimer? {
+        precondition(isCurrent, "EventThread.scheduleTimer(...) must run on the event thread")
+
         guard let runLoop else {
             return nil
         }

--- a/LinearMouse/EventTap/EventThread.swift
+++ b/LinearMouse/EventTap/EventThread.swift
@@ -1,0 +1,159 @@
+// MIT License
+// Copyright (c) 2021-2026 LinearMouse
+
+import Foundation
+import os.log
+
+/// Manages a dedicated background thread with its own RunLoop for CGEvent processing.
+///
+/// All event transformer state access (transform, tick, deactivate) must happen on this thread.
+/// Use ``perform(_:)`` to dispatch work from other threads, and ``scheduleTimer(interval:repeats:handler:)``
+/// to create timers that fire on this thread.
+final class EventThread {
+    static let shared = EventThread()
+
+    private static let log = OSLog(subsystem: Bundle.main.bundleIdentifier!, category: "EventThread")
+
+    /// The RunLoop of the background thread. Nil when the thread is not running.
+    /// Exposed for `EventTap` to attach its `CFMachPort` source.
+    private(set) var runLoop: RunLoop?
+
+    /// Called on the event thread just before it stops.
+    /// Set by `GlobalEventTap` to wire up cleanup (e.g. cache invalidation) without tight coupling.
+    var onWillStop: (() -> Void)?
+
+    private var thread: Thread?
+    private let runLoopReady = DispatchSemaphore(value: 0)
+
+    init() {}
+
+    /// Whether the current thread is the event processing thread.
+    var isCurrent: Bool {
+        Thread.current === thread
+    }
+
+    // MARK: - Lifecycle
+
+    func start() {
+        guard thread == nil else {
+            return
+        }
+
+        let thread = Thread { [weak self] in
+            guard let self else {
+                return
+            }
+            let rl = RunLoop.current
+            // Keep the RunLoop alive even without event sources.
+            rl.add(Port(), forMode: .common)
+            self.runLoop = rl
+            self.runLoopReady.signal()
+            CFRunLoopRun()
+        }
+        thread.name = "com.linearmouse.event-thread"
+        thread.qualityOfService = .userInteractive
+        thread.start()
+        self.thread = thread
+
+        runLoopReady.wait()
+    }
+
+    func stop() {
+        guard let cfRunLoop = runLoop?.getCFRunLoop() else {
+            return
+        }
+
+        // Queue the willStop callback and CFRunLoopStop via FIFO ordering.
+        // All previously queued blocks (e.g. timer invalidations) complete first.
+        CFRunLoopPerformBlock(cfRunLoop, CFRunLoopMode.commonModes.rawValue) { [weak self] in
+            self?.onWillStop?()
+        }
+        CFRunLoopPerformBlock(cfRunLoop, CFRunLoopMode.commonModes.rawValue) {
+            CFRunLoopStop(cfRunLoop)
+        }
+        CFRunLoopWakeUp(cfRunLoop)
+
+        thread?.cancel()
+        thread = nil
+        runLoop = nil
+    }
+
+    // MARK: - Dispatch
+
+    /// Schedule a block to run on the event thread.
+    /// Returns `false` if the event thread is not running (block is not enqueued).
+    @discardableResult
+    func perform(_ block: @escaping () -> Void) -> Bool {
+        guard let cfRunLoop = runLoop?.getCFRunLoop() else {
+            return false
+        }
+        CFRunLoopPerformBlock(cfRunLoop, CFRunLoopMode.commonModes.rawValue, block)
+        CFRunLoopWakeUp(cfRunLoop)
+        return true
+    }
+
+    // MARK: - Timer
+
+    /// Create a repeating or one-shot timer on the event thread's RunLoop.
+    /// Returns `nil` if the event thread is not running.
+    func scheduleTimer(
+        interval: TimeInterval,
+        repeats: Bool,
+        handler: @escaping () -> Void
+    ) -> EventThreadTimer? {
+        guard let runLoop else {
+            return nil
+        }
+
+        let timer = Timer(timeInterval: interval, repeats: repeats) { _ in
+            handler()
+        }
+        runLoop.add(timer, forMode: .common)
+        return EventThreadTimer(timer: timer, eventThread: self)
+    }
+}
+
+// MARK: - EventThreadTimer
+
+/// Lightweight wrapper around `Timer` that ensures invalidation happens on the correct thread.
+///
+/// When invalidated from the event thread, the underlying timer is stopped synchronously.
+/// When invalidated from any other thread, invalidation is dispatched to the event thread.
+/// On `deinit`, the timer is automatically invalidated — callers don't need manual cleanup.
+final class EventThreadTimer {
+    private var timer: Timer?
+    private weak var eventThread: EventThread?
+
+    init(timer: Timer, eventThread: EventThread) {
+        self.timer = timer
+        self.eventThread = eventThread
+    }
+
+    deinit {
+        invalidate()
+    }
+
+    /// Invalidate the underlying timer. Safe to call from any thread and idempotent.
+    func invalidate() {
+        guard let timer else {
+            return
+        }
+        self.timer = nil
+
+        if let eventThread, eventThread.isCurrent {
+            // Already on the event thread — invalidate synchronously.
+            timer.invalidate()
+        } else if let eventThread {
+            // Dispatch to the event thread where the timer was installed.
+            eventThread.perform {
+                timer.invalidate()
+            }
+        }
+        // If eventThread is nil (already deallocated), the RunLoop is gone
+        // and the timer is implicitly dead.
+    }
+
+    var isValid: Bool {
+        timer?.isValid ?? false
+    }
+}

--- a/LinearMouse/EventTap/EventThread.swift
+++ b/LinearMouse/EventTap/EventThread.swift
@@ -68,17 +68,17 @@ final class EventThread {
             return
         }
 
-        // Nil out early so that new perform() calls during teardown return false
-        // instead of enqueuing on the dying RunLoop.
-        thread?.cancel()
-        thread = nil
-        runLoop = nil
-
         // Queue the willStop callback and CFRunLoopStop via FIFO ordering.
         // All previously queued blocks (e.g. timer invalidations) complete first.
+        // thread/runLoop are kept alive until onWillStop finishes so that isCurrent
+        // and perform() still work correctly during teardown.
         let done = DispatchSemaphore(value: 0)
         CFRunLoopPerformBlock(cfRunLoop, CFRunLoopMode.commonModes.rawValue) { [weak self] in
             self?.onWillStop?()
+            // Clear state after onWillStop so isCurrent was valid during teardown.
+            self?.thread?.cancel()
+            self?.thread = nil
+            self?.runLoop = nil
         }
         CFRunLoopPerformBlock(cfRunLoop, CFRunLoopMode.commonModes.rawValue) {
             CFRunLoopStop(cfRunLoop)

--- a/LinearMouse/EventTap/EventThread.swift
+++ b/LinearMouse/EventTap/EventThread.swift
@@ -58,24 +58,37 @@ final class EventThread {
         runLoopReady.wait()
     }
 
+    /// Stop the event thread synchronously.
+    ///
+    /// Fires `onWillStop` on the event thread, waits for the RunLoop to exit,
+    /// then returns. This makes `stop(); start()` safe — the old thread is fully
+    /// torn down before a new one is created.
     func stop() {
         guard let cfRunLoop = runLoop?.getCFRunLoop() else {
             return
         }
 
+        // Nil out early so that new perform() calls during teardown return false
+        // instead of enqueuing on the dying RunLoop.
+        thread?.cancel()
+        thread = nil
+        runLoop = nil
+
         // Queue the willStop callback and CFRunLoopStop via FIFO ordering.
         // All previously queued blocks (e.g. timer invalidations) complete first.
+        let done = DispatchSemaphore(value: 0)
         CFRunLoopPerformBlock(cfRunLoop, CFRunLoopMode.commonModes.rawValue) { [weak self] in
             self?.onWillStop?()
         }
         CFRunLoopPerformBlock(cfRunLoop, CFRunLoopMode.commonModes.rawValue) {
             CFRunLoopStop(cfRunLoop)
+            done.signal()
         }
         CFRunLoopWakeUp(cfRunLoop)
 
-        thread?.cancel()
-        thread = nil
-        runLoop = nil
+        // Wait for the event thread to finish. The onWillStop callback only uses
+        // DispatchQueue.main.async (non-blocking) and NSLock (no deadlock risk).
+        done.wait()
     }
 
     // MARK: - Dispatch

--- a/LinearMouse/EventTap/EventThread.swift
+++ b/LinearMouse/EventTap/EventThread.swift
@@ -142,8 +142,20 @@ final class EventThread {
         repeats: Bool,
         handler: @escaping () -> Void
     ) -> EventThreadTimer? {
-        precondition(isCurrent, "EventThread.scheduleTimer(...) must run on the event thread")
+        if isCurrent {
+            return scheduleTimerOnCurrentThread(interval: interval, repeats: repeats, handler: handler)
+        }
 
+        return performAndWait {
+            self.scheduleTimerOnCurrentThread(interval: interval, repeats: repeats, handler: handler)
+        }
+    }
+
+    private func scheduleTimerOnCurrentThread(
+        interval: TimeInterval,
+        repeats: Bool,
+        handler: @escaping () -> Void
+    ) -> EventThreadTimer? {
         guard let runLoop else {
             return nil
         }

--- a/LinearMouse/EventTap/GlobalEventTap.swift
+++ b/LinearMouse/EventTap/GlobalEventTap.swift
@@ -11,8 +11,31 @@ class GlobalEventTap {
 
     static let shared = GlobalEventTap()
 
+    /// The RunLoop running on the dedicated event processing thread.
+    /// All transformer state access (transform, tick, deactivate) must happen on this RunLoop's thread.
+    static var processingRunLoop: RunLoop? {
+        shared._processingRunLoop
+    }
+
+    /// Schedule a block to run on the event processing thread.
+    /// Use this from other threads (e.g. Logitech HID thread) to serialize transformer state access.
+    static func performOnEventThread(_ block: @escaping () -> Void) {
+        guard let cfRunLoop = shared._processingRunLoop?.getCFRunLoop() else {
+            return
+        }
+        CFRunLoopPerformBlock(cfRunLoop, CFRunLoopMode.commonModes.rawValue, block)
+        CFRunLoopWakeUp(cfRunLoop)
+    }
+
     private var observationToken: ObservationToken?
     private lazy var watchdog = GlobalEventTapWatchdog()
+
+    /// Background thread dedicated to the CGEvent tap RunLoop.
+    private var eventThread: Thread?
+
+    /// The RunLoop running on the background event thread.
+    private var _processingRunLoop: RunLoop?
+    private let runLoopReady = DispatchSemaphore(value: 0)
 
     init() {}
 
@@ -25,7 +48,7 @@ class GlobalEventTap {
             withSourcePid: mouseEventView.sourcePid,
             withTargetPid: mouseEventView.targetPid,
             withMouseLocationPid: mouseEventView.mouseLocationWindowID.ownerPid,
-            withDisplay: ScreenManager.shared.currentScreenName
+            withDisplay: ScreenManager.shared.atomicCurrentScreenName
         )
         return eventTransformer.transform(event)
     }
@@ -52,8 +75,34 @@ class GlobalEventTap {
             eventTypes.append(EventType.mouseMoved)
         }
 
+        // Start the background event thread with its own RunLoop.
+        let thread = Thread { [weak self] in
+            guard let self else {
+                return
+            }
+            let runLoop = RunLoop.current
+            // Add a keep-alive port so the RunLoop doesn't exit before the event tap source is added.
+            runLoop.add(Port(), forMode: .common)
+            self._processingRunLoop = runLoop
+            self.runLoopReady.signal()
+            CFRunLoopRun()
+        }
+        thread.name = "com.linearmouse.event-tap"
+        thread.qualityOfService = .userInteractive
+        thread.start()
+        eventThread = thread
+
+        runLoopReady.wait()
+
+        guard let processingRunLoop = _processingRunLoop else {
+            return
+        }
+
         do {
-            observationToken = try EventTap.observe(eventTypes) { [weak self] in self?.callback($1) }
+            observationToken = try EventTap.observe(
+                eventTypes,
+                at: processingRunLoop
+            ) { [weak self] in self?.callback($1) }
         } catch {
             NSAlert(error: error).runModal()
         }
@@ -63,6 +112,13 @@ class GlobalEventTap {
 
     func stop() {
         observationToken = nil
+
+        if let cfRunLoop = _processingRunLoop?.getCFRunLoop() {
+            CFRunLoopStop(cfRunLoop)
+        }
+        eventThread?.cancel()
+        eventThread = nil
+        _processingRunLoop = nil
 
         watchdog.stop()
     }

--- a/LinearMouse/EventTap/GlobalEventTap.swift
+++ b/LinearMouse/EventTap/GlobalEventTap.swift
@@ -11,34 +11,9 @@ class GlobalEventTap {
 
     static let shared = GlobalEventTap()
 
-    /// The RunLoop running on the dedicated event processing thread.
-    /// All transformer state access (transform, tick, deactivate) must happen on this RunLoop's thread.
-    static var processingRunLoop: RunLoop? {
-        shared._processingRunLoop
-    }
-
-    /// Schedule a block to run on the event processing thread.
-    /// Use this from other threads (e.g. Logitech HID thread) to serialize transformer state access.
-    /// Returns `false` if the event thread is not running (block is not enqueued).
-    @discardableResult
-    static func performOnEventThread(_ block: @escaping () -> Void) -> Bool {
-        guard let cfRunLoop = shared._processingRunLoop?.getCFRunLoop() else {
-            return false
-        }
-        CFRunLoopPerformBlock(cfRunLoop, CFRunLoopMode.commonModes.rawValue, block)
-        CFRunLoopWakeUp(cfRunLoop)
-        return true
-    }
-
     private var observationToken: ObservationToken?
     private lazy var watchdog = GlobalEventTapWatchdog()
-
-    /// Background thread dedicated to the CGEvent tap RunLoop.
-    private var eventThread: Thread?
-
-    /// The RunLoop running on the background event thread.
-    private var _processingRunLoop: RunLoop?
-    private let runLoopReady = DispatchSemaphore(value: 0)
+    private let eventThread = EventThread.shared
 
     init() {}
 
@@ -78,26 +53,12 @@ class GlobalEventTap {
             eventTypes.append(EventType.mouseMoved)
         }
 
-        // Start the background event thread with its own RunLoop.
-        let thread = Thread { [weak self] in
-            guard let self else {
-                return
-            }
-            let runLoop = RunLoop.current
-            // Add a keep-alive port so the RunLoop doesn't exit before the event tap source is added.
-            runLoop.add(Port(), forMode: .common)
-            self._processingRunLoop = runLoop
-            self.runLoopReady.signal()
-            CFRunLoopRun()
+        eventThread.onWillStop = {
+            EventTransformerManager.shared.resetForRestart()
         }
-        thread.name = "com.linearmouse.event-tap"
-        thread.qualityOfService = .userInteractive
-        thread.start()
-        eventThread = thread
+        eventThread.start()
 
-        runLoopReady.wait()
-
-        guard let processingRunLoop = _processingRunLoop else {
+        guard let processingRunLoop = eventThread.runLoop else {
             return
         }
 
@@ -107,12 +68,7 @@ class GlobalEventTap {
                 at: processingRunLoop
             ) { [weak self] in self?.callback($1) }
         } catch {
-            // Clean up the event thread that was just created.
-            CFRunLoopStop(processingRunLoop.getCFRunLoop())
-            eventThread?.cancel()
-            eventThread = nil
-            _processingRunLoop = nil
-
+            eventThread.stop()
             NSAlert(error: error).runModal()
             return
         }
@@ -125,20 +81,9 @@ class GlobalEventTap {
         // to the event RunLoop (see EventTap.observe).
         observationToken = nil
 
-        // Clear the transformer cache so stale timer references from the old
-        // RunLoop are not reused if start() is called again.
-        EventTransformerManager.shared.resetForRestart()
-
-        if let cfRunLoop = _processingRunLoop?.getCFRunLoop() {
-            // Queue RunLoop stop after any pending cleanup blocks (FIFO ordering).
-            CFRunLoopPerformBlock(cfRunLoop, CFRunLoopMode.commonModes.rawValue) {
-                CFRunLoopStop(cfRunLoop)
-            }
-            CFRunLoopWakeUp(cfRunLoop)
-        }
-        eventThread?.cancel()
-        eventThread = nil
-        _processingRunLoop = nil
+        // EventThread.stop() fires onWillStop (which calls resetForRestart)
+        // then stops the RunLoop, all in FIFO order.
+        eventThread.stop()
 
         watchdog.stop()
     }

--- a/LinearMouse/EventTap/GlobalEventTap.swift
+++ b/LinearMouse/EventTap/GlobalEventTap.swift
@@ -58,16 +58,19 @@ class GlobalEventTap {
         }
         eventThread.start()
 
-        guard let processingRunLoop = eventThread.runLoop else {
+        guard let observationResult = eventThread.performAndWait({
+            Result {
+                try EventTap.observe(eventTypes) { [weak self] in self?.callback($1) }
+            }
+        }) else {
+            eventThread.stop()
             return
         }
 
-        do {
-            observationToken = try EventTap.observe(
-                eventTypes,
-                at: processingRunLoop
-            ) { [weak self] in self?.callback($1) }
-        } catch {
+        switch observationResult {
+        case let .success(token):
+            observationToken = token
+        case let .failure(error):
             eventThread.stop()
             NSAlert(error: error).runModal()
             return

--- a/LinearMouse/EventTap/GlobalEventTap.swift
+++ b/LinearMouse/EventTap/GlobalEventTap.swift
@@ -26,7 +26,7 @@ class GlobalEventTap {
             withSourcePid: mouseEventView.sourcePid,
             withTargetPid: mouseEventView.targetPid,
             withMouseLocationPid: mouseEventView.mouseLocationWindowID.ownerPid,
-            withDisplay: ScreenManager.shared.atomicCurrentScreenName
+            withDisplay: ScreenManager.shared.currentScreenNameSnapshot
         )
         return eventTransformer.transform(event)
     }

--- a/LinearMouse/EventTap/GlobalEventTap.swift
+++ b/LinearMouse/EventTap/GlobalEventTap.swift
@@ -19,12 +19,15 @@ class GlobalEventTap {
 
     /// Schedule a block to run on the event processing thread.
     /// Use this from other threads (e.g. Logitech HID thread) to serialize transformer state access.
-    static func performOnEventThread(_ block: @escaping () -> Void) {
+    /// Returns `false` if the event thread is not running (block is not enqueued).
+    @discardableResult
+    static func performOnEventThread(_ block: @escaping () -> Void) -> Bool {
         guard let cfRunLoop = shared._processingRunLoop?.getCFRunLoop() else {
-            return
+            return false
         }
         CFRunLoopPerformBlock(cfRunLoop, CFRunLoopMode.commonModes.rawValue, block)
         CFRunLoopWakeUp(cfRunLoop)
+        return true
     }
 
     private var observationToken: ObservationToken?
@@ -104,17 +107,30 @@ class GlobalEventTap {
                 at: processingRunLoop
             ) { [weak self] in self?.callback($1) }
         } catch {
+            // Clean up the event thread that was just created.
+            CFRunLoopStop(processingRunLoop.getCFRunLoop())
+            eventThread?.cancel()
+            eventThread = nil
+            _processingRunLoop = nil
+
             NSAlert(error: error).runModal()
+            return
         }
 
         watchdog.start()
     }
 
     func stop() {
+        // Release the observation token, which dispatches timer invalidation
+        // to the event RunLoop (see EventTap.observe).
         observationToken = nil
 
         if let cfRunLoop = _processingRunLoop?.getCFRunLoop() {
-            CFRunLoopStop(cfRunLoop)
+            // Queue RunLoop stop after any pending cleanup blocks (FIFO ordering).
+            CFRunLoopPerformBlock(cfRunLoop, CFRunLoopMode.commonModes.rawValue) {
+                CFRunLoopStop(cfRunLoop)
+            }
+            CFRunLoopWakeUp(cfRunLoop)
         }
         eventThread?.cancel()
         eventThread = nil

--- a/LinearMouse/EventTap/GlobalEventTap.swift
+++ b/LinearMouse/EventTap/GlobalEventTap.swift
@@ -125,6 +125,10 @@ class GlobalEventTap {
         // to the event RunLoop (see EventTap.observe).
         observationToken = nil
 
+        // Clear the transformer cache so stale timer references from the old
+        // RunLoop are not reused if start() is called again.
+        EventTransformerManager.shared.resetForRestart()
+
         if let cfRunLoop = _processingRunLoop?.getCFRunLoop() {
             // Queue RunLoop stop after any pending cleanup blocks (FIFO ordering).
             CFRunLoopPerformBlock(cfRunLoop, CFRunLoopMode.commonModes.rawValue) {

--- a/LinearMouse/EventTransformer/AutoScrollTransformer.swift
+++ b/LinearMouse/EventTransformer/AutoScrollTransformer.swift
@@ -81,6 +81,18 @@ final class AutoScrollTransformer {
         self.speed = speed
         self.preserveNativeMiddleClick = preserveNativeMiddleClick
     }
+
+    deinit {
+        let timer = self.timer
+        if let timer {
+            GlobalEventTap.performOnEventThread {
+                timer.invalidate()
+            }
+        }
+        DispatchQueue.main.async { [indicatorController] in
+            indicatorController.hide()
+        }
+    }
 }
 
 extension AutoScrollTransformer: EventTransformer {
@@ -843,7 +855,8 @@ extension AutoScrollTransformer {
         let mouseLocation = NSEvent.mouseLocation
 
         // Dispatch state mutation to the event processing thread to maintain single-threaded access.
-        GlobalEventTap.performOnEventThread { [self] in
+        // If the event thread is not running, return false so the caller falls back to synthetic button.
+        guard GlobalEventTap.performOnEventThread({ [self] in
             if context.isPressed {
                 // If already active in toggle mode, deactivate on re-press
                 if case let .active(_, _, session) = state, session == .toggle {
@@ -878,6 +891,8 @@ extension AutoScrollTransformer {
             default:
                 break
             }
+        }) else {
+            return false
         }
         return true
     }

--- a/LinearMouse/EventTransformer/AutoScrollTransformer.swift
+++ b/LinearMouse/EventTransformer/AutoScrollTransformer.swift
@@ -843,8 +843,6 @@ extension AutoScrollTransformer: LogitechControlEventHandling {
             return false
         }
 
-        let mouseLocation = NSEvent.mouseLocation
-
         if context.isPressed {
             // If already active in toggle mode, deactivate on re-press
             if case let .active(_, _, session) = state, session == .toggle {
@@ -859,7 +857,7 @@ extension AutoScrollTransformer: LogitechControlEventHandling {
                 return true
             }
 
-            activate(at: CGPoint(x: mouseLocation.x, y: mouseLocation.y), session: activationSession)
+            activate(at: context.mouseLocation, session: activationSession)
             return true
         }
 

--- a/LinearMouse/EventTransformer/AutoScrollTransformer.swift
+++ b/LinearMouse/EventTransformer/AutoScrollTransformer.swift
@@ -67,7 +67,7 @@ final class AutoScrollTransformer {
     private var state: State = .idle
     private var suppressTriggerUp = false
     private var suppressedExitMouseButton: CGMouseButton?
-    private var timer: Timer?
+    private var timer: EventThreadTimer?
     private let indicatorController = AutoScrollIndicatorWindowController()
 
     init(
@@ -83,12 +83,6 @@ final class AutoScrollTransformer {
     }
 
     deinit {
-        let timer = self.timer
-        if let timer {
-            GlobalEventTap.performOnEventThread {
-                timer.invalidate()
-            }
-        }
         DispatchQueue.main.async { [indicatorController] in
             indicatorController.hide()
         }
@@ -348,15 +342,12 @@ extension AutoScrollTransformer: EventTransformer {
             return
         }
 
-        guard let runLoop = GlobalEventTap.processingRunLoop else {
-            return
-        }
-
-        let timer = Timer(timeInterval: Self.timerInterval, repeats: true) { [weak self] _ in
+        timer = EventThread.shared.scheduleTimer(
+            interval: Self.timerInterval,
+            repeats: true
+        ) { [weak self] in
             self?.tick()
         }
-        runLoop.add(timer, forMode: .common)
-        self.timer = timer
     }
 
     private func tick() {
@@ -856,7 +847,7 @@ extension AutoScrollTransformer {
 
         // Dispatch state mutation to the event processing thread to maintain single-threaded access.
         // If the event thread is not running, return false so the caller falls back to synthetic button.
-        guard GlobalEventTap.performOnEventThread({ [self] in
+        guard EventThread.shared.perform({ [self] in
             if context.isPressed {
                 // If already active in toggle mode, deactivate on re-press
                 if case let .active(_, _, session) = state, session == .toggle {

--- a/LinearMouse/EventTransformer/AutoScrollTransformer.swift
+++ b/LinearMouse/EventTransformer/AutoScrollTransformer.swift
@@ -67,7 +67,7 @@ final class AutoScrollTransformer {
     private var state: State = .idle
     private var suppressTriggerUp = false
     private var suppressedExitMouseButton: CGMouseButton?
-    private var timer: DispatchSourceTimer?
+    private var timer: Timer?
     private let indicatorController = AutoScrollIndicatorWindowController()
 
     init(
@@ -225,7 +225,10 @@ extension AutoScrollTransformer: EventTransformer {
                exceedsDeadZone(from: anchor, to: point) {
                 activate(at: anchor, session: .hold)
                 state = .active(anchor: anchor, current: point, session: .hold)
-                indicatorController.update(delta: CGVector(dx: point.x - anchor.x, dy: point.y - anchor.y))
+                let delta = CGVector(dx: point.x - anchor.x, dy: point.y - anchor.y)
+                DispatchQueue.main.async { [indicatorController] in
+                    indicatorController.update(delta: delta)
+                }
                 return nil
             }
 
@@ -250,7 +253,10 @@ extension AutoScrollTransformer: EventTransformer {
             }
 
             state = .active(anchor: anchor, current: point, session: resolvedSession)
-            indicatorController.update(delta: CGVector(dx: point.x - anchor.x, dy: point.y - anchor.y))
+            let delta = CGVector(dx: point.x - anchor.x, dy: point.y - anchor.y)
+            DispatchQueue.main.async { [indicatorController] in
+                indicatorController.update(delta: delta)
+            }
 
             if event.type == triggerMouseDraggedEventType, suppressTriggerUp {
                 return nil
@@ -318,8 +324,10 @@ extension AutoScrollTransformer: EventTransformer {
 
         suppressedExitMouseButton = nil
         state = .active(anchor: point, current: point, session: session)
-        indicatorController.show(at: point)
-        indicatorController.update(delta: .zero)
+        DispatchQueue.main.async { [indicatorController] in
+            indicatorController.show(at: point)
+            indicatorController.update(delta: .zero)
+        }
         startTimerIfNeeded()
     }
 
@@ -328,13 +336,15 @@ extension AutoScrollTransformer: EventTransformer {
             return
         }
 
-        let timer = DispatchSource.makeTimerSource(queue: .main)
-        timer.schedule(deadline: .now(), repeating: Self.timerInterval)
-        timer.setEventHandler { [weak self] in
+        guard let runLoop = GlobalEventTap.processingRunLoop else {
+            return
+        }
+
+        let timer = Timer(timeInterval: Self.timerInterval, repeats: true) { [weak self] _ in
             self?.tick()
         }
+        runLoop.add(timer, forMode: .common)
         self.timer = timer
-        timer.resume()
     }
 
     private func tick() {
@@ -831,50 +841,45 @@ extension AutoScrollTransformer {
         }
 
         let mouseLocation = NSEvent.mouseLocation
-        DispatchQueue.main.async { [self] in
-            handleLogitechControlEventOnMain(context, mouseLocation: mouseLocation)
-        }
-        return true
-    }
 
-    private func handleLogitechControlEventOnMain(
-        _ context: LogitechEventContext,
-        mouseLocation: NSPoint
-    ) {
-        if context.isPressed {
-            // If already active in toggle mode, deactivate on re-press
-            if case let .active(_, _, session) = state, session == .toggle {
-                guard hasToggleMode else {
+        // Dispatch state mutation to the event processing thread to maintain single-threaded access.
+        GlobalEventTap.performOnEventThread { [self] in
+            if context.isPressed {
+                // If already active in toggle mode, deactivate on re-press
+                if case let .active(_, _, session) = state, session == .toggle {
+                    guard hasToggleMode else {
+                        return
+                    }
+                    deactivate()
                     return
                 }
-                deactivate()
-                return
-            }
 
-            guard trigger.matches(modifierFlags: context.modifierFlags) else {
-                return
-            }
-
-            activate(at: CGPoint(x: mouseLocation.x, y: mouseLocation.y), session: activationSession)
-            return
-        }
-        switch state {
-        case let .active(anchor, current, session):
-            switch session {
-            case .hold:
-                deactivate()
-            case .pendingToggleOrHold:
-                if exceedsDeadZone(from: anchor, to: current) {
-                    deactivate()
-                } else {
-                    state = .active(anchor: anchor, current: current, session: .toggle)
+                guard trigger.matches(modifierFlags: context.modifierFlags) else {
+                    return
                 }
-            case .toggle:
+
+                activate(at: CGPoint(x: mouseLocation.x, y: mouseLocation.y), session: activationSession)
+                return
+            }
+            switch state {
+            case let .active(anchor, current, session):
+                switch session {
+                case .hold:
+                    deactivate()
+                case .pendingToggleOrHold:
+                    if exceedsDeadZone(from: anchor, to: current) {
+                        deactivate()
+                    } else {
+                        state = .active(anchor: anchor, current: current, session: .toggle)
+                    }
+                case .toggle:
+                    break
+                }
+            default:
                 break
             }
-        default:
-            break
         }
+        return true
     }
 }
 
@@ -886,12 +891,12 @@ extension AutoScrollTransformer: Deactivatable {
 
         state = .idle
         suppressTriggerUp = false
-        indicatorController.hide()
-
-        if let timer {
-            timer.cancel()
-            self.timer = nil
+        DispatchQueue.main.async { [indicatorController] in
+            indicatorController.hide()
         }
+
+        timer?.invalidate()
+        timer = nil
     }
 }
 

--- a/LinearMouse/EventTransformer/AutoScrollTransformer.swift
+++ b/LinearMouse/EventTransformer/AutoScrollTransformer.swift
@@ -836,7 +836,7 @@ private struct ActivationProbe {
     let hit: ActivationHit
 }
 
-extension AutoScrollTransformer {
+extension AutoScrollTransformer: LogitechControlEventHandling {
     func handleLogitechControlEvent(_ context: LogitechEventContext) -> Bool {
         guard let triggerLogitechControl = trigger.button?.logitechControl,
               context.controlIdentity.matches(triggerLogitechControl) else {
@@ -845,46 +845,42 @@ extension AutoScrollTransformer {
 
         let mouseLocation = NSEvent.mouseLocation
 
-        // Dispatch state mutation to the event processing thread to maintain single-threaded access.
-        // If the event thread is not running, return false so the caller falls back to synthetic button.
-        guard EventThread.shared.perform({ [self] in
-            if context.isPressed {
-                // If already active in toggle mode, deactivate on re-press
-                if case let .active(_, _, session) = state, session == .toggle {
-                    guard hasToggleMode else {
-                        return
-                    }
-                    deactivate()
-                    return
+        if context.isPressed {
+            // If already active in toggle mode, deactivate on re-press
+            if case let .active(_, _, session) = state, session == .toggle {
+                guard hasToggleMode else {
+                    return true
                 }
-
-                guard trigger.matches(modifierFlags: context.modifierFlags) else {
-                    return
-                }
-
-                activate(at: CGPoint(x: mouseLocation.x, y: mouseLocation.y), session: activationSession)
-                return
+                deactivate()
+                return true
             }
-            switch state {
-            case let .active(anchor, current, session):
-                switch session {
-                case .hold:
+
+            guard trigger.matches(modifierFlags: context.modifierFlags) else {
+                return true
+            }
+
+            activate(at: CGPoint(x: mouseLocation.x, y: mouseLocation.y), session: activationSession)
+            return true
+        }
+
+        switch state {
+        case let .active(anchor, current, session):
+            switch session {
+            case .hold:
+                deactivate()
+            case .pendingToggleOrHold:
+                if exceedsDeadZone(from: anchor, to: current) {
                     deactivate()
-                case .pendingToggleOrHold:
-                    if exceedsDeadZone(from: anchor, to: current) {
-                        deactivate()
-                    } else {
-                        state = .active(anchor: anchor, current: current, session: .toggle)
-                    }
-                case .toggle:
-                    break
+                } else {
+                    state = .active(anchor: anchor, current: current, session: .toggle)
                 }
-            default:
+            case .toggle:
                 break
             }
-        }) else {
-            return false
+        default:
+            break
         }
+
         return true
     }
 }

--- a/LinearMouse/EventTransformer/ButtonActionsTransformer.swift
+++ b/LinearMouse/EventTransformer/ButtonActionsTransformer.swift
@@ -31,8 +31,12 @@ class ButtonActionsTransformer {
     }
 
     deinit {
-        repeatTimer?.invalidate()
-        logitechRepeatTimer?.invalidate()
+        let timer = repeatTimer
+        let logTimer = logitechRepeatTimer
+        GlobalEventTap.performOnEventThread {
+            timer?.invalidate()
+            logTimer?.invalidate()
+        }
     }
 }
 
@@ -147,6 +151,7 @@ extension ButtonActionsTransformer: EventTransformer {
             return false
         }
 
+        // Matching is read-only on immutable mappings, safe from any thread.
         let matchingMappings = mappings.filter { mapping in
             guard let logiButton = mapping.button?.logitechControl,
                   context.controlIdentity.matches(logiButton) else {
@@ -175,32 +180,35 @@ extension ButtonActionsTransformer: EventTransformer {
             return false
         }
 
-        if mapping.repeat != true {
-            if handleLogitechModifiersHold(action: action, isPressed: context.isPressed) {
-                return true
+        // Dispatch timer and action work to the event thread for single-threaded state access.
+        GlobalEventTap.performOnEventThread { [self] in
+            if mapping.repeat != true {
+                if handleLogitechModifiersHold(action: action, isPressed: context.isPressed) {
+                    return
+                }
             }
+
+            logitechRepeatTimer?.invalidate()
+            logitechRepeatTimer = nil
+
+            let keyRepeatDelay = mapping.repeat == true ? NSEvent.keyRepeatDelay : 0
+            let keyRepeatInterval = mapping.repeat == true ? NSEvent.keyRepeatInterval : 0
+            let keyRepeatEnabled = keyRepeatDelay > 0 && keyRepeatInterval > 0
+            let shouldExecute = keyRepeatEnabled ? context.isPressed : !context.isPressed
+
+            guard shouldExecute else {
+                return
+            }
+
+            queueLogitechActions(
+                event: nil,
+                action: action,
+                targetBundleIdentifier: context.pid?.bundleIdentifier,
+                keyRepeatEnabled: keyRepeatEnabled,
+                keyRepeatDelay: keyRepeatDelay,
+                keyRepeatInterval: keyRepeatInterval
+            )
         }
-
-        logitechRepeatTimer?.invalidate()
-        logitechRepeatTimer = nil
-
-        let keyRepeatDelay = mapping.repeat == true ? NSEvent.keyRepeatDelay : 0
-        let keyRepeatInterval = mapping.repeat == true ? NSEvent.keyRepeatInterval : 0
-        let keyRepeatEnabled = keyRepeatDelay > 0 && keyRepeatInterval > 0
-        let shouldExecute = keyRepeatEnabled ? context.isPressed : !context.isPressed
-
-        guard shouldExecute else {
-            return true
-        }
-
-        queueLogitechActions(
-            event: nil,
-            action: action,
-            targetBundleIdentifier: context.pid?.bundleIdentifier,
-            keyRepeatEnabled: keyRepeatEnabled,
-            keyRepeatDelay: keyRepeatDelay,
-            keyRepeatInterval: keyRepeatInterval
-        )
 
         return true
     }
@@ -237,33 +245,34 @@ extension ButtonActionsTransformer: EventTransformer {
 
         DispatchQueue.main.async { [self] in
             executeIgnoreErrors(action: action, targetBundleIdentifier: targetBundleIdentifier)
+        }
 
-            guard keyRepeatEnabled else {
+        guard keyRepeatEnabled, let runLoop = GlobalEventTap.processingRunLoop else {
+            return
+        }
+
+        // Schedule repeat timer on the event processing RunLoop so it can be safely
+        // invalidated from transform() on the same thread.
+        repeatTimer = Timer(timeInterval: keyRepeatDelay, repeats: false) { [weak self] _ in
+            guard let self else {
                 return
             }
 
-            repeatTimer = Timer.scheduledTimer(
-                withTimeInterval: keyRepeatDelay,
-                repeats: false
-            ) { [weak self] _ in
+            DispatchQueue.main.async { [self] in
+                self.executeIgnoreErrors(action: action, targetBundleIdentifier: targetBundleIdentifier)
+            }
+
+            self.repeatTimer = Timer(timeInterval: keyRepeatInterval, repeats: true) { [weak self] _ in
                 guard let self else {
                     return
                 }
-
-                self.executeIgnoreErrors(action: action, targetBundleIdentifier: targetBundleIdentifier)
-
-                self.repeatTimer = Timer.scheduledTimer(
-                    withTimeInterval: keyRepeatInterval,
-                    repeats: true
-                ) { [weak self] _ in
-                    guard let self else {
-                        return
-                    }
-
+                DispatchQueue.main.async { [self] in
                     self.executeIgnoreErrors(action: action, targetBundleIdentifier: targetBundleIdentifier)
                 }
             }
+            runLoop.add(self.repeatTimer!, forMode: .common)
         }
+        runLoop.add(repeatTimer!, forMode: .common)
     }
 
     private func queueLogitechActions(
@@ -276,33 +285,32 @@ extension ButtonActionsTransformer: EventTransformer {
     ) {
         DispatchQueue.main.async { [self] in
             executeIgnoreErrors(action: action, targetBundleIdentifier: targetBundleIdentifier)
+        }
 
-            guard keyRepeatEnabled else {
+        guard keyRepeatEnabled, let runLoop = GlobalEventTap.processingRunLoop else {
+            return
+        }
+
+        logitechRepeatTimer = Timer(timeInterval: keyRepeatDelay, repeats: false) { [weak self] _ in
+            guard let self else {
                 return
             }
 
-            logitechRepeatTimer = Timer.scheduledTimer(
-                withTimeInterval: keyRepeatDelay,
-                repeats: false
-            ) { [weak self] _ in
+            DispatchQueue.main.async { [self] in
+                self.executeIgnoreErrors(action: action, targetBundleIdentifier: targetBundleIdentifier)
+            }
+
+            self.logitechRepeatTimer = Timer(timeInterval: keyRepeatInterval, repeats: true) { [weak self] _ in
                 guard let self else {
                     return
                 }
-
-                self.executeIgnoreErrors(action: action, targetBundleIdentifier: targetBundleIdentifier)
-
-                self.logitechRepeatTimer = Timer.scheduledTimer(
-                    withTimeInterval: keyRepeatInterval,
-                    repeats: true
-                ) { [weak self] _ in
-                    guard let self else {
-                        return
-                    }
-
+                DispatchQueue.main.async { [self] in
                     self.executeIgnoreErrors(action: action, targetBundleIdentifier: targetBundleIdentifier)
                 }
             }
+            runLoop.add(self.logitechRepeatTimer!, forMode: .common)
         }
+        runLoop.add(logitechRepeatTimer!, forMode: .common)
     }
 
     private func executeIgnoreErrors(

--- a/LinearMouse/EventTransformer/ButtonActionsTransformer.swift
+++ b/LinearMouse/EventTransformer/ButtonActionsTransformer.swift
@@ -14,8 +14,13 @@ class ButtonActionsTransformer {
     let mappings: [Scheme.Buttons.Mapping]
     let universalBackForward: Scheme.Buttons.UniversalBackForward?
 
-    var repeatTimer: Timer?
-    private var logitechRepeatTimer: Timer?
+    private enum TimerSlot {
+        case standard
+        case logitech
+    }
+
+    var repeatTimer: EventThreadTimer?
+    private var logitechRepeatTimer: EventThreadTimer?
 
     static let keySimulator = KeySimulator()
     var keySimulator: KeySimulator {
@@ -30,12 +35,17 @@ class ButtonActionsTransformer {
         self.universalBackForward = universalBackForward
     }
 
-    deinit {
-        let timer = repeatTimer
-        let logTimer = logitechRepeatTimer
-        GlobalEventTap.performOnEventThread {
-            timer?.invalidate()
-            logTimer?.invalidate()
+    private func timer(for slot: TimerSlot) -> EventThreadTimer? {
+        switch slot {
+        case .standard: repeatTimer
+        case .logitech: logitechRepeatTimer
+        }
+    }
+
+    private func setTimer(_ slot: TimerSlot, _ timer: EventThreadTimer?) {
+        switch slot {
+        case .standard: repeatTimer = timer
+        case .logitech: logitechRepeatTimer = timer
         }
     }
 }
@@ -192,7 +202,7 @@ extension ButtonActionsTransformer: EventTransformer {
 
         // Dispatch timer and action work to the event thread for single-threaded state access.
         // If the event thread is not running, return false so the caller falls back to synthetic button.
-        return GlobalEventTap.performOnEventThread { [self] in
+        return EventThread.shared.perform { [self] in
             if mapping.repeat != true {
                 if handleLogitechModifiersHold(action: action, isPressed: context.isPressed) {
                     return
@@ -251,37 +261,14 @@ extension ButtonActionsTransformer: EventTransformer {
         keyRepeatInterval: TimeInterval = 0
     ) {
         let targetBundleIdentifier = event.flatMap { MouseEventView($0).targetPid?.bundleIdentifier }
-
-        DispatchQueue.main.async { [self] in
-            executeIgnoreErrors(action: action, targetBundleIdentifier: targetBundleIdentifier)
-        }
-
-        guard keyRepeatEnabled, let runLoop = GlobalEventTap.processingRunLoop else {
-            return
-        }
-
-        // Schedule repeat timer on the event processing RunLoop so it can be safely
-        // invalidated from transform() on the same thread.
-        repeatTimer = Timer(timeInterval: keyRepeatDelay, repeats: false) { [weak self] _ in
-            guard let self else {
-                return
-            }
-
-            DispatchQueue.main.async { [self] in
-                self.executeIgnoreErrors(action: action, targetBundleIdentifier: targetBundleIdentifier)
-            }
-
-            self.repeatTimer = Timer(timeInterval: keyRepeatInterval, repeats: true) { [weak self] _ in
-                guard let self else {
-                    return
-                }
-                DispatchQueue.main.async { [self] in
-                    self.executeIgnoreErrors(action: action, targetBundleIdentifier: targetBundleIdentifier)
-                }
-            }
-            runLoop.add(self.repeatTimer!, forMode: .common)
-        }
-        runLoop.add(repeatTimer!, forMode: .common)
+        scheduleRepeatActions(
+            slot: .standard,
+            action: action,
+            targetBundleIdentifier: targetBundleIdentifier,
+            keyRepeatEnabled: keyRepeatEnabled,
+            keyRepeatDelay: keyRepeatDelay,
+            keyRepeatInterval: keyRepeatInterval
+        )
     }
 
     private func queueLogitechActions(
@@ -292,15 +279,36 @@ extension ButtonActionsTransformer: EventTransformer {
         keyRepeatDelay: TimeInterval = 0,
         keyRepeatInterval: TimeInterval = 0
     ) {
+        scheduleRepeatActions(
+            slot: .logitech,
+            action: action,
+            targetBundleIdentifier: targetBundleIdentifier,
+            keyRepeatEnabled: keyRepeatEnabled,
+            keyRepeatDelay: keyRepeatDelay,
+            keyRepeatInterval: keyRepeatInterval
+        )
+    }
+
+    private func scheduleRepeatActions(
+        slot: TimerSlot,
+        action: Scheme.Buttons.Mapping.Action,
+        targetBundleIdentifier: String?,
+        keyRepeatEnabled: Bool,
+        keyRepeatDelay: TimeInterval,
+        keyRepeatInterval: TimeInterval
+    ) {
         DispatchQueue.main.async { [self] in
             executeIgnoreErrors(action: action, targetBundleIdentifier: targetBundleIdentifier)
         }
 
-        guard keyRepeatEnabled, let runLoop = GlobalEventTap.processingRunLoop else {
+        guard keyRepeatEnabled else {
             return
         }
 
-        logitechRepeatTimer = Timer(timeInterval: keyRepeatDelay, repeats: false) { [weak self] _ in
+        setTimer(slot, EventThread.shared.scheduleTimer(
+            interval: keyRepeatDelay,
+            repeats: false
+        ) { [weak self] in
             guard let self else {
                 return
             }
@@ -309,17 +317,18 @@ extension ButtonActionsTransformer: EventTransformer {
                 self.executeIgnoreErrors(action: action, targetBundleIdentifier: targetBundleIdentifier)
             }
 
-            self.logitechRepeatTimer = Timer(timeInterval: keyRepeatInterval, repeats: true) { [weak self] _ in
+            self.setTimer(slot, EventThread.shared.scheduleTimer(
+                interval: keyRepeatInterval,
+                repeats: true
+            ) { [weak self] in
                 guard let self else {
                     return
                 }
                 DispatchQueue.main.async { [self] in
                     self.executeIgnoreErrors(action: action, targetBundleIdentifier: targetBundleIdentifier)
                 }
-            }
-            runLoop.add(self.logitechRepeatTimer!, forMode: .common)
-        }
-        runLoop.add(logitechRepeatTimer!, forMode: .common)
+            })
+        })
     }
 
     private func executeIgnoreErrors(

--- a/LinearMouse/EventTransformer/ButtonActionsTransformer.swift
+++ b/LinearMouse/EventTransformer/ButtonActionsTransformer.swift
@@ -50,7 +50,7 @@ class ButtonActionsTransformer {
     }
 }
 
-extension ButtonActionsTransformer: EventTransformer {
+extension ButtonActionsTransformer: EventTransformer, LogitechControlEventHandling {
     var mouseDownEventTypes: [CGEventType] {
         [.leftMouseDown, .rightMouseDown, .otherMouseDown]
     }
@@ -200,36 +200,33 @@ extension ButtonActionsTransformer: EventTransformer {
             return false
         }
 
-        // Dispatch timer and action work to the event thread for single-threaded state access.
-        // If the event thread is not running, return false so the caller falls back to synthetic button.
-        return EventThread.shared.perform { [self] in
-            if mapping.repeat != true {
-                if handleLogitechModifiersHold(action: action, isPressed: context.isPressed) {
-                    return
-                }
+        if mapping.repeat != true {
+            if handleLogitechModifiersHold(action: action, isPressed: context.isPressed) {
+                return true
             }
-
-            logitechRepeatTimer?.invalidate()
-            logitechRepeatTimer = nil
-
-            let keyRepeatDelay = mapping.repeat == true ? NSEvent.keyRepeatDelay : 0
-            let keyRepeatInterval = mapping.repeat == true ? NSEvent.keyRepeatInterval : 0
-            let keyRepeatEnabled = keyRepeatDelay > 0 && keyRepeatInterval > 0
-            let shouldExecute = keyRepeatEnabled ? context.isPressed : !context.isPressed
-
-            guard shouldExecute else {
-                return
-            }
-
-            queueLogitechActions(
-                event: nil,
-                action: action,
-                targetBundleIdentifier: context.pid?.bundleIdentifier,
-                keyRepeatEnabled: keyRepeatEnabled,
-                keyRepeatDelay: keyRepeatDelay,
-                keyRepeatInterval: keyRepeatInterval
-            )
         }
+
+        logitechRepeatTimer?.invalidate()
+        logitechRepeatTimer = nil
+
+        let keyRepeatDelay = mapping.repeat == true ? NSEvent.keyRepeatDelay : 0
+        let keyRepeatInterval = mapping.repeat == true ? NSEvent.keyRepeatInterval : 0
+        let keyRepeatEnabled = keyRepeatDelay > 0 && keyRepeatInterval > 0
+        let shouldExecute = keyRepeatEnabled ? context.isPressed : !context.isPressed
+
+        guard shouldExecute else {
+            return true
+        }
+
+        queueLogitechActions(
+            event: nil,
+            action: action,
+            targetBundleIdentifier: context.pid?.bundleIdentifier,
+            keyRepeatEnabled: keyRepeatEnabled,
+            keyRepeatDelay: keyRepeatDelay,
+            keyRepeatInterval: keyRepeatInterval
+        )
+        return true
     }
 
     private func handleLogitechModifiersHold(action: Scheme.Buttons.Mapping.Action, isPressed: Bool) -> Bool {

--- a/LinearMouse/EventTransformer/ButtonActionsTransformer.swift
+++ b/LinearMouse/EventTransformer/ButtonActionsTransformer.swift
@@ -181,6 +181,8 @@ extension ButtonActionsTransformer: EventTransformer {
         }
 
         // Dispatch timer and action work to the event thread for single-threaded state access.
+        // The mapping matched, so return true regardless of whether the dispatch succeeds
+        // (the event is claimed by this transformer).
         GlobalEventTap.performOnEventThread { [self] in
             if mapping.repeat != true {
                 if handleLogitechModifiersHold(action: action, isPressed: context.isPressed) {

--- a/LinearMouse/EventTransformer/ButtonActionsTransformer.swift
+++ b/LinearMouse/EventTransformer/ButtonActionsTransformer.swift
@@ -146,12 +146,14 @@ extension ButtonActionsTransformer: EventTransformer {
         mappings.last { $0.match(with: event) }
     }
 
-    func handleLogitechControlEvent(_ context: LogitechEventContext) -> Bool {
+    /// Find the best Logitech mapping for the given control event context (read-only, thread-safe).
+    func findLogitechMapping(
+        for context: LogitechEventContext
+    ) -> (mapping: Scheme.Buttons.Mapping, action: Scheme.Buttons.Mapping.Action)? {
         guard !SettingsState.shared.recording else {
-            return false
+            return nil
         }
 
-        // Matching is read-only on immutable mappings, safe from any thread.
         let matchingMappings = mappings.filter { mapping in
             guard let logiButton = mapping.button?.logitechControl,
                   context.controlIdentity.matches(logiButton) else {
@@ -173,17 +175,24 @@ extension ButtonActionsTransformer: EventTransformer {
                 return lhsSpecificity < rhsSpecificity
             })?.element,
             let action = mapping.action else {
-            return false
+            return nil
         }
 
         if case .arg0(.auto) = action {
+            return nil
+        }
+
+        return (mapping, action)
+    }
+
+    func handleLogitechControlEvent(_ context: LogitechEventContext) -> Bool {
+        guard let (mapping, action) = findLogitechMapping(for: context) else {
             return false
         }
 
         // Dispatch timer and action work to the event thread for single-threaded state access.
-        // The mapping matched, so return true regardless of whether the dispatch succeeds
-        // (the event is claimed by this transformer).
-        GlobalEventTap.performOnEventThread { [self] in
+        // If the event thread is not running, return false so the caller falls back to synthetic button.
+        return GlobalEventTap.performOnEventThread { [self] in
             if mapping.repeat != true {
                 if handleLogitechModifiersHold(action: action, isPressed: context.isPressed) {
                     return
@@ -211,8 +220,6 @@ extension ButtonActionsTransformer: EventTransformer {
                 keyRepeatInterval: keyRepeatInterval
             )
         }
-
-        return true
     }
 
     private func handleLogitechModifiersHold(action: Scheme.Buttons.Mapping.Action, isPressed: Bool) -> Bool {

--- a/LinearMouse/EventTransformer/EventTransformer.swift
+++ b/LinearMouse/EventTransformer/EventTransformer.swift
@@ -9,6 +9,10 @@ protocol EventTransformer {
     func transform(_ event: CGEvent) -> CGEvent?
 }
 
+protocol LogitechControlEventHandling {
+    func handleLogitechControlEvent(_ context: LogitechEventContext) -> Bool
+}
+
 extension [EventTransformer]: EventTransformer {
     func transform(_ event: CGEvent) -> CGEvent? {
         var event: CGEvent? = event
@@ -18,6 +22,14 @@ extension [EventTransformer]: EventTransformer {
         }
 
         return event
+    }
+}
+
+extension [EventTransformer]: LogitechControlEventHandling {
+    func handleLogitechControlEvent(_ context: LogitechEventContext) -> Bool {
+        contains { eventTransformer in
+            (eventTransformer as? LogitechControlEventHandling)?.handleLogitechControlEvent(context) == true
+        }
     }
 }
 

--- a/LinearMouse/EventTransformer/EventTransformerManager.swift
+++ b/LinearMouse/EventTransformer/EventTransformerManager.swift
@@ -55,6 +55,23 @@ class EventTransformerManager {
             .store(in: &subscriptions)
     }
 
+    /// Called when the event tap stops. Clears all cached transformers so they are
+    /// recreated with the new RunLoop on restart. Transformer deinit handles timer cleanup.
+    func resetForRestart() {
+        lock.lock()
+        let oldAutoScroll = sharedAutoScrollTransformer
+        sharedAutoScrollTransformer = nil
+        activeCacheKey = nil
+        eventTransformerCache.removeAllValues()
+        lock.unlock()
+
+        if let oldAutoScroll {
+            GlobalEventTap.performOnEventThread {
+                oldAutoScroll.deactivate()
+            }
+        }
+    }
+
     private let sourceBundleIdentifierBypassSet: Set<String> = [
         "cc.ffitch.shottr"
     ]

--- a/LinearMouse/EventTransformer/EventTransformerManager.swift
+++ b/LinearMouse/EventTransformer/EventTransformerManager.swift
@@ -57,8 +57,44 @@ class EventTransformerManager {
         withMouseLocationPid mouseLocationPid: pid_t?,
         withDisplay display: String?
     ) -> EventTransformer {
-        assert(EventThread.shared.isCurrent, "EventTransformerManager.get(withCGEvent:...) must run on EventThread")
+        if EventThread.shared.isCurrent {
+            return getOnCurrentThread(
+                withCGEvent: cgEvent,
+                withSourcePid: sourcePid,
+                withTargetPid: targetPid,
+                withMouseLocationPid: mouseLocationPid,
+                withDisplay: display
+            )
+        }
 
+        if let transformer = EventThread.shared.performAndWait({
+            self.getOnCurrentThread(
+                withCGEvent: cgEvent,
+                withSourcePid: sourcePid,
+                withTargetPid: targetPid,
+                withMouseLocationPid: mouseLocationPid,
+                withDisplay: display
+            )
+        }) {
+            return transformer
+        }
+
+        return getOnCurrentThread(
+            withCGEvent: cgEvent,
+            withSourcePid: sourcePid,
+            withTargetPid: targetPid,
+            withMouseLocationPid: mouseLocationPid,
+            withDisplay: display
+        )
+    }
+
+    private func getOnCurrentThread(
+        withCGEvent cgEvent: CGEvent,
+        withSourcePid sourcePid: pid_t?,
+        withTargetPid targetPid: pid_t?,
+        withMouseLocationPid mouseLocationPid: pid_t?,
+        withDisplay display: String?
+    ) -> EventTransformer {
         if sourcePid != nil, bypassEventsFromOtherApplications, !cgEvent.isLinearMouseSyntheticEvent {
             os_log(
                 "Return noop transformer because this event is sent by %{public}s",
@@ -86,16 +122,42 @@ class EventTransformerManager {
     }
 
     func get(withDevice device: Device?, withPid pid: pid_t?, withDisplay display: String?) -> EventTransformer {
-        assert(EventThread.shared.isCurrent, "EventTransformerManager.get(withDevice:...) must run on EventThread")
-        return get(withDevice: device, withPid: pid, withDisplay: display, updateActiveCacheKey: false)
+        if EventThread.shared.isCurrent {
+            return getOnCurrentThread(withDevice: device, withPid: pid, withDisplay: display)
+        }
+
+        if let transformer = EventThread.shared.performAndWait({
+            self.getOnCurrentThread(withDevice: device, withPid: pid, withDisplay: display)
+        }) {
+            return transformer
+        }
+
+        return getOnCurrentThread(withDevice: device, withPid: pid, withDisplay: display)
+    }
+
+    private func getOnCurrentThread(
+        withDevice device: Device?,
+        withPid pid: pid_t?,
+        withDisplay display: String?
+    ) -> EventTransformer {
+        get(withDevice: device, withPid: pid, withDisplay: display, updateActiveCacheKey: false)
     }
 
     func handleLogitechControlEvent(_ context: LogitechEventContext) -> Bool {
-        assert(
-            EventThread.shared.isCurrent,
-            "EventTransformerManager.handleLogitechControlEvent(_:) must run on EventThread"
-        )
+        if EventThread.shared.isCurrent {
+            return handleLogitechControlEventOnCurrentThread(context)
+        }
 
+        if let handled = EventThread.shared.performAndWait({
+            self.handleLogitechControlEventOnCurrentThread(context)
+        }) {
+            return handled
+        }
+
+        return handleLogitechControlEventOnCurrentThread(context)
+    }
+
+    private func handleLogitechControlEventOnCurrentThread(_ context: LogitechEventContext) -> Bool {
         let transformer = get(withDevice: context.device, withPid: context.pid, withDisplay: context.display)
         return (transformer as? LogitechControlEventHandling)?.handleLogitechControlEvent(context) ?? false
     }

--- a/LinearMouse/EventTransformer/EventTransformerManager.swift
+++ b/LinearMouse/EventTransformer/EventTransformerManager.swift
@@ -13,6 +13,10 @@ class EventTransformerManager {
 
     @Default(.bypassEventsFromOtherApplications) var bypassEventsFromOtherApplications
 
+    /// Protects cache, activeCacheKey, and sharedAutoScrollTransformer from concurrent access
+    /// across the event tap thread, Logitech HID thread, and main thread.
+    private let lock = NSLock()
+
     private var eventTransformerCache = LRUCache<CacheKey, EventTransformer>(countLimit: 16)
     private var activeCacheKey: CacheKey?
     private var sharedAutoScrollTransformer: AutoScrollTransformer?
@@ -30,10 +34,23 @@ class EventTransformerManager {
             .$configuration
             .removeDuplicates()
             .sink { [weak self] _ in
-                self?.sharedAutoScrollTransformer?.deactivate()
-                self?.sharedAutoScrollTransformer = nil
-                self?.activeCacheKey = nil
-                self?.eventTransformerCache.removeAllValues()
+                guard let self else {
+                    return
+                }
+                self.lock.lock()
+                let oldAutoScroll = self.sharedAutoScrollTransformer
+                self.sharedAutoScrollTransformer = nil
+                self.activeCacheKey = nil
+                self.eventTransformerCache.removeAllValues()
+                self.lock.unlock()
+
+                // Dispatch transformer deactivation to the event thread where
+                // Timer.invalidate() is safe (same thread the timers were created on).
+                if let oldAutoScroll {
+                    GlobalEventTap.performOnEventThread {
+                        oldAutoScroll.deactivate()
+                    }
+                }
             }
             .store(in: &subscriptions)
     }
@@ -49,8 +66,6 @@ class EventTransformerManager {
         withMouseLocationPid mouseLocationPid: pid_t?,
         withDisplay display: String?
     ) -> EventTransformer {
-        activeCacheKey = nil
-
         if sourcePid != nil, bypassEventsFromOtherApplications, !cgEvent.isLinearMouseSyntheticEvent {
             os_log(
                 "Return noop transformer because this event is sent by %{public}s",
@@ -74,20 +89,27 @@ class EventTransformerManager {
         let pid = mouseLocationPid ?? targetPid
         let device = DeviceManager.shared.deviceFromCGEvent(cgEvent)
 
-        return get(withDevice: device, withPid: pid, withDisplay: display, updateActiveCacheKey: true)
+        lock.lock()
+        defer { lock.unlock() }
+        return getUnderLock(withDevice: device, withPid: pid, withDisplay: display, updateActiveCacheKey: true)
     }
 
     func get(withDevice device: Device?, withPid pid: pid_t?, withDisplay display: String?) -> EventTransformer {
-        get(withDevice: device, withPid: pid, withDisplay: display, updateActiveCacheKey: false)
+        lock.lock()
+        defer { lock.unlock() }
+        return getUnderLock(withDevice: device, withPid: pid, withDisplay: display, updateActiveCacheKey: false)
     }
 
-    private func get(
+    private func getUnderLock(
         withDevice device: Device?,
         withPid pid: pid_t?,
         withDisplay display: String?,
         updateActiveCacheKey: Bool
     ) -> EventTransformer {
         let prevActiveCacheKey = activeCacheKey
+        if updateActiveCacheKey {
+            activeCacheKey = nil
+        }
         defer {
             if updateActiveCacheKey,
                let prevActiveCacheKey,

--- a/LinearMouse/EventTransformer/EventTransformerManager.swift
+++ b/LinearMouse/EventTransformer/EventTransformerManager.swift
@@ -276,8 +276,7 @@ class EventTransformerManager {
               autoScroll.enabled ?? false,
               let trigger = autoScroll.trigger,
               trigger.valid else {
-            sharedAutoScrollTransformer?.deactivate()
-            sharedAutoScrollTransformer = nil
+            deactivateAutoScrollOnEventThread()
             return nil
         }
 
@@ -295,7 +294,7 @@ class EventTransformerManager {
             return sharedAutoScrollTransformer
         }
 
-        sharedAutoScrollTransformer?.deactivate()
+        deactivateAutoScrollOnEventThread()
         let transformer = AutoScrollTransformer(
             trigger: trigger,
             modes: modes,
@@ -304,6 +303,18 @@ class EventTransformerManager {
         )
         sharedAutoScrollTransformer = transformer
         return transformer
+    }
+
+    /// Deactivate the shared auto-scroll transformer on the event thread (where its
+    /// Timer was created), then clear the reference. Safe to call from any thread.
+    private func deactivateAutoScrollOnEventThread() {
+        let old = sharedAutoScrollTransformer
+        sharedAutoScrollTransformer = nil
+        if let old {
+            GlobalEventTap.performOnEventThread {
+                old.deactivate()
+            }
+        }
     }
 
     private func transition(from previous: EventTransformer?, to current: EventTransformer?) {

--- a/LinearMouse/EventTransformer/EventTransformerManager.swift
+++ b/LinearMouse/EventTransformer/EventTransformerManager.swift
@@ -13,10 +13,6 @@ class EventTransformerManager {
 
     @Default(.bypassEventsFromOtherApplications) var bypassEventsFromOtherApplications
 
-    /// Protects cache, activeCacheKey, and sharedAutoScrollTransformer from concurrent access
-    /// across the event tap thread, Logitech HID thread, and main thread.
-    private let lock = NSLock()
-
     private var eventTransformerCache = LRUCache<CacheKey, EventTransformer>(countLimit: 16)
     private var activeCacheKey: CacheKey?
     private var sharedAutoScrollTransformer: AutoScrollTransformer?
@@ -38,34 +34,16 @@ class EventTransformerManager {
                     return
                 }
 
-                let oldAutoScroll = self.lock.withLock { self.clearCacheUnderLock() }
-
-                if let oldAutoScroll {
-                    EventThread.shared.perform {
-                        oldAutoScroll.deactivate()
-                    }
+                if EventThread.shared.performAndWait({ self.resetState() }) == nil {
+                    self.resetState()
                 }
             }
             .store(in: &subscriptions)
     }
 
-    /// Called from `EventThread.onWillStop` (already on the event thread).
-    /// Clears all cached transformers so they are recreated with the new RunLoop on restart.
+    /// Called from `EventThread.onWillStop` on the event thread.
     func resetForRestart() {
-        let oldAutoScroll = lock.withLock { clearCacheUnderLock() }
-
-        // Already on the event thread — deactivate synchronously.
-        oldAutoScroll?.deactivate()
-    }
-
-    /// Clears the cache and returns the old auto-scroll transformer for deactivation.
-    /// Must be called while holding `lock`.
-    private func clearCacheUnderLock() -> AutoScrollTransformer? {
-        let old = sharedAutoScrollTransformer
-        sharedAutoScrollTransformer = nil
-        activeCacheKey = nil
-        eventTransformerCache.removeAllValues()
-        return old
+        resetState()
     }
 
     private let sourceBundleIdentifierBypassSet: Set<String> = [
@@ -79,6 +57,8 @@ class EventTransformerManager {
         withMouseLocationPid mouseLocationPid: pid_t?,
         withDisplay display: String?
     ) -> EventTransformer {
+        assert(EventThread.shared.isCurrent, "EventTransformerManager.get(withCGEvent:...) must run on EventThread")
+
         if sourcePid != nil, bypassEventsFromOtherApplications, !cgEvent.isLinearMouseSyntheticEvent {
             os_log(
                 "Return noop transformer because this event is sent by %{public}s",
@@ -102,18 +82,25 @@ class EventTransformerManager {
         let pid = mouseLocationPid ?? targetPid
         let device = DeviceManager.shared.deviceFromCGEvent(cgEvent)
 
-        return lock.withLock {
-            getUnderLock(withDevice: device, withPid: pid, withDisplay: display, updateActiveCacheKey: true)
-        }
+        return get(withDevice: device, withPid: pid, withDisplay: display, updateActiveCacheKey: true)
     }
 
     func get(withDevice device: Device?, withPid pid: pid_t?, withDisplay display: String?) -> EventTransformer {
-        lock.withLock {
-            getUnderLock(withDevice: device, withPid: pid, withDisplay: display, updateActiveCacheKey: false)
-        }
+        assert(EventThread.shared.isCurrent, "EventTransformerManager.get(withDevice:...) must run on EventThread")
+        return get(withDevice: device, withPid: pid, withDisplay: display, updateActiveCacheKey: false)
     }
 
-    private func getUnderLock(
+    func handleLogitechControlEvent(_ context: LogitechEventContext) -> Bool {
+        assert(
+            EventThread.shared.isCurrent,
+            "EventTransformerManager.handleLogitechControlEvent(_:) must run on EventThread"
+        )
+
+        let transformer = get(withDevice: context.device, withPid: context.pid, withDisplay: context.display)
+        return (transformer as? LogitechControlEventHandling)?.handleLogitechControlEvent(context) ?? false
+    }
+
+    private func get(
         withDevice device: Device?,
         withPid pid: pid_t?,
         withDisplay display: String?,
@@ -289,7 +276,8 @@ class EventTransformerManager {
               autoScroll.enabled ?? false,
               let trigger = autoScroll.trigger,
               trigger.valid else {
-            deactivateAutoScrollOnEventThread()
+            sharedAutoScrollTransformer?.deactivate()
+            sharedAutoScrollTransformer = nil
             return nil
         }
 
@@ -307,7 +295,8 @@ class EventTransformerManager {
             return sharedAutoScrollTransformer
         }
 
-        deactivateAutoScrollOnEventThread()
+        sharedAutoScrollTransformer?.deactivate()
+        sharedAutoScrollTransformer = nil
         let transformer = AutoScrollTransformer(
             trigger: trigger,
             modes: modes,
@@ -318,18 +307,6 @@ class EventTransformerManager {
         return transformer
     }
 
-    /// Deactivate the shared auto-scroll transformer on the event thread (where its
-    /// Timer was created), then clear the reference. Safe to call from any thread.
-    private func deactivateAutoScrollOnEventThread() {
-        let old = sharedAutoScrollTransformer
-        sharedAutoScrollTransformer = nil
-        if let old {
-            EventThread.shared.perform {
-                old.deactivate()
-            }
-        }
-    }
-
     private func transition(from previous: EventTransformer?, to current: EventTransformer?) {
         let preservedAutoScrollTransformer = sharedAutoScrollTransformer?.isAutoscrollActive == true
             ? sharedAutoScrollTransformer
@@ -337,6 +314,14 @@ class EventTransformerManager {
 
         deactivate(previous, excluding: preservedAutoScrollTransformer)
         reactivate(current, excluding: preservedAutoScrollTransformer)
+    }
+
+    private func resetState() {
+        let oldAutoScroll = sharedAutoScrollTransformer
+        sharedAutoScrollTransformer = nil
+        activeCacheKey = nil
+        eventTransformerCache.removeAllValues()
+        oldAutoScroll?.deactivate()
     }
 
     private func deactivate(

--- a/LinearMouse/EventTransformer/EventTransformerManager.swift
+++ b/LinearMouse/EventTransformer/EventTransformerManager.swift
@@ -37,17 +37,11 @@ class EventTransformerManager {
                 guard let self else {
                     return
                 }
-                self.lock.lock()
-                let oldAutoScroll = self.sharedAutoScrollTransformer
-                self.sharedAutoScrollTransformer = nil
-                self.activeCacheKey = nil
-                self.eventTransformerCache.removeAllValues()
-                self.lock.unlock()
 
-                // Dispatch transformer deactivation to the event thread where
-                // Timer.invalidate() is safe (same thread the timers were created on).
+                let oldAutoScroll = self.lock.withLock { self.clearCacheUnderLock() }
+
                 if let oldAutoScroll {
-                    GlobalEventTap.performOnEventThread {
+                    EventThread.shared.perform {
                         oldAutoScroll.deactivate()
                     }
                 }
@@ -55,21 +49,23 @@ class EventTransformerManager {
             .store(in: &subscriptions)
     }
 
-    /// Called when the event tap stops. Clears all cached transformers so they are
-    /// recreated with the new RunLoop on restart. Transformer deinit handles timer cleanup.
+    /// Called from `EventThread.onWillStop` (already on the event thread).
+    /// Clears all cached transformers so they are recreated with the new RunLoop on restart.
     func resetForRestart() {
-        lock.lock()
-        let oldAutoScroll = sharedAutoScrollTransformer
+        let oldAutoScroll = lock.withLock { clearCacheUnderLock() }
+
+        // Already on the event thread — deactivate synchronously.
+        oldAutoScroll?.deactivate()
+    }
+
+    /// Clears the cache and returns the old auto-scroll transformer for deactivation.
+    /// Must be called while holding `lock`.
+    private func clearCacheUnderLock() -> AutoScrollTransformer? {
+        let old = sharedAutoScrollTransformer
         sharedAutoScrollTransformer = nil
         activeCacheKey = nil
         eventTransformerCache.removeAllValues()
-        lock.unlock()
-
-        if let oldAutoScroll {
-            GlobalEventTap.performOnEventThread {
-                oldAutoScroll.deactivate()
-            }
-        }
+        return old
     }
 
     private let sourceBundleIdentifierBypassSet: Set<String> = [
@@ -106,15 +102,15 @@ class EventTransformerManager {
         let pid = mouseLocationPid ?? targetPid
         let device = DeviceManager.shared.deviceFromCGEvent(cgEvent)
 
-        lock.lock()
-        defer { lock.unlock() }
-        return getUnderLock(withDevice: device, withPid: pid, withDisplay: display, updateActiveCacheKey: true)
+        return lock.withLock {
+            getUnderLock(withDevice: device, withPid: pid, withDisplay: display, updateActiveCacheKey: true)
+        }
     }
 
     func get(withDevice device: Device?, withPid pid: pid_t?, withDisplay display: String?) -> EventTransformer {
-        lock.lock()
-        defer { lock.unlock() }
-        return getUnderLock(withDevice: device, withPid: pid, withDisplay: display, updateActiveCacheKey: false)
+        lock.withLock {
+            getUnderLock(withDevice: device, withPid: pid, withDisplay: display, updateActiveCacheKey: false)
+        }
     }
 
     private func getUnderLock(
@@ -328,7 +324,7 @@ class EventTransformerManager {
         let old = sharedAutoScrollTransformer
         sharedAutoScrollTransformer = nil
         if let old {
-            GlobalEventTap.performOnEventThread {
+            EventThread.shared.perform {
                 old.deactivate()
             }
         }

--- a/LinearMouse/EventTransformer/GestureButtonTransformer.swift
+++ b/LinearMouse/EventTransformer/GestureButtonTransformer.swift
@@ -277,41 +277,38 @@ extension GestureButtonTransformer: EventTransformer {
     }
 }
 
-extension GestureButtonTransformer {
+extension GestureButtonTransformer: LogitechControlEventHandling {
     func handleLogitechControlEvent(_ context: LogitechEventContext) -> Bool {
         guard let triggerLogitechControl = trigger.button?.logitechControl,
               context.controlIdentity.matches(triggerLogitechControl) else {
             return false
         }
 
-        // Dispatch state mutation to the event processing thread to maintain single-threaded access.
-        // If the event thread is not running, return false so the caller falls back to synthetic button.
-        return EventThread.shared.perform { [self] in
-            // Check cooldown
-            if case let .cooldown(until) = state {
-                if DispatchTime.now().uptimeNanoseconds < until {
-                    return
-                }
-                state = .idle
+        if case let .cooldown(until) = state {
+            if DispatchTime.now().uptimeNanoseconds < until {
+                return true
             }
+            state = .idle
+        }
 
-            if context.isPressed {
-                guard trigger.matches(modifierFlags: context.modifierFlags) else {
-                    return
-                }
-                state = .tracking(startTime: DispatchTime.now().uptimeNanoseconds, deltaX: 0, deltaY: 0)
-                os_log("Started tracking gesture (Logitech control)", log: Self.log, type: .info)
-            } else {
-                switch state {
-                case .tracking:
-                    state = .idle
-                case .cooldown:
-                    break
-                default:
-                    break
-                }
+        if context.isPressed {
+            guard trigger.matches(modifierFlags: context.modifierFlags) else {
+                return true
+            }
+            state = .tracking(startTime: DispatchTime.now().uptimeNanoseconds, deltaX: 0, deltaY: 0)
+            os_log("Started tracking gesture (Logitech control)", log: Self.log, type: .info)
+        } else {
+            switch state {
+            case .tracking:
+                state = .idle
+            case .cooldown:
+                break
+            default:
+                break
             }
         }
+
+        return true
     }
 }
 

--- a/LinearMouse/EventTransformer/GestureButtonTransformer.swift
+++ b/LinearMouse/EventTransformer/GestureButtonTransformer.swift
@@ -286,7 +286,7 @@ extension GestureButtonTransformer {
 
         // Dispatch state mutation to the event processing thread to maintain single-threaded access.
         // If the event thread is not running, return false so the caller falls back to synthetic button.
-        return GlobalEventTap.performOnEventThread { [self] in
+        return EventThread.shared.perform { [self] in
             // Check cooldown
             if case let .cooldown(until) = state {
                 if DispatchTime.now().uptimeNanoseconds < until {

--- a/LinearMouse/EventTransformer/GestureButtonTransformer.swift
+++ b/LinearMouse/EventTransformer/GestureButtonTransformer.swift
@@ -285,7 +285,8 @@ extension GestureButtonTransformer {
         }
 
         // Dispatch state mutation to the event processing thread to maintain single-threaded access.
-        GlobalEventTap.performOnEventThread { [self] in
+        // If the event thread is not running, return false so the caller falls back to synthetic button.
+        return GlobalEventTap.performOnEventThread { [self] in
             // Check cooldown
             if case let .cooldown(until) = state {
                 if DispatchTime.now().uptimeNanoseconds < until {
@@ -311,7 +312,6 @@ extension GestureButtonTransformer {
                 }
             }
         }
-        return true
     }
 }
 

--- a/LinearMouse/EventTransformer/GestureButtonTransformer.swift
+++ b/LinearMouse/EventTransformer/GestureButtonTransformer.swift
@@ -284,43 +284,39 @@ extension GestureButtonTransformer {
             return false
         }
 
-        DispatchQueue.main.async { [self] in
-            handleLogitechControlEventOnMain(context)
+        // Dispatch state mutation to the event processing thread to maintain single-threaded access.
+        GlobalEventTap.performOnEventThread { [self] in
+            // Check cooldown
+            if case let .cooldown(until) = state {
+                if DispatchTime.now().uptimeNanoseconds < until {
+                    return
+                }
+                state = .idle
+            }
+
+            if context.isPressed {
+                guard trigger.matches(modifierFlags: context.modifierFlags) else {
+                    return
+                }
+                state = .tracking(startTime: DispatchTime.now().uptimeNanoseconds, deltaX: 0, deltaY: 0)
+                os_log("Started tracking gesture (Logitech control)", log: Self.log, type: .info)
+            } else {
+                switch state {
+                case .tracking:
+                    state = .idle
+                case .cooldown:
+                    break
+                default:
+                    break
+                }
+            }
         }
         return true
-    }
-
-    private func handleLogitechControlEventOnMain(_ context: LogitechEventContext) {
-        // Check cooldown
-        if case let .cooldown(until) = state {
-            if DispatchTime.now().uptimeNanoseconds < until {
-                return
-            }
-            state = .idle
-        }
-
-        if context.isPressed {
-            guard trigger.matches(modifierFlags: context.modifierFlags) else {
-                return
-            }
-            state = .tracking(startTime: DispatchTime.now().uptimeNanoseconds, deltaX: 0, deltaY: 0)
-            os_log("Started tracking gesture (Logitech control)", log: Self.log, type: .info)
-        } else {
-            switch state {
-            case .tracking:
-                state = .idle
-            case .cooldown:
-                break
-            default:
-                break
-            }
-        }
     }
 }
 
 extension GestureButtonTransformer: Deactivatable {
     func deactivate() {
-//        os_log("Deactivating gesture transformer", log: Self.log, type: .info)
         state = .idle
     }
 }

--- a/LinearMouse/EventTransformer/LogitechEventContext.swift
+++ b/LinearMouse/EventTransformer/LogitechEventContext.swift
@@ -7,6 +7,7 @@ struct LogitechEventContext {
     let device: Device?
     let pid: pid_t?
     let display: String?
+    let mouseLocation: CGPoint
     let controlIdentity: LogitechControlIdentity
     let isPressed: Bool
     let modifierFlags: CGEventFlags

--- a/LinearMouse/EventTransformer/SmoothedScrollingTransformer.swift
+++ b/LinearMouse/EventTransformer/SmoothedScrollingTransformer.swift
@@ -17,7 +17,7 @@ final class SmoothedScrollingTransformer: EventTransformer, Deactivatable {
     private let eventSink: (CGEvent) -> Void
 
     private var engine: SmoothedScrollingEngine
-    private var timer: Timer?
+    private var timer: EventThreadTimer?
     private var lastFlags: CGEventFlags = []
 
     init(
@@ -29,17 +29,6 @@ final class SmoothedScrollingTransformer: EventTransformer, Deactivatable {
         self.now = now
         self.eventSink = eventSink
         engine = SmoothedScrollingEngine(smoothed: smoothed)
-    }
-
-    deinit {
-        // Timer is held by the RunLoop even after this object is released (e.g. cache clear).
-        // Dispatch invalidation to the event thread where the timer was created.
-        let timer = self.timer
-        if let timer {
-            GlobalEventTap.performOnEventThread {
-                timer.invalidate()
-            }
-        }
     }
 
     func transform(_ event: CGEvent) -> CGEvent? {
@@ -119,15 +108,12 @@ final class SmoothedScrollingTransformer: EventTransformer, Deactivatable {
             return
         }
 
-        guard let runLoop = GlobalEventTap.processingRunLoop else {
-            return
-        }
-
-        let timer = Timer(timeInterval: Self.timerInterval, repeats: true) { [weak self] _ in
+        timer = EventThread.shared.scheduleTimer(
+            interval: Self.timerInterval,
+            repeats: true
+        ) { [weak self] in
             self?.tick()
         }
-        runLoop.add(timer, forMode: .common)
-        self.timer = timer
     }
 
     private func transformNativeContinuousGesture(

--- a/LinearMouse/EventTransformer/SmoothedScrollingTransformer.swift
+++ b/LinearMouse/EventTransformer/SmoothedScrollingTransformer.swift
@@ -31,6 +31,17 @@ final class SmoothedScrollingTransformer: EventTransformer, Deactivatable {
         engine = SmoothedScrollingEngine(smoothed: smoothed)
     }
 
+    deinit {
+        // Timer is held by the RunLoop even after this object is released (e.g. cache clear).
+        // Dispatch invalidation to the event thread where the timer was created.
+        let timer = self.timer
+        if let timer {
+            GlobalEventTap.performOnEventThread {
+                timer.invalidate()
+            }
+        }
+    }
+
     func transform(_ event: CGEvent) -> CGEvent? {
         guard event.type == .scrollWheel else {
             return event

--- a/LinearMouse/EventTransformer/SmoothedScrollingTransformer.swift
+++ b/LinearMouse/EventTransformer/SmoothedScrollingTransformer.swift
@@ -15,8 +15,9 @@ final class SmoothedScrollingTransformer: EventTransformer, Deactivatable {
     private let smoothed: Scheme.Scrolling.Bidirectional<Scheme.Scrolling.Smoothed>
     private let now: () -> TimeInterval
     private let eventSink: (CGEvent) -> Void
+
     private var engine: SmoothedScrollingEngine
-    private var timer: DispatchSourceTimer?
+    private var timer: Timer?
     private var lastFlags: CGEventFlags = []
 
     init(
@@ -107,13 +108,15 @@ final class SmoothedScrollingTransformer: EventTransformer, Deactivatable {
             return
         }
 
-        let timer = DispatchSource.makeTimerSource(queue: .main)
-        timer.schedule(deadline: .now(), repeating: Self.timerInterval)
-        timer.setEventHandler { [weak self] in
+        guard let runLoop = GlobalEventTap.processingRunLoop else {
+            return
+        }
+
+        let timer = Timer(timeInterval: Self.timerInterval, repeats: true) { [weak self] _ in
             self?.tick()
         }
+        runLoop.add(timer, forMode: .common)
         self.timer = timer
-        timer.resume()
     }
 
     private func transformNativeContinuousGesture(
@@ -179,7 +182,7 @@ final class SmoothedScrollingTransformer: EventTransformer, Deactivatable {
     }
 
     private func stopTimer() {
-        timer?.cancel()
+        timer?.invalidate()
         timer = nil
     }
 

--- a/LinearMouse/Localizable.xcstrings
+++ b/LinearMouse/Localizable.xcstrings
@@ -2150,7 +2150,7 @@
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "%.1f ピクセル"
+            "value" : "%#@value@"
           },
           "substitutions" : {
             "value" : {

--- a/LinearMouse/ScreenManager/ScreenManager.swift
+++ b/LinearMouse/ScreenManager/ScreenManager.swift
@@ -16,15 +16,15 @@ class ScreenManager: ObservableObject {
     @Published private(set) var currentScreen: NSScreen?
     @Published private(set) var currentScreenName: String? {
         didSet {
-            screenNameLock.withLock { _atomicCurrentScreenName = currentScreenName }
+            screenNameLock.withLock { _currentScreenNameSnapshot = currentScreenName }
         }
     }
 
     /// Thread-safe access to `currentScreenName`, for use from the background event tap thread.
     private let screenNameLock = NSLock()
-    private var _atomicCurrentScreenName: String?
-    var atomicCurrentScreenName: String? {
-        screenNameLock.withLock { _atomicCurrentScreenName }
+    private var _currentScreenNameSnapshot: String?
+    var currentScreenNameSnapshot: String? {
+        screenNameLock.withLock { _currentScreenNameSnapshot }
     }
 
     private var hasDisplaySpecificSchemes = false

--- a/LinearMouse/ScreenManager/ScreenManager.swift
+++ b/LinearMouse/ScreenManager/ScreenManager.swift
@@ -14,7 +14,22 @@ class ScreenManager: ObservableObject {
     @Published private(set) var screens: [NSScreen] = []
 
     @Published private(set) var currentScreen: NSScreen?
-    @Published private(set) var currentScreenName: String?
+    @Published private(set) var currentScreenName: String? {
+        didSet {
+            screenNameLock.lock()
+            _atomicCurrentScreenName = currentScreenName
+            screenNameLock.unlock()
+        }
+    }
+
+    /// Thread-safe access to `currentScreenName`, for use from the background event tap thread.
+    private let screenNameLock = NSLock()
+    private var _atomicCurrentScreenName: String?
+    var atomicCurrentScreenName: String? {
+        screenNameLock.lock()
+        defer { screenNameLock.unlock() }
+        return _atomicCurrentScreenName
+    }
 
     private var hasDisplaySpecificSchemes = false
     private var timer: Timer?

--- a/LinearMouse/ScreenManager/ScreenManager.swift
+++ b/LinearMouse/ScreenManager/ScreenManager.swift
@@ -16,9 +16,7 @@ class ScreenManager: ObservableObject {
     @Published private(set) var currentScreen: NSScreen?
     @Published private(set) var currentScreenName: String? {
         didSet {
-            screenNameLock.lock()
-            _atomicCurrentScreenName = currentScreenName
-            screenNameLock.unlock()
+            screenNameLock.withLock { _atomicCurrentScreenName = currentScreenName }
         }
     }
 
@@ -26,9 +24,7 @@ class ScreenManager: ObservableObject {
     private let screenNameLock = NSLock()
     private var _atomicCurrentScreenName: String?
     var atomicCurrentScreenName: String? {
-        screenNameLock.lock()
-        defer { screenNameLock.unlock() }
-        return _atomicCurrentScreenName
+        screenNameLock.withLock { _atomicCurrentScreenName }
     }
 
     private var hasDisplaySpecificSchemes = false

--- a/LinearMouseUnitTests/EventTransformer/ButtonActionsTransformerTests.swift
+++ b/LinearMouseUnitTests/EventTransformer/ButtonActionsTransformerTests.swift
@@ -15,7 +15,7 @@ final class ButtonActionsTransformerTests: XCTestCase {
             )
         ])
 
-        let handled = transformer.handleLogitechControlEvent(.init(
+        let result = transformer.findLogitechMapping(for: .init(
             device: nil,
             pid: nil,
             display: nil,
@@ -24,7 +24,7 @@ final class ButtonActionsTransformerTests: XCTestCase {
             modifierFlags: [.maskCommand, .init(rawValue: UInt64(NX_DEVICERCMDKEYMASK))]
         ))
 
-        XCTAssertTrue(handled)
+        XCTAssertNotNil(result)
     }
 
     func testLogitechSpecificMappingWinsOverGenericMapping() {
@@ -39,7 +39,7 @@ final class ButtonActionsTransformerTests: XCTestCase {
             )
         ])
 
-        let handled = transformer.handleLogitechControlEvent(.init(
+        let result = transformer.findLogitechMapping(for: .init(
             device: nil,
             pid: nil,
             display: nil,
@@ -48,7 +48,8 @@ final class ButtonActionsTransformerTests: XCTestCase {
             modifierFlags: []
         ))
 
-        XCTAssertTrue(handled)
+        XCTAssertNotNil(result)
+        XCTAssertEqual(result?.action, .arg0(.mouseButtonBack))
     }
 
     func testLogitechControlEventMatchesWithPartialIdentity() {
@@ -60,7 +61,7 @@ final class ButtonActionsTransformerTests: XCTestCase {
             )
         ])
 
-        let handled = transformer.handleLogitechControlEvent(.init(
+        let result = transformer.findLogitechMapping(for: .init(
             device: nil,
             pid: nil,
             display: nil,
@@ -73,7 +74,7 @@ final class ButtonActionsTransformerTests: XCTestCase {
             modifierFlags: []
         ))
 
-        XCTAssertTrue(handled)
+        XCTAssertNotNil(result)
     }
 
     func testLogitechConfiguredProductIDMatchesEventWithoutSerialNumber() {
@@ -84,7 +85,7 @@ final class ButtonActionsTransformerTests: XCTestCase {
             )
         ])
 
-        let handled = transformer.handleLogitechControlEvent(.init(
+        let result = transformer.findLogitechMapping(for: .init(
             device: nil,
             pid: nil,
             display: nil,
@@ -93,6 +94,6 @@ final class ButtonActionsTransformerTests: XCTestCase {
             modifierFlags: []
         ))
 
-        XCTAssertTrue(handled)
+        XCTAssertNotNil(result)
     }
 }

--- a/LinearMouseUnitTests/EventTransformer/ButtonActionsTransformerTests.swift
+++ b/LinearMouseUnitTests/EventTransformer/ButtonActionsTransformerTests.swift
@@ -19,6 +19,7 @@ final class ButtonActionsTransformerTests: XCTestCase {
             device: nil,
             pid: nil,
             display: nil,
+            mouseLocation: .zero,
             controlIdentity: .init(controlID: 0x0053),
             isPressed: false,
             modifierFlags: [.maskCommand, .init(rawValue: UInt64(NX_DEVICERCMDKEYMASK))]
@@ -43,13 +44,14 @@ final class ButtonActionsTransformerTests: XCTestCase {
             device: nil,
             pid: nil,
             display: nil,
+            mouseLocation: .zero,
             controlIdentity: .init(controlID: 0x0053, productID: 0x405E, serialNumber: nil),
             isPressed: false,
             modifierFlags: []
         ))
 
         XCTAssertNotNil(result)
-        XCTAssertEqual(result?.action, .arg0(.mouseButtonBack))
+        XCTAssertEqual(result?.action, Scheme.Buttons.Mapping.Action.arg0(.mouseButtonBack))
     }
 
     func testLogitechControlEventMatchesWithPartialIdentity() {
@@ -65,6 +67,7 @@ final class ButtonActionsTransformerTests: XCTestCase {
             device: nil,
             pid: nil,
             display: nil,
+            mouseLocation: .zero,
             controlIdentity: .init(
                 controlID: 0x00C3,
                 productID: 0x405E,
@@ -89,6 +92,7 @@ final class ButtonActionsTransformerTests: XCTestCase {
             device: nil,
             pid: nil,
             display: nil,
+            mouseLocation: .zero,
             controlIdentity: .init(controlID: 0x00C3, productID: 0x405E, serialNumber: nil),
             isPressed: false,
             modifierFlags: []


### PR DESCRIPTION
## Summary

This PR moves mouse event processing off the main thread so the UI stays responsive under heavy input.

It does that by running the `CGEvent` tap, Logitech control-button handling, and event-driven timers on the same dedicated background thread with its own RunLoop.

## What changed

- Move the global `CGEvent` tap to a dedicated background event thread.
- Route Logitech HID++ control-button events onto that same event thread before touching transformer state.
- Keep transformer state single-threaded by making the event thread the owner of transform, timer, activate/deactivate, and restart work.
- Run event timers such as smooth scrolling, auto-scroll, and repeat handling on the event thread instead of the main thread.
- Keep UI work on the main thread, including auto-scroll indicator updates and action execution that needs AppKit.

## Why this structure

The main goal is to avoid blocking the UI without paying a large thread-safety tax.

Instead of spreading locks and cross-thread state management across individual transformers, this change centralizes mutable event-processing state on one background thread. That keeps the concurrency model easier to reason about and keeps the code closer to the original complexity level.

## Expected outcome

- Smoother UI while mouse events are being processed
- Less risk of races during timer, gesture, and auto-scroll handling
- Simpler ownership for event-processing state and restart behavior

## Test plan

- [x] `xcodebuild build` succeeds
- [ ] Manual: verify smooth scrolling works as before
- [ ] Manual: verify auto-scroll in both hold and toggle modes
- [ ] Manual: verify button mappings and repeat handling still work
- [ ] Manual: verify Logitech HID++ control buttons still trigger the expected actions
- [ ] Manual: verify settings changes still take effect immediately
- [ ] Manual: verify the UI remains responsive during heavy scroll input
