### PR TITLE
Add hold-while-pressed mode for keyboard mappings

### DIFF
--- a/Documentation/Configuration.d.ts
+++ b/Documentation/Configuration.d.ts
@@ -550,6 +550,11 @@ declare namespace Scheme {
            * @description Indicates if key repeat is enabled. If the value is true, the action will be repeatedly executed when the button is hold according to the key repeat settings in System Settings.
            */
           repeat?: boolean;
+
+          /**
+           * @description Indicates if keyboard shortcut actions should stay pressed while the button is held. When enabled, LinearMouse sends key down on button press and key up on button release instead of repeating the shortcut.
+           */
+          hold?: boolean;
         }
       | {
           /**

--- a/Documentation/Configuration.json
+++ b/Documentation/Configuration.json
@@ -399,6 +399,10 @@
               "description": "Indicates if the control modifier key should be pressed.",
               "type": "boolean"
             },
+            "hold": {
+              "description": "Indicates if keyboard shortcut actions should stay pressed while the button is held. When enabled, LinearMouse sends key down on button press and key up on button release instead of repeating the shortcut.",
+              "type": "boolean"
+            },
             "option": {
               "description": "Indicates if the option modifier key should be pressed.",
               "type": "boolean"

--- a/Documentation/Configuration.md
+++ b/Documentation/Configuration.md
@@ -584,6 +584,42 @@ If you hold <kbd>option + back</kbd>, the volume will continue to decrease.
 }
 ```
 
+### Hold keyboard shortcuts while pressed
+
+With `hold: true`, keyboard shortcut actions stay pressed for as long as the mouse button is held.
+
+This is different from `repeat: true`:
+
+- `repeat: true` keeps sending the shortcut over and over.
+- `hold: true` sends key down when the mouse button is pressed, then key up when it is released.
+
+This is useful for apps that expect a real held key, such as timeline scrubbing or temporary tools.
+
+```json
+{
+  "schemes": [
+    {
+      "if": {
+        "device": {
+          "category": "mouse"
+        }
+      },
+      "buttons": {
+        "mappings": [
+          {
+            "button": 3,
+            "hold": true,
+            "action": {
+              "keyPress": ["c"]
+            }
+          }
+        ]
+      }
+    }
+  ]
+}
+```
+
 ### Volume up and down with <kbd>option + scrollUp</kbd> and <kbd>option + scrollDown</kbd>
 
 `scroll` can be specified instead of `button` to map scroll events to specific actions.

--- a/LinearMouse/EventTransformer/ButtonActionsTransformer.swift
+++ b/LinearMouse/EventTransformer/ButtonActionsTransformer.swift
@@ -23,17 +23,17 @@ class ButtonActionsTransformer {
     private var logitechRepeatTimer: EventThreadTimer?
     private var heldKeysByButton = [Scheme.Buttons.Mapping.Button: [Key]]()
 
-    static let keySimulator = KeySimulator()
-    var keySimulator: KeySimulator {
-        Self.keySimulator
-    }
+    private static let defaultKeySimulator = KeySimulator()
+    let keySimulator: KeySimulating
 
     init(
         mappings: [Scheme.Buttons.Mapping],
-        universalBackForward: Scheme.Buttons.UniversalBackForward? = nil
+        universalBackForward: Scheme.Buttons.UniversalBackForward? = nil,
+        keySimulator: KeySimulating? = nil
     ) {
         self.mappings = mappings
         self.universalBackForward = universalBackForward
+        self.keySimulator = keySimulator ?? Self.defaultKeySimulator
     }
 
     private func timer(for slot: TimerSlot) -> EventThreadTimer? {
@@ -680,7 +680,14 @@ extension ButtonActionsTransformer: EventTransformer, LogitechControlEventHandli
 
         os_log("Up keys: %{public}@", log: Self.log, type: .info, String(describing: keys))
         try? keySimulator.up(keys: keys.reversed(), tap: .cgSessionEventTap)
-        keySimulator.reset()
+
+        // Only clear KeySimulator's tracked modifier flags once nothing is held; otherwise an
+        // overlapping hold on another button would have its modifier state forgotten, which then
+        // leaks into the next synthetic event we emit (event.flags would be missing the still-held
+        // modifier and the OS would interpret it as released).
+        if heldKeysByButton.isEmpty {
+            keySimulator.reset()
+        }
     }
 
     private func postClickEvent(mouseButton: CGMouseButton, clickState: Int64? = nil) {

--- a/LinearMouse/EventTransformer/ButtonActionsTransformer.swift
+++ b/LinearMouse/EventTransformer/ButtonActionsTransformer.swift
@@ -21,6 +21,7 @@ class ButtonActionsTransformer {
 
     var repeatTimer: EventThreadTimer?
     private var logitechRepeatTimer: EventThreadTimer?
+    private var heldKeysByButton = [Scheme.Buttons.Mapping.Button: [Key]]()
 
     static let keySimulator = KeySimulator()
     var keySimulator: KeySimulator {
@@ -121,6 +122,10 @@ extension ButtonActionsTransformer: EventTransformer, LogitechControlEventHandli
         if event.type == .scrollWheel {
             queueActions(event: event.copy(), action: action)
         } else {
+            if handleKeyPressHold(event: event, mapping: mapping, action: action) {
+                return nil
+            }
+
             // FIXME: `NSEvent.keyRepeatDelay` and `NSEvent.keyRepeatInterval` are not kept up to date
             // TODO: Support override `repeatDelay` and `repeatInterval`
             let keyRepeatDelay = mapping.repeat == true ? KeyboardSettingsSnapshot.shared.keyRepeatDelay : 0
@@ -130,9 +135,6 @@ extension ButtonActionsTransformer: EventTransformer, LogitechControlEventHandli
             if !keyRepeatEnabled {
                 if handleButtonSwaps(event: event, action: action) {
                     return event
-                }
-                if handleModifiersHold(event: event, action: action) {
-                    return nil
                 }
             }
 
@@ -204,10 +206,8 @@ extension ButtonActionsTransformer: EventTransformer, LogitechControlEventHandli
             return false
         }
 
-        if mapping.repeat != true {
-            if handleLogitechModifiersHold(action: action, isPressed: context.isPressed) {
-                return true
-            }
+        if handleLogitechKeyPressHold(mapping: mapping, action: action, context: context) {
+            return true
         }
 
         logitechRepeatTimer?.invalidate()
@@ -233,22 +233,32 @@ extension ButtonActionsTransformer: EventTransformer, LogitechControlEventHandli
         return true
     }
 
-    private func handleLogitechModifiersHold(action: Scheme.Buttons.Mapping.Action, isPressed: Bool) -> Bool {
+    private func shouldHoldKeys(
+        for mapping: Scheme.Buttons.Mapping,
+        action: Scheme.Buttons.Mapping.Action
+    ) -> Bool {
         guard case let .arg1(.keyPress(keys)) = action else {
             return false
         }
 
-        guard keys.allSatisfy(\.isModifier) else {
+        return mapping.hold == true || keys.allSatisfy(\.isModifier)
+    }
+
+    private func handleLogitechKeyPressHold(
+        mapping: Scheme.Buttons.Mapping,
+        action: Scheme.Buttons.Mapping.Action,
+        context: LogitechEventContext
+    ) -> Bool {
+        guard let button = mapping.button,
+              shouldHoldKeys(for: mapping, action: action),
+              case let .arg1(.keyPress(keys)) = action else {
             return false
         }
 
-        if isPressed {
-            os_log("Down keys: %{public}@", log: Self.log, type: .info, String(describing: keys))
-            try? keySimulator.down(keys: keys, tap: .cgSessionEventTap)
+        if context.isPressed {
+            pressAndStoreHeldKeys(keys, for: button)
         } else {
-            os_log("Up keys: %{public}@", log: Self.log, type: .info, String(describing: keys))
-            try? keySimulator.up(keys: keys.reversed(), tap: .cgSessionEventTap)
-            keySimulator.reset()
+            releaseHeldKeys(for: button, fallbackKeys: keys)
         }
 
         return true
@@ -623,46 +633,54 @@ extension ButtonActionsTransformer: EventTransformer, LogitechControlEventHandli
         return true
     }
 
-    private func handleModifiersHold(event: CGEvent, action: Scheme.Buttons.Mapping.Action) -> Bool {
-        guard [mouseDownEventTypes, mouseUpEventTypes]
-            .flatMap(\.self)
-            .contains(event.type)
-        else {
+    private func handleKeyPressHold(
+        event: CGEvent,
+        mapping: Scheme.Buttons.Mapping,
+        action: Scheme.Buttons.Mapping.Action
+    ) -> Bool {
+        guard let button = mapping.button,
+              [mouseDownEventTypes, mouseUpEventTypes, mouseDraggedEventTypes]
+              .flatMap(\.self)
+              .contains(event.type),
+              shouldHoldKeys(for: mapping, action: action),
+              case let .arg1(.keyPress(keys)) = action else {
             return false
         }
 
-        guard case let .arg1(.keyPress(keys)) = action else {
-            return false
-        }
-
-        guard keys.allSatisfy(\.isModifier) else {
-            return false
+        if mouseDraggedEventTypes.contains(event.type) {
+            return true
         }
 
         if mouseDownEventTypes.contains(event.type) {
-            os_log(
-                "Down keys: %{public}@",
-                log: Self.log,
-                type: .info,
-                String(describing: keys)
-            )
-            try? keySimulator.down(keys: keys, tap: .cgSessionEventTap)
+            pressAndStoreHeldKeys(keys, for: button)
             return true
         }
 
         if mouseUpEventTypes.contains(event.type) {
-            os_log(
-                "Up keys: %{public}@",
-                log: Self.log,
-                type: .info,
-                String(describing: keys)
-            )
-            try? keySimulator.up(keys: keys.reversed(), tap: .cgSessionEventTap)
-            keySimulator.reset()
+            releaseHeldKeys(for: button, fallbackKeys: keys)
             return true
         }
 
         return false
+    }
+
+    private func pressAndStoreHeldKeys(_ keys: [Key], for button: Scheme.Buttons.Mapping.Button) {
+        if heldKeysByButton[button] == keys {
+            return
+        }
+
+        heldKeysByButton[button] = keys
+
+        os_log("Down keys: %{public}@", log: Self.log, type: .info, String(describing: keys))
+        try? keySimulator.down(keys: keys, tap: .cgSessionEventTap)
+    }
+
+    private func releaseHeldKeys(for button: Scheme.Buttons.Mapping.Button, fallbackKeys: [Key]) {
+        let keys = heldKeysByButton.removeValue(forKey: button) ?? fallbackKeys
+
+        os_log("Up keys: %{public}@", log: Self.log, type: .info, String(describing: keys))
+        try? keySimulator.up(keys: keys.reversed(), tap: .cgSessionEventTap)
+        keySimulator.reset()
     }
 
     private func postClickEvent(mouseButton: CGMouseButton, clickState: Int64? = nil) {
@@ -709,5 +727,12 @@ extension ButtonActionsTransformer: Deactivatable {
             logitechRepeatTimer.invalidate()
             self.logitechRepeatTimer = nil
         }
+
+        let heldKeys = heldKeysByButton.values
+        heldKeysByButton.removeAll()
+        for keys in heldKeys {
+            try? keySimulator.up(keys: keys.reversed(), tap: .cgSessionEventTap)
+        }
+        keySimulator.reset()
     }
 }

--- a/LinearMouse/EventTransformer/ButtonActionsTransformer.swift
+++ b/LinearMouse/EventTransformer/ButtonActionsTransformer.swift
@@ -665,7 +665,12 @@ extension ButtonActionsTransformer: EventTransformer, LogitechControlEventHandli
     }
 
     private func pressAndStoreHeldKeys(_ keys: [Key], for button: Scheme.Buttons.Mapping.Button) {
-        if heldKeysByButton[button] == keys {
+        // Treat the down→up cycle as atomic: once a button is tracked, ignore any subsequent
+        // pressed=true reports until release. Otherwise a stuttering pressed=true that resolves
+        // to a different mapping (e.g. modifier flags changed mid-hold and matched another rule)
+        // would overwrite `heldKeysByButton[button]` without releasing the originally pressed
+        // keys, leaving them stuck until something else clears them.
+        if heldKeysByButton[button] != nil {
             return
         }
 

--- a/LinearMouse/Localizable.xcstrings
+++ b/LinearMouse/Localizable.xcstrings
@@ -24201,7 +24201,212 @@
       }
     },
     "Hold keys while pressed" : {
-
+      "localizations" : {
+        "af" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hou sleutels in tydens druk"
+          }
+        },
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "إبقاء المفاتيح مضغوطة أثناء الضغط"
+          }
+        },
+        "bs" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Drži tipke dok je pritisnut"
+          }
+        },
+        "ca" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mantén les tecles premudes"
+          }
+        },
+        "cs" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Držet klávesy stisknuté"
+          }
+        },
+        "da" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hold tasterne nede"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tasten gedrückt halten"
+          }
+        },
+        "el" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Κράτημα πλήκτρων όσο πατιέται"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mantener teclas mientras se pulsa"
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pidä näppäimet painettuna"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Maintenir les touches enfoncées"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "החזק מקשים בעת לחיצה"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Billentyűk lenyomva tartása"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tahan tombol saat ditekan"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tieni premuti i tasti"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "押している間キーを保持"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "누르고 있는 동안 키 유지"
+          }
+        },
+        "my" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ဖိထားစဉ် ကီးများကို ဖိထားရန်"
+          }
+        },
+        "nb-NO" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hold tastene nede"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Houd toetsen ingedrukt"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Trzymaj klawisze wciśnięte"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Manter teclas premidas"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Manter teclas pressionadas"
+          }
+        },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Menține tastele apăsate"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Удерживать клавиши при нажатии"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Držať klávesy stlačené"
+          }
+        },
+        "sr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Држи тастере док је притиснут"
+          }
+        },
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Håll tangenter intryckta"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tuşları basılı tut"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Утримувати клавіші при натисканні"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Giữ phím khi nhấn"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "按住时保持按下"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "按住時維持按下"
+          }
+        },
+        "zh-Hant-HK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "按住時維持按下"
+          }
+        }
+      }
     },
     "Hold the button and drag to trigger gestures. Drag at least %lld pixels in one direction." : {
       "localizations" : {
@@ -39210,7 +39415,212 @@
       }
     },
     "Repeat" : {
-
+      "localizations" : {
+        "af" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Herhaal"
+          }
+        },
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "تكرار"
+          }
+        },
+        "bs" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ponovi"
+          }
+        },
+        "ca" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Repeteix"
+          }
+        },
+        "cs" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Opakovat"
+          }
+        },
+        "da" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Gentag"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Wiederholen"
+          }
+        },
+        "el" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Επανάληψη"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Repetir"
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Toista"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Répéter"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "חזור"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ismétlés"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ulangi"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ripeti"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "繰り返し"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "반복"
+          }
+        },
+        "my" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ပြန်လုပ်ရန်"
+          }
+        },
+        "nb-NO" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Gjenta"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Herhalen"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Powtarzaj"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Repetir"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Repetir"
+          }
+        },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Repetă"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Повтор"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Opakovať"
+          }
+        },
+        "sr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Понови"
+          }
+        },
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Upprepa"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tekrarla"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Повторювати"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Lặp lại"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "重复"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "重複"
+          }
+        },
+        "zh-Hant-HK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "重複"
+          }
+        }
+      }
     },
     "Repeat on hold" : {
       "localizations" : {
@@ -47764,7 +48174,212 @@
       }
     },
     "Send once on release" : {
-
+      "localizations" : {
+        "af" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Stuur een keer met loslaat"
+          }
+        },
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "إرسال مرة واحدة عند الإفلات"
+          }
+        },
+        "bs" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pošalji jednom pri otpuštanju"
+          }
+        },
+        "ca" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Envia un cop en deixar anar"
+          }
+        },
+        "cs" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Odeslat jednou při uvolnění"
+          }
+        },
+        "da" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Send én gang ved slip"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Einmal beim Loslassen senden"
+          }
+        },
+        "el" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Αποστολή μία φορά κατά την απελευθέρωση"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Enviar una vez al soltar"
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Lähetä kerran vapautettaessa"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Envoyer une fois au relâchement"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "שלח פעם אחת בשחרור"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Küldés egyszer felengedéskor"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kirim sekali saat dilepas"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Invia una volta al rilascio"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "離したときに 1 回送信"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "놓을 때 한 번 전송"
+          }
+        },
+        "my" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "လွှတ်လိုက်သော အခါ တစ်ကြိမ် ပို့ရန်"
+          }
+        },
+        "nb-NO" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Send én gang ved slipp"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Eén keer verzenden bij loslaten"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Wyślij raz po zwolnieniu"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Enviar uma vez ao soltar"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Enviar uma vez ao soltar"
+          }
+        },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Trimite o dată la eliberare"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Отправить один раз при отпускании"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Odoslať raz pri uvoľnení"
+          }
+        },
+        "sr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Пошаљи једном при пуштању"
+          }
+        },
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Skicka en gång vid släpp"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bırakınca bir kez gönder"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Надіслати один раз при відпусканні"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Gửi một lần khi nhả"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "松开时发送一次"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "放開時發送一次"
+          }
+        },
+        "zh-Hant-HK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "放開時發送一次"
+          }
+        }
+      }
     },
     "Settings" : {
       "extractionState" : "manual",
@@ -56738,7 +57353,212 @@
       }
     },
     "While pressed" : {
-
+      "localizations" : {
+        "af" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tydens druk"
+          }
+        },
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "أثناء الضغط"
+          }
+        },
+        "bs" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dok je pritisnut"
+          }
+        },
+        "ca" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mentre està premut"
+          }
+        },
+        "cs" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Při stisknutí"
+          }
+        },
+        "da" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mens trykket"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Während gedrückt"
+          }
+        },
+        "el" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Όσο πατιέται"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mientras se mantiene pulsado"
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Painettuna"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pendant l’appui"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "בעת לחיצה"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Lenyomás közben"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Saat ditekan"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mentre premuto"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "押している間"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "누르고 있는 동안"
+          }
+        },
+        "my" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ဖိထားစဉ်"
+          }
+        },
+        "nb-NO" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mens trykket"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tijdens indrukken"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Podczas naciskania"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Enquanto premido"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Enquanto pressionado"
+          }
+        },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "În timpul apăsării"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Пока нажато"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Počas stlačenia"
+          }
+        },
+        "sr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Док је притиснут"
+          }
+        },
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "När nedtryckt"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Basılı tutarken"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Поки натиснуто"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Khi đang nhấn"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "按住时"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "按住時"
+          }
+        },
+        "zh-Hant-HK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "按住時"
+          }
+        }
+      }
     },
     "You may also press ⌃⇧⌘Z to revert to system defaults." : {
       "localizations" : {

--- a/LinearMouse/Localizable.xcstrings
+++ b/LinearMouse/Localizable.xcstrings
@@ -24200,6 +24200,9 @@
         }
       }
     },
+    "Hold keys while pressed" : {
+
+    },
     "Hold the button and drag to trigger gestures. Drag at least %lld pixels in one direction." : {
       "localizations" : {
         "af" : {
@@ -39206,6 +39209,9 @@
         }
       }
     },
+    "Repeat" : {
+
+    },
     "Repeat on hold" : {
       "localizations" : {
         "af" : {
@@ -47756,6 +47762,9 @@
           }
         }
       }
+    },
+    "Send once on release" : {
+
     },
     "Settings" : {
       "extractionState" : "manual",
@@ -56727,6 +56736,9 @@
           }
         }
       }
+    },
+    "While pressed" : {
+
     },
     "You may also press ⌃⇧⌘Z to revert to system defaults." : {
       "localizations" : {

--- a/LinearMouse/Model/Configuration/Scheme/Buttons/Mapping/Mapping.swift
+++ b/LinearMouse/Model/Configuration/Scheme/Buttons/Mapping/Mapping.swift
@@ -5,6 +5,7 @@ extension Scheme.Buttons {
     struct Mapping: Equatable, Hashable {
         var button: Button?
         var `repeat`: Bool?
+        var hold: Bool?
 
         var scroll: ScrollDirection?
 
@@ -62,6 +63,43 @@ extension Scheme.Buttons.Mapping {
 
     enum ScrollDirection: String, Codable, Hashable {
         case up, down, left, right
+    }
+
+    enum KeyPressBehavior: String, CaseIterable, Identifiable {
+        case sendOnRelease
+        case `repeat`
+        case holdWhilePressed
+
+        var id: Self {
+            self
+        }
+    }
+
+    var keyPressBehavior: KeyPressBehavior {
+        get {
+            if hold == true {
+                return .holdWhilePressed
+            }
+
+            if `repeat` == true {
+                return .repeat
+            }
+
+            return .sendOnRelease
+        }
+        set {
+            switch newValue {
+            case .sendOnRelease:
+                `repeat` = nil
+                hold = nil
+            case .repeat:
+                `repeat` = true
+                hold = nil
+            case .holdWhilePressed:
+                `repeat` = nil
+                hold = true
+            }
+        }
     }
 
     var modifierFlags: CGEventFlags {
@@ -198,6 +236,7 @@ extension Scheme.Buttons.Mapping: Codable {
         case logiButton
         case logitechControl
         case `repeat`
+        case hold
         case scroll
         case command
         case shift
@@ -214,6 +253,7 @@ extension Scheme.Buttons.Mapping: Codable {
             ?? container.decodeIfPresent(LogitechControlIdentity.self, forKey: .logitechControl)
             .map(Button.logitechControl)
         `repeat` = try container.decodeIfPresent(Bool.self, forKey: .repeat)
+        hold = try container.decodeIfPresent(Bool.self, forKey: .hold)
         scroll = try container.decodeIfPresent(ScrollDirection.self, forKey: .scroll)
         command = try container.decodeIfPresent(Bool.self, forKey: .command)
         shift = try container.decodeIfPresent(Bool.self, forKey: .shift)
@@ -227,6 +267,7 @@ extension Scheme.Buttons.Mapping: Codable {
 
         try container.encodeIfPresent(button, forKey: .button)
         try container.encodeIfPresent(`repeat`, forKey: .repeat)
+        try container.encodeIfPresent(hold, forKey: .hold)
         try container.encodeIfPresent(scroll, forKey: .scroll)
         try container.encodeIfPresent(command, forKey: .command)
         try container.encodeIfPresent(shift, forKey: .shift)

--- a/LinearMouse/UI/ButtonsSettings/ButtonMappingsSection/ButtonMappingButtonRecorder.swift
+++ b/LinearMouse/UI/ButtonsSettings/ButtonMappingsSection/ButtonMappingButtonRecorder.swift
@@ -79,6 +79,7 @@ struct ButtonMappingButtonRecorder: View {
             mapping.modifierFlags = []
             mapping.button = nil
             mapping.repeat = nil
+            mapping.hold = nil
             mapping.scroll = nil
             startEventObservation()
         }

--- a/LinearMouse/UI/ButtonsSettings/ButtonMappingsSection/ButtonMappingEditSheet.swift
+++ b/LinearMouse/UI/ButtonsSettings/ButtonMappingsSection/ButtonMappingEditSheet.swift
@@ -58,8 +58,19 @@ struct ButtonMappingEditSheet: View {
                     ButtonMappingAction(action: $mapping.action.default(.arg0(.auto)))
 
                     if mapping.button != nil {
-                        Toggle(isOn: $mapping.repeat.default(false)) {
-                            Text("Repeat on hold")
+                        if mapping.isKeyPressAction {
+                            Picker("While pressed", selection: $mapping.keyPressBehavior) {
+                                Text("Send once on release").tag(Scheme.Buttons.Mapping.KeyPressBehavior.sendOnRelease)
+                                Text("Repeat").tag(Scheme.Buttons.Mapping.KeyPressBehavior.repeat)
+                                Text("Hold keys while pressed").tag(
+                                    Scheme.Buttons.Mapping.KeyPressBehavior.holdWhilePressed
+                                )
+                            }
+                            .modifier(PickerViewModifier())
+                        } else {
+                            Toggle(isOn: $mapping.repeat.default(false)) {
+                                Text("Repeat on hold")
+                            }
                         }
                     }
                 }
@@ -101,5 +112,28 @@ extension ButtonMappingEditSheet {
 
     var valid: Bool {
         mapping.valid && !conflicted
+    }
+}
+
+private extension Scheme.Buttons.Mapping {
+    var isKeyPressAction: Bool {
+        guard case .arg1(.keyPress) = action else {
+            return false
+        }
+
+        return true
+    }
+}
+
+private extension Binding where Value == Scheme.Buttons.Mapping {
+    var keyPressBehavior: Binding<Scheme.Buttons.Mapping.KeyPressBehavior> {
+        Binding<Scheme.Buttons.Mapping.KeyPressBehavior>(
+            get: {
+                wrappedValue.keyPressBehavior
+            },
+            set: {
+                wrappedValue.keyPressBehavior = $0
+            }
+        )
     }
 }

--- a/LinearMouse/UI/ButtonsSettings/ButtonsSettingsState.swift
+++ b/LinearMouse/UI/ButtonsSettings/ButtonsSettingsState.swift
@@ -214,6 +214,7 @@ extension ButtonsSettingsState {
             var trigger = newValue
             trigger.action = nil
             trigger.repeat = nil
+            trigger.hold = nil
             trigger.scroll = nil
             scheme.buttons.autoScroll.trigger = trigger
         }
@@ -304,6 +305,7 @@ extension ButtonsSettingsState {
             var trigger = newValue
             trigger.action = nil
             trigger.repeat = nil
+            trigger.hold = nil
             trigger.scroll = nil
             scheme.buttons.gesture.trigger = trigger
         }

--- a/LinearMouseUnitTests/EventTransformer/ButtonActionsTransformerTests.swift
+++ b/LinearMouseUnitTests/EventTransformer/ButtonActionsTransformerTests.swift
@@ -39,7 +39,8 @@ private final class RecordingKeySimulator: KeySimulating {
 
 private func logitechContext(
     _ controlID: Int,
-    pressed: Bool
+    pressed: Bool,
+    modifierFlags: CGEventFlags = []
 ) -> LogitechEventContext {
     .init(
         device: nil,
@@ -48,7 +49,7 @@ private func logitechContext(
         mouseLocation: .zero,
         controlIdentity: .init(controlID: controlID),
         isPressed: pressed,
-        modifierFlags: []
+        modifierFlags: modifierFlags
     )
 }
 
@@ -166,6 +167,40 @@ final class ButtonActionsTransformerTests: XCTestCase {
         XCTAssertTrue(transformer.handleLogitechControlEvent(logitechContext(0x0001, pressed: true)))
         XCTAssertTrue(transformer.handleLogitechControlEvent(logitechContext(0x0001, pressed: false)))
 
+        XCTAssertEqual(simulator.events, [.down([.a]), .up([.a]), .reset])
+    }
+
+    func testHoldIgnoresSecondPressEvenWithDifferentKeys() {
+        // If a duplicate pressed=true arrives that resolves to a different mapping (e.g. the
+        // event's modifier flags changed mid-hold), we must not overwrite the tracked keys —
+        // doing so would orphan the originally-pressed keys (release would only release the
+        // overwritten set, leaving the originals stuck).
+        let simulator = RecordingKeySimulator()
+        let transformer = ButtonActionsTransformer(
+            mappings: [
+                .init(
+                    button: .logitechControl(.init(controlID: 0x0001)),
+                    hold: true,
+                    action: .arg1(.keyPress([.a]))
+                ),
+                .init(
+                    button: .logitechControl(.init(controlID: 0x0001)),
+                    hold: true,
+                    shift: true,
+                    action: .arg1(.keyPress([.b]))
+                )
+            ],
+            keySimulator: simulator
+        )
+
+        _ = transformer.handleLogitechControlEvent(logitechContext(0x0001, pressed: true))
+        _ = transformer.handleLogitechControlEvent(
+            logitechContext(0x0001, pressed: true, modifierFlags: .maskShift)
+        )
+        _ = transformer.handleLogitechControlEvent(logitechContext(0x0001, pressed: false))
+
+        // Only the first mapping's keys are pressed and released; the second pressed event is
+        // ignored entirely so nothing gets stuck.
         XCTAssertEqual(simulator.events, [.down([.a]), .up([.a]), .reset])
     }
 

--- a/LinearMouseUnitTests/EventTransformer/ButtonActionsTransformerTests.swift
+++ b/LinearMouseUnitTests/EventTransformer/ButtonActionsTransformerTests.swift
@@ -2,8 +2,55 @@
 // Copyright (c) 2021-2026 LinearMouse
 
 import CoreGraphics
+import KeyKit
 @testable import LinearMouse
 import XCTest
+
+private final class RecordingKeySimulator: KeySimulating {
+    enum Event: Equatable {
+        case down([Key])
+        case up([Key])
+        case press([Key])
+        case reset
+    }
+
+    private(set) var events: [Event] = []
+
+    func down(keys: [Key], tap _: CGEventTapLocation?) throws {
+        events.append(.down(keys))
+    }
+
+    func up(keys: [Key], tap _: CGEventTapLocation?) throws {
+        events.append(.up(keys))
+    }
+
+    func press(keys: [Key], tap _: CGEventTapLocation?) throws {
+        events.append(.press(keys))
+    }
+
+    func reset() {
+        events.append(.reset)
+    }
+
+    func modifiedCGEventFlags(of _: CGEvent) -> CGEventFlags? {
+        nil
+    }
+}
+
+private func logitechContext(
+    _ controlID: Int,
+    pressed: Bool
+) -> LogitechEventContext {
+    .init(
+        device: nil,
+        pid: nil,
+        display: nil,
+        mouseLocation: .zero,
+        controlIdentity: .init(controlID: controlID),
+        isPressed: pressed,
+        modifierFlags: []
+    )
+}
 
 final class ButtonActionsTransformerTests: XCTestCase {
     func testLogitechControlEventMatchesGenericCommandMappingWithRightCommandFlag() {
@@ -99,5 +146,103 @@ final class ButtonActionsTransformerTests: XCTestCase {
         ))
 
         XCTAssertNotNil(result)
+    }
+
+    // MARK: - Hold-while-pressed
+
+    func testHoldKeyPressDownOnButtonDownAndUpOnButtonUp() {
+        let simulator = RecordingKeySimulator()
+        let transformer = ButtonActionsTransformer(
+            mappings: [
+                .init(
+                    button: .logitechControl(.init(controlID: 0x0001)),
+                    hold: true,
+                    action: .arg1(.keyPress([.a]))
+                )
+            ],
+            keySimulator: simulator
+        )
+
+        XCTAssertTrue(transformer.handleLogitechControlEvent(logitechContext(0x0001, pressed: true)))
+        XCTAssertTrue(transformer.handleLogitechControlEvent(logitechContext(0x0001, pressed: false)))
+
+        XCTAssertEqual(simulator.events, [.down([.a]), .up([.a]), .reset])
+    }
+
+    func testHoldDoesNotResendDownIfButtonRepeats() {
+        let simulator = RecordingKeySimulator()
+        let transformer = ButtonActionsTransformer(
+            mappings: [
+                .init(
+                    button: .logitechControl(.init(controlID: 0x0001)),
+                    hold: true,
+                    action: .arg1(.keyPress([.a]))
+                )
+            ],
+            keySimulator: simulator
+        )
+
+        _ = transformer.handleLogitechControlEvent(logitechContext(0x0001, pressed: true))
+        // A second pressed=true event for the same button (e.g. a stuttering report) should not
+        // re-emit a key down — `pressAndStoreHeldKeys` short-circuits when the same keys are
+        // already tracked.
+        _ = transformer.handleLogitechControlEvent(logitechContext(0x0001, pressed: true))
+
+        XCTAssertEqual(simulator.events, [.down([.a])])
+    }
+
+    func testOverlappingHoldsDoNotResetWhileAnotherHoldIsActive() {
+        let simulator = RecordingKeySimulator()
+        let transformer = ButtonActionsTransformer(
+            mappings: [
+                .init(
+                    button: .logitechControl(.init(controlID: 0x0001)),
+                    hold: true,
+                    action: .arg1(.keyPress([.command]))
+                ),
+                .init(
+                    button: .logitechControl(.init(controlID: 0x0002)),
+                    hold: true,
+                    action: .arg1(.keyPress([.shift]))
+                )
+            ],
+            keySimulator: simulator
+        )
+
+        _ = transformer.handleLogitechControlEvent(logitechContext(0x0001, pressed: true))
+        _ = transformer.handleLogitechControlEvent(logitechContext(0x0002, pressed: true))
+        _ = transformer.handleLogitechControlEvent(logitechContext(0x0002, pressed: false))
+        _ = transformer.handleLogitechControlEvent(logitechContext(0x0001, pressed: false))
+
+        // Crucially: no `.reset` between releasing button 2 and releasing button 1, so the
+        // KeySimulator's tracked modifier flags still know command is held while shift is gone.
+        XCTAssertEqual(simulator.events, [
+            .down([.command]),
+            .down([.shift]),
+            .up([.shift]),
+            .up([.command]),
+            .reset
+        ])
+    }
+
+    func testHoldFallsBackToFallbackKeysWhenNothingTracked() {
+        // If a button-up arrives with no prior down (e.g. the down event was filtered out by
+        // app-specific matching), `releaseHeldKeys` still releases the action's keys so the
+        // synthetic key never gets stuck.
+        let simulator = RecordingKeySimulator()
+        let transformer = ButtonActionsTransformer(
+            mappings: [
+                .init(
+                    button: .logitechControl(.init(controlID: 0x0001)),
+                    hold: true,
+                    action: .arg1(.keyPress([.a]))
+                )
+            ],
+            keySimulator: simulator
+        )
+
+        _ = transformer.handleLogitechControlEvent(logitechContext(0x0001, pressed: false))
+
+        XCTAssertEqual(simulator.events, [.up([.a]), .reset])
     }
 }

--- a/LinearMouseUnitTests/Model/ConfigurationTests.swift
+++ b/LinearMouseUnitTests/Model/ConfigurationTests.swift
@@ -125,6 +125,48 @@ final class ConfigurationTests: XCTestCase {
         XCTAssertEqual(button["serialNumber"] as? String, "ABC123")
     }
 
+    func testMappingDecodesHoldFlag() throws {
+        let mapping = try JSONDecoder().decode(
+            Scheme.Buttons.Mapping.self,
+            from: XCTUnwrap(#"{"button":3,"hold":true,"action":{"keyPress":["c"]}}"#.data(using: .utf8))
+        )
+
+        XCTAssertEqual(mapping.button, .mouse(3))
+        XCTAssertEqual(mapping.hold, true)
+        XCTAssertNil(mapping.repeat)
+    }
+
+    func testMappingEncodesHoldFlag() throws {
+        let mapping = Scheme.Buttons.Mapping(
+            button: .mouse(3),
+            hold: true,
+            action: .arg1(.keyPress([.c]))
+        )
+
+        let data = try JSONEncoder().encode(mapping)
+        let jsonObject = try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: Any])
+
+        XCTAssertEqual(jsonObject["button"] as? Int, 3)
+        XCTAssertEqual(jsonObject["hold"] as? Bool, true)
+        XCTAssertNil(jsonObject["repeat"])
+    }
+
+    func testKeyPressBehaviorMapsFlagsExclusively() {
+        var mapping = Scheme.Buttons.Mapping()
+
+        mapping.keyPressBehavior = .repeat
+        XCTAssertEqual(mapping.repeat, true)
+        XCTAssertNil(mapping.hold)
+
+        mapping.keyPressBehavior = .holdWhilePressed
+        XCTAssertEqual(mapping.hold, true)
+        XCTAssertNil(mapping.repeat)
+
+        mapping.keyPressBehavior = .sendOnRelease
+        XCTAssertNil(mapping.hold)
+        XCTAssertNil(mapping.repeat)
+    }
+
     func testLogitechControlButtonDecodesHexProductID() throws {
         let mapping = try JSONDecoder().decode(
             Scheme.Buttons.Mapping.self,

--- a/Modules/KeyKit/Sources/KeyKit/KeyCodeResolver.swift
+++ b/Modules/KeyKit/Sources/KeyKit/KeyCodeResolver.swift
@@ -1,6 +1,7 @@
 // MIT License
 // Copyright (c) 2021-2026 LinearMouse
 
+import AppKit
 import Carbon
 import Combine
 import Foundation
@@ -27,27 +28,17 @@ public class KeyCodeResolver {
             }
             .store(in: &subscriptions)
 
-        runOnMain { self.updateMapping() }
-    }
-
-    private func scheduleMappingUpdate(after delay: TimeInterval) {
-        // The TIS-source-changed notification fires before the new layout is fully published; a
-        // small delay lets the new source settle before we re-translate.
-        DispatchQueue.main.asyncAfter(deadline: .now() + delay) { [weak self] in
-            self?.updateMapping()
+        // `NSEvent.characters` below asserts on the main thread.
+        if Thread.isMainThread {
+            updateMapping()
+        } else {
+            DispatchQueue.main.sync { updateMapping() }
         }
     }
 
-    /// `TISCopyCurrentKeyboardLayoutInputSource` and `TISGetInputSourceProperty` (used inside
-    /// `updateMapping`) are not reliably thread-safe — they trap with `EXC_BREAKPOINT` when called
-    /// off the main thread, even though `UCKeyTranslate` itself is fine. Force the work onto the
-    /// main thread; updates are infrequent enough (init + input-source notifications) that the
-    /// hop is negligible.
-    private func runOnMain(_ work: @escaping () -> Void) {
-        if Thread.isMainThread {
-            work()
-        } else {
-            DispatchQueue.main.sync(execute: work)
+    private func scheduleMappingUpdate(after delay: TimeInterval) {
+        DispatchQueue.main.asyncAfter(deadline: .now() + delay) { [weak self] in
+            self?.updateMapping()
         }
     }
 
@@ -56,7 +47,17 @@ public class KeyCodeResolver {
         var newReversedMapping: [CGKeyCode: Key] = [:]
 
         for keyCode: CGKeyCode in 0 ..< 128 {
-            guard let characters = translatedCharacters(for: keyCode), characters.count == 1 else {
+            guard let cgEvent = CGEvent(keyboardEventSource: nil, virtualKey: keyCode, keyDown: true) else {
+                continue
+            }
+            cgEvent.flags = []
+            guard let nsEvent = NSEvent(cgEvent: cgEvent) else {
+                continue
+            }
+            guard nsEvent.type == .keyDown else {
+                continue
+            }
+            guard let characters = nsEvent.characters, characters.count == 1 else {
                 continue
             }
             guard newMapping[characters] == nil else {
@@ -129,60 +130,6 @@ public class KeyCodeResolver {
             mapping = newMapping
             reversedMapping = newReversedMapping
         }
-    }
-
-    private func translatedCharacters(for keyCode: CGKeyCode) -> String? {
-        guard let layoutData = currentKeyboardLayoutData(),
-              let layoutBytes = CFDataGetBytePtr(layoutData) else {
-            return nil
-        }
-
-        let keyboardType = UInt32(LMGetKbdType())
-
-        var deadKeyState: UInt32 = 0
-        var length = 0
-        var chars = [UniChar](repeating: 0, count: 4)
-
-        let status = layoutBytes.withMemoryRebound(to: UCKeyboardLayout.self, capacity: 1) { keyboardLayout in
-            UCKeyTranslate(
-                keyboardLayout,
-                UInt16(keyCode),
-                UInt16(kUCKeyActionDisplay),
-                0,
-                keyboardType,
-                OptionBits(kUCKeyTranslateNoDeadKeysBit),
-                &deadKeyState,
-                chars.count,
-                &length,
-                &chars
-            )
-        }
-
-        guard status == noErr, length > 0 else {
-            return nil
-        }
-
-        // Layouts that uppercase-by-default (none in the standard ones, but defensive against
-        // exotic third-party layouts) would otherwise miss the lowercase entries in `Key`.
-        return String(utf16CodeUnits: chars, count: Int(length)).lowercased()
-    }
-
-    private func currentKeyboardLayoutData() -> CFData? {
-        let sources: [Unmanaged<TISInputSource>?] = [
-            TISCopyCurrentKeyboardLayoutInputSource(),
-            TISCopyCurrentASCIICapableKeyboardLayoutInputSource()
-        ]
-
-        for source in sources {
-            guard let source = source?.takeRetainedValue(),
-                  let layoutDataPointer = TISGetInputSourceProperty(source, kTISPropertyUnicodeKeyLayoutData) else {
-                continue
-            }
-
-            return unsafeBitCast(layoutDataPointer, to: CFData.self)
-        }
-
-        return nil
     }
 
     public func keyCode(for key: Key) -> CGKeyCode? {

--- a/Modules/KeyKit/Sources/KeyKit/KeyCodeResolver.swift
+++ b/Modules/KeyKit/Sources/KeyKit/KeyCodeResolver.swift
@@ -1,7 +1,6 @@
 // MIT License
 // Copyright (c) 2021-2026 LinearMouse
 
-import AppKit
 import Carbon
 import Combine
 import Foundation
@@ -47,17 +46,7 @@ public class KeyCodeResolver {
         var newReversedMapping: [CGKeyCode: Key] = [:]
 
         for keyCode: CGKeyCode in 0 ..< 128 {
-            guard let cgEvent = CGEvent(keyboardEventSource: nil, virtualKey: keyCode, keyDown: true) else {
-                continue
-            }
-            cgEvent.flags = []
-            guard let nsEvent = NSEvent(cgEvent: cgEvent) else {
-                continue
-            }
-            guard nsEvent.type == .keyDown else {
-                continue
-            }
-            guard let characters = nsEvent.characters, characters.count == 1 else {
+            guard let characters = translatedCharacters(for: keyCode), characters.count == 1 else {
                 continue
             }
             guard newMapping[characters] == nil else {
@@ -130,6 +119,58 @@ public class KeyCodeResolver {
             mapping = newMapping
             reversedMapping = newReversedMapping
         }
+    }
+
+    private func translatedCharacters(for keyCode: CGKeyCode) -> String? {
+        guard let layoutData = currentKeyboardLayoutData(),
+              let layoutBytes = CFDataGetBytePtr(layoutData) else {
+            return nil
+        }
+
+        let keyboardType = UInt32(LMGetKbdType())
+
+        var deadKeyState: UInt32 = 0
+        var length = 0
+        var chars = [UniChar](repeating: 0, count: 4)
+
+        let status = layoutBytes.withMemoryRebound(to: UCKeyboardLayout.self, capacity: 1) { keyboardLayout in
+            UCKeyTranslate(
+                keyboardLayout,
+                UInt16(keyCode),
+                UInt16(kUCKeyActionDisplay),
+                0,
+                keyboardType,
+                OptionBits(kUCKeyTranslateNoDeadKeysBit),
+                &deadKeyState,
+                chars.count,
+                &length,
+                &chars
+            )
+        }
+
+        guard status == noErr, length > 0 else {
+            return nil
+        }
+
+        return String(utf16CodeUnits: chars, count: Int(length)).lowercased()
+    }
+
+    private func currentKeyboardLayoutData() -> CFData? {
+        let sources: [Unmanaged<TISInputSource>?] = [
+            TISCopyCurrentKeyboardLayoutInputSource(),
+            TISCopyCurrentASCIICapableKeyboardLayoutInputSource()
+        ]
+
+        for source in sources {
+            guard let source = source?.takeRetainedValue(),
+                  let layoutDataPointer = TISGetInputSourceProperty(source, kTISPropertyUnicodeKeyLayoutData) else {
+                continue
+            }
+
+            return unsafeBitCast(layoutDataPointer, to: CFData.self)
+        }
+
+        return nil
     }
 
     public func keyCode(for key: Key) -> CGKeyCode? {

--- a/Modules/KeyKit/Sources/KeyKit/KeyCodeResolver.swift
+++ b/Modules/KeyKit/Sources/KeyKit/KeyCodeResolver.swift
@@ -27,14 +27,27 @@ public class KeyCodeResolver {
             }
             .store(in: &subscriptions)
 
-        updateMapping()
+        runOnMain { self.updateMapping() }
     }
 
     private func scheduleMappingUpdate(after delay: TimeInterval) {
         // The TIS-source-changed notification fires before the new layout is fully published; a
         // small delay lets the new source settle before we re-translate.
-        DispatchQueue.global(qos: .utility).asyncAfter(deadline: .now() + delay) { [weak self] in
+        DispatchQueue.main.asyncAfter(deadline: .now() + delay) { [weak self] in
             self?.updateMapping()
+        }
+    }
+
+    /// `TISCopyCurrentKeyboardLayoutInputSource` and `TISGetInputSourceProperty` (used inside
+    /// `updateMapping`) are not reliably thread-safe — they trap with `EXC_BREAKPOINT` when called
+    /// off the main thread, even though `UCKeyTranslate` itself is fine. Force the work onto the
+    /// main thread; updates are infrequent enough (init + input-source notifications) that the
+    /// hop is negligible.
+    private func runOnMain(_ work: @escaping () -> Void) {
+        if Thread.isMainThread {
+            work()
+        } else {
+            DispatchQueue.main.sync(execute: work)
         }
     }
 

--- a/Modules/KeyKit/Sources/KeyKit/KeyCodeResolver.swift
+++ b/Modules/KeyKit/Sources/KeyKit/KeyCodeResolver.swift
@@ -27,16 +27,13 @@ public class KeyCodeResolver {
             }
             .store(in: &subscriptions)
 
-        // `NSEvent.characters` below asserts on the main thread.
-        if Thread.isMainThread {
-            updateMapping()
-        } else {
-            DispatchQueue.main.sync { updateMapping() }
-        }
+        updateMapping()
     }
 
     private func scheduleMappingUpdate(after delay: TimeInterval) {
-        DispatchQueue.main.asyncAfter(deadline: .now() + delay) { [weak self] in
+        // The TIS-source-changed notification fires before the new layout is fully published; a
+        // small delay lets the new source settle before we re-translate.
+        DispatchQueue.global(qos: .utility).asyncAfter(deadline: .now() + delay) { [weak self] in
             self?.updateMapping()
         }
     }
@@ -152,6 +149,8 @@ public class KeyCodeResolver {
             return nil
         }
 
+        // Layouts that uppercase-by-default (none in the standard ones, but defensive against
+        // exotic third-party layouts) would otherwise miss the lowercase entries in `Key`.
         return String(utf16CodeUnits: chars, count: Int(length)).lowercased()
     }
 

--- a/Modules/KeyKit/Sources/KeyKit/KeySimulator.swift
+++ b/Modules/KeyKit/Sources/KeyKit/KeySimulator.swift
@@ -7,8 +7,18 @@ public enum KeySimulatorError: Error {
     case unsupportedKey
 }
 
+/// Abstracts `KeySimulator` so call sites can inject a recorder/mock and avoid posting real key
+/// events from unit tests.
+public protocol KeySimulating: AnyObject {
+    func down(keys: [Key], tap: CGEventTapLocation?) throws
+    func up(keys: [Key], tap: CGEventTapLocation?) throws
+    func press(keys: [Key], tap: CGEventTapLocation?) throws
+    func reset()
+    func modifiedCGEventFlags(of event: CGEvent) -> CGEventFlags?
+}
+
 /// Simulate key presses.
-public class KeySimulator {
+public class KeySimulator: KeySimulating {
     private let keyCodeResolver = KeyCodeResolver()
     private let lock = NSLock()
 


### PR DESCRIPTION
## Summary
- add a dedicated hold-while-pressed mode for keyboard shortcut button mappings
- keep repeat behavior available, but present hold/repeat/send-on-release as clear mutually exclusive options in the UI

## Details
- add a new `hold` mapping flag and document it in the configuration schema/docs
- treat `hold` as a true key down / key up flow instead of repeated taps
- continue to support modifier-key hold behavior, and extend the same semantics to regular key mappings when hold mode is selected
- reset transient mapping state when recording auto-scroll / gesture triggers so hold/repeat settings do not leak into those paths
- only reset `KeySimulator`'s tracked modifier flags once nothing is held, so releasing one button while another still holds a modifier no longer zeroes the simulator's flag state mid-flight (overlapping holds keep working as expected)
- introduce a `KeySimulating` protocol so unit tests inject a recorder instead of posting real key events; covers down/up lifecycle, duplicate-press dedup, fallback-keys path, and the overlapping-holds invariant

## Testing
- `xcodebuild test -scheme LinearMouse -destination 'platform=macOS' -only-testing:LinearMouseUnitTests/ButtonActionsTransformerTests -only-testing:LinearMouseUnitTests/ButtonMappingActionBindingTests -only-testing:LinearMouseUnitTests/ConfigurationTests`
- `xcodebuild test -scheme KeyKit -destination 'platform=macOS'`

## Linked issues
- Fixes #893
- Fixes #974

## Notes
This addresses the use case behind the assigned keyboard-hold requests where a button should keep a key such as \`C\` pressed until the button is released, instead of repeatedly tapping it.