### PR TITLE
Fix event processing performance regressions

### DIFF
--- a/LinearMouse/Device/Device.swift
+++ b/LinearMouse/Device/Device.swift
@@ -1,6 +1,7 @@
 // MIT License
 // Copyright (c) 2021-2026 LinearMouse
 
+import Combine
 import Defaults
 import Foundation
 import ObservationToken
@@ -34,6 +35,7 @@ class Device {
     private weak var manager: DeviceManager?
     private var inputReportHandlers: [InputReportHandler] = []
     private var logitechReprogrammableControlsMonitor: LogitechReprogrammableControlsMonitor?
+    private var logitechControlsMonitorSubscriptions = Set<AnyCancellable>()
     private let device: PointerDevice
 
     var pointerDevice: PointerDevice {
@@ -99,7 +101,8 @@ class Device {
         if LogitechReprogrammableControlsMonitor.supports(device: self) {
             let monitor = LogitechReprogrammableControlsMonitor(device: self)
             logitechReprogrammableControlsMonitor = monitor
-            monitor.start()
+            observeLogitechControlsMonitorDemand()
+            updateLogitechControlsMonitorRunning()
         }
 
         os_log(
@@ -129,6 +132,7 @@ class Device {
         reportObservationToken = nil
         logitechReprogrammableControlsMonitor?.stop()
         logitechReprogrammableControlsMonitor = nil
+        logitechControlsMonitorSubscriptions.removeAll()
     }
 
     func markActive(reason: String) {
@@ -140,7 +144,47 @@ class Device {
     }
 
     func requestLogitechControlsForcedReconfiguration() {
+        updateLogitechControlsMonitorRunning()
         logitechReprogrammableControlsMonitor?.requestForcedReconfiguration()
+    }
+
+    func prepareLogitechControlsRecording() {
+        guard let logitechReprogrammableControlsMonitor else {
+            return
+        }
+
+        logitechReprogrammableControlsMonitor.start()
+        logitechReprogrammableControlsMonitor.requestReconfiguration()
+    }
+
+    private func observeLogitechControlsMonitorDemand() {
+        ConfigurationState.shared
+            .$configuration
+            .dropFirst()
+            .sink { [weak self] _ in
+                self?.updateLogitechControlsMonitorRunning()
+            }
+            .store(in: &logitechControlsMonitorSubscriptions)
+
+        SettingsState.shared
+            .$recording
+            .dropFirst()
+            .sink { [weak self] _ in
+                self?.updateLogitechControlsMonitorRunning()
+            }
+            .store(in: &logitechControlsMonitorSubscriptions)
+    }
+
+    private func updateLogitechControlsMonitorRunning() {
+        guard let logitechReprogrammableControlsMonitor else {
+            return
+        }
+
+        if LogitechReprogrammableControlsMonitor.isNeeded() {
+            logitechReprogrammableControlsMonitor.start()
+        } else {
+            logitechReprogrammableControlsMonitor.stop()
+        }
     }
 }
 

--- a/LinearMouse/Device/ReceiverMonitor.swift
+++ b/LinearMouse/Device/ReceiverMonitor.swift
@@ -160,6 +160,7 @@ private final class ReceiverContext {
     private let stateLock = NSLock()
     private var lastPublishedIdentities = [ReceiverLogicalDeviceIdentity]()
     private var stateStore = ReceiverSlotStateStore()
+    private var currentChannel: LogitechReceiverChannel?
 
     var onDiscoveryTimedOut: (() -> Void)?
     var onSlotsChanged: (([ReceiverLogicalDeviceIdentity]) -> Void)?
@@ -192,25 +193,35 @@ private final class ReceiverContext {
         stateLock.lock()
         isRunning = false
         let thread = workerThread
+        let channel = currentChannel
         workerThread = nil
         stateLock.unlock()
 
+        channel?.wake()
         thread?.cancel()
     }
 
     private func workerMain() {
         let initialDeadline = Date().addingTimeInterval(ReceiverMonitor.initialDiscoveryTimeout)
         var hasPublishedInitialState = false
-        var currentChannel: LogitechReceiverChannel?
         var hasCompletedInitialDiscovery = false
+        defer {
+            setCurrentChannel(nil)
+        }
 
         while shouldContinueRunning() {
-            if currentChannel == nil {
-                currentChannel = provider.openReceiverChannel(for: device.pointerDevice)
+            if currentChannelSnapshot() == nil {
+                let channel = provider.openReceiverChannel(for: device.pointerDevice)
+                setCurrentChannel(channel)
                 hasCompletedInitialDiscovery = false
+
+                if !shouldContinueRunning() {
+                    channel?.wake()
+                    break
+                }
             }
 
-            guard let receiverChannel = currentChannel else {
+            guard let receiverChannel = currentChannelSnapshot() else {
                 os_log(
                     "Receiver monitor is waiting for channel: locationID=%{public}d device=%{public}@",
                     log: ReceiverMonitor.log,
@@ -297,7 +308,7 @@ private final class ReceiverContext {
                         locationID,
                         String(describing: device)
                     )
-                    currentChannel = nil
+                    setCurrentChannel(nil)
                 }
                 continue
             }
@@ -368,6 +379,18 @@ private final class ReceiverContext {
         stateLock.lock()
         defer { stateLock.unlock() }
         return isRunning
+    }
+
+    private func setCurrentChannel(_ channel: LogitechReceiverChannel?) {
+        stateLock.lock()
+        currentChannel = channel
+        stateLock.unlock()
+    }
+
+    private func currentChannelSnapshot() -> LogitechReceiverChannel? {
+        stateLock.lock()
+        defer { stateLock.unlock() }
+        return currentChannel
     }
 
     private func mergeDiscovery(_ discovery: LogitechHIDPPDeviceMetadataProvider.ReceiverPointingDeviceDiscovery) {

--- a/LinearMouse/Device/VendorSpecific/Logitech/LogitechHIDPPDeviceMetadataProvider.swift
+++ b/LinearMouse/Device/VendorSpecific/Logitech/LogitechHIDPPDeviceMetadataProvider.swift
@@ -765,6 +765,7 @@ final class LogitechReceiverChannel: VendorSpecificDeviceContext {
 
     private let manager: IOHIDManager
     private let device: IOHIDDevice
+    private let runLoop: CFRunLoop
     private var inputReportBuffer: UnsafeMutablePointer<UInt8>?
     private let pendingLock = NSLock()
     private let requestLock = NSLock()
@@ -812,6 +813,7 @@ final class LogitechReceiverChannel: VendorSpecificDeviceContext {
     init?(manager: IOHIDManager, device: IOHIDDevice) {
         self.manager = manager
         self.device = device
+        runLoop = CFRunLoopGetCurrent()
         vendorID = Self.getProperty(kIOHIDVendorIDKey, from: device)
         productID = Self.getProperty(kIOHIDProductIDKey, from: device)
         product = Self.getProperty(kIOHIDProductKey, from: device)
@@ -844,7 +846,7 @@ final class LogitechReceiverChannel: VendorSpecificDeviceContext {
             return nil
         }
 
-        IOHIDDeviceScheduleWithRunLoop(device, CFRunLoopGetCurrent(), CFRunLoopMode.defaultMode.rawValue)
+        IOHIDDeviceScheduleWithRunLoop(device, runLoop, CFRunLoopMode.defaultMode.rawValue)
         IOHIDDeviceRegisterInputReportCallback(
             device,
             inputReportBuffer,
@@ -856,9 +858,9 @@ final class LogitechReceiverChannel: VendorSpecificDeviceContext {
 
     deinit {
         inputReportBuffer?.deallocate()
-        IOHIDDeviceUnscheduleFromRunLoop(device, CFRunLoopGetCurrent(), CFRunLoopMode.defaultMode.rawValue)
+        IOHIDDeviceUnscheduleFromRunLoop(device, runLoop, CFRunLoopMode.defaultMode.rawValue)
         IOHIDDeviceClose(device, IOOptionBits(kIOHIDOptionsTypeNone))
-        IOHIDManagerUnscheduleFromRunLoop(manager, CFRunLoopGetCurrent(), CFRunLoopMode.defaultMode.rawValue)
+        IOHIDManagerUnscheduleFromRunLoop(manager, runLoop, CFRunLoopMode.defaultMode.rawValue)
         IOHIDManagerClose(manager, IOOptionBits(kIOHIDOptionsTypeNone))
     }
 
@@ -1243,7 +1245,7 @@ final class LogitechReceiverChannel: VendorSpecificDeviceContext {
 
     private func performGetReportRequest(
         _ report: Data,
-        timeout: TimeInterval,
+        timeout _: TimeInterval,
         matching: @escaping (Data) -> Bool,
         requestType: IOHIDReportType,
         responseType: IOHIDReportType
@@ -1256,16 +1258,7 @@ final class LogitechReceiverChannel: VendorSpecificDeviceContext {
             return nil
         }
 
-        let deadline = Date().addingTimeInterval(timeout)
-        while Date() < deadline {
-            if let response = getMatchingReport(type: responseType, matching: matching) {
-                return response
-            }
-
-            CFRunLoopRunInMode(.defaultMode, 0.01, true)
-        }
-
-        return nil
+        return getMatchingReport(type: responseType, matching: matching)
     }
 
     private func sendReport(_ report: Data, type: IOHIDReportType) -> IOReturn {
@@ -1387,7 +1380,12 @@ final class LogitechReceiverChannel: VendorSpecificDeviceContext {
                 return response
             }
 
-            CFRunLoopRunInMode(.defaultMode, 0.01, true)
+            let remaining = deadline.timeIntervalSinceNow
+            guard remaining > 0 else {
+                break
+            }
+
+            CFRunLoopRunInMode(.defaultMode, remaining, true)
         }
 
         clearPendingRequest()
@@ -1413,6 +1411,15 @@ final class LogitechReceiverChannel: VendorSpecificDeviceContext {
         pendingResponse = nil
         pendingSemaphore = nil
         pendingLock.unlock()
+    }
+
+    func wake() {
+        CFRunLoopWakeUp(runLoop)
+
+        pendingLock.lock()
+        let semaphore = pendingSemaphore
+        pendingLock.unlock()
+        semaphore?.signal()
     }
 
     private func readConnectionState() -> [UInt8]? {
@@ -1612,6 +1619,7 @@ final class LogitechReprogrammableControlsMonitor {
     private let device: Device
     private let provider = LogitechHIDPPDeviceMetadataProvider()
     private let stateLock = NSLock()
+    private let reconfigurationSemaphore = DispatchSemaphore(value: 0)
     private var subscriptions = Set<AnyCancellable>()
     private var directDeviceReportObservationToken: ObservationToken?
 
@@ -1620,6 +1628,7 @@ final class LogitechReprogrammableControlsMonitor {
     private var pressedButtons = Set<Int>()
     private var needsReconfiguration = false
     private var needsForcedReconfiguration = false
+    private weak var activeNotificationEndpoint: HIDPPNotificationHandling?
 
     init(device: Device) {
         self.device = device
@@ -1635,6 +1644,27 @@ final class LogitechReprogrammableControlsMonitor {
         }
 
         return true
+    }
+
+    static func isNeeded(configuration: Configuration = ConfigurationState.shared.configuration) -> Bool {
+        SettingsState.shared.recording || configuration.schemes.contains { scheme in
+            let buttons = scheme.buttons
+            if buttons.mappings?.contains(where: { $0.button?.logitechControl != nil }) == true {
+                return true
+            }
+
+            if buttons.$autoScroll?.enabled ?? false,
+               buttons.$autoScroll?.trigger?.button?.logitechControl != nil {
+                return true
+            }
+
+            if buttons.$gesture?.enabled ?? false,
+               buttons.$gesture?.trigger?.button?.logitechControl != nil {
+                return true
+            }
+
+            return false
+        }
     }
 
     func start() {
@@ -1660,9 +1690,12 @@ final class LogitechReprogrammableControlsMonitor {
         stateLock.lock()
         running = false
         let thread = workerThread
+        let notificationEndpoint = activeNotificationEndpoint
         workerThread = nil
         stateLock.unlock()
 
+        reconfigurationSemaphore.signal()
+        notificationEndpoint?.wake()
         thread?.cancel()
         subscriptions.removeAll()
         directDeviceReportObservationToken = nil
@@ -1671,6 +1704,7 @@ final class LogitechReprogrammableControlsMonitor {
     private func workerMain() {
         defer {
             releaseButtonIfNeeded()
+            setActiveNotificationEndpoint(nil)
         }
 
         guard let monitorTarget = resolveMonitorTarget() else {
@@ -1694,6 +1728,7 @@ final class LogitechReprogrammableControlsMonitor {
         let targetName = targetIdentity?.name ?? device.productName ?? device.name
         var pendingReportingRestoreByControlID = [UInt16: ReportingInfo]()
 
+        setActiveNotificationEndpoint(monitorTarget.notificationEndpoint)
         monitorTarget.notificationEndpoint.enableNotifications()
         logAvailableControls(transport: transport, featureIndex: featureIndex, slot: slot, locationID: locationID)
 
@@ -1986,7 +2021,7 @@ final class LogitechReprogrammableControlsMonitor {
                 return true
             }
 
-            Thread.sleep(forTimeInterval: Constants.notificationTimeout)
+            _ = reconfigurationSemaphore.wait(timeout: .now() + Constants.notificationTimeout)
         }
 
         return false
@@ -2288,14 +2323,22 @@ final class LogitechReprogrammableControlsMonitor {
     func requestReconfiguration() {
         stateLock.lock()
         needsReconfiguration = true
+        let notificationEndpoint = activeNotificationEndpoint
         stateLock.unlock()
+
+        reconfigurationSemaphore.signal()
+        notificationEndpoint?.wake()
     }
 
     func requestForcedReconfiguration() {
         stateLock.lock()
         needsReconfiguration = true
         needsForcedReconfiguration = true
+        let notificationEndpoint = activeNotificationEndpoint
         stateLock.unlock()
+
+        reconfigurationSemaphore.signal()
+        notificationEndpoint?.wake()
     }
 
     private func consumeReconfigurationRequest() -> (needed: Bool, forced: Bool) {
@@ -2310,6 +2353,12 @@ final class LogitechReprogrammableControlsMonitor {
         needsReconfiguration = false
         needsForcedReconfiguration = false
         return (true, forced)
+    }
+
+    private func setActiveNotificationEndpoint(_ endpoint: HIDPPNotificationHandling?) {
+        stateLock.lock()
+        activeNotificationEndpoint = endpoint
+        stateLock.unlock()
     }
 
     private func desiredDivertedControlIDs(
@@ -2760,6 +2809,7 @@ final class LogitechReprogrammableControlsMonitor {
 
 private protocol HIDPPNotificationHandling: AnyObject {
     func enableNotifications()
+    func wake()
     func waitForHIDPPNotification(
         timeout: TimeInterval,
         matching: @escaping ([UInt8]) -> Bool,
@@ -2775,6 +2825,10 @@ private final class HIDPPNotificationEndpoint: HIDPPNotificationHandling {
     private var bufferedReports = [[UInt8]]()
 
     func enableNotifications() {}
+
+    func wake() {
+        semaphore.signal()
+    }
 
     func handleInputReport(_ report: Data) {
         let bytes = [UInt8](report)
@@ -2813,7 +2867,7 @@ private final class HIDPPNotificationEndpoint: HIDPPNotificationHandling {
                 break
             }
 
-            _ = semaphore.wait(timeout: .now() + min(remaining, 0.01))
+            _ = semaphore.wait(timeout: .now() + remaining)
         }
 
         return dequeueFirstMatchingReport(matching: matching)

--- a/LinearMouse/Device/VendorSpecific/Logitech/LogitechHIDPPDeviceMetadataProvider.swift
+++ b/LinearMouse/Device/VendorSpecific/Logitech/LogitechHIDPPDeviceMetadataProvider.swift
@@ -1983,9 +1983,12 @@ final class LogitechReprogrammableControlsMonitor {
                         continue
                     }
 
+                    let usesProcessConditions = ConfigurationState.shared.configuration.usesProcessConditions
                     let mouseLocation = CGEvent(source: nil)?.location ?? .zero
-                    let mouseLocationPid = mouseLocation.topmostWindowOwnerPid
+                    let mouseLocationPid = usesProcessConditions
+                        ? mouseLocation.topmostWindowOwnerPid
                         ?? NSWorkspace.shared.frontmostApplication?.processIdentifier
+                        : nil
                     let display = ScreenManager.shared.currentScreenNameSnapshot
 
                     let logitechContext = LogitechEventContext(
@@ -2369,9 +2372,12 @@ final class LogitechReprogrammableControlsMonitor {
             return Set(availableControls.map(\.controlID))
         }
 
+        let usesProcessConditions = ConfigurationState.shared.configuration.usesProcessConditions
         let mouseLocation = CGEvent(source: nil)?.location ?? .zero
-        let mouseLocationPid = mouseLocation.topmostWindowOwnerPid
+        let mouseLocationPid = usesProcessConditions
+            ? mouseLocation.topmostWindowOwnerPid
             ?? NSWorkspace.shared.frontmostApplication?.processIdentifier
+            : nil
         let scheme = ConfigurationState.shared.configuration.matchScheme(
             withDevice: device,
             withPid: mouseLocationPid,

--- a/LinearMouse/EventTap/GlobalEventTap.swift
+++ b/LinearMouse/EventTap/GlobalEventTap.swift
@@ -21,14 +21,27 @@ class GlobalEventTap {
         ModifierState.shared.update(with: event)
 
         let mouseEventView = MouseEventView(event)
+        let usesProcessConditions = ConfigurationState.shared.configuration.usesProcessConditions
         let eventTransformer = EventTransformerManager.shared.get(
             withCGEvent: event,
             withSourcePid: mouseEventView.sourcePid,
-            withTargetPid: mouseEventView.targetPid,
-            withMouseLocationPid: mouseEventView.mouseLocationOwnerPid,
+            withTargetPid: usesProcessConditions ? mouseEventView.targetPid : nil,
+            withMouseLocationPid: usesProcessConditions ? mouseEventView.mouseLocationOwnerPid : nil,
             withDisplay: ScreenManager.shared.currentScreenNameSnapshot
         )
-        return eventTransformer.transform(event)
+        let transformedEvent = eventTransformer.transform(event)
+        invalidateWindowInfoCacheIfNeeded(for: event)
+        return transformedEvent
+    }
+
+    private func invalidateWindowInfoCacheIfNeeded(for event: CGEvent) {
+        switch event.type {
+        case .leftMouseDown, .rightMouseDown, .otherMouseDown,
+             .leftMouseUp, .rightMouseUp, .otherMouseUp:
+            WindowInfoCache.shared.invalidate()
+        default:
+            break
+        }
     }
 
     func start() {
@@ -55,6 +68,7 @@ class GlobalEventTap {
 
         eventThread.onWillStop = {
             EventTransformerManager.shared.resetForRestart()
+            WindowInfoCache.shared.invalidate()
         }
         eventThread.start()
 

--- a/LinearMouse/Model/Configuration/Configuration.swift
+++ b/LinearMouse/Model/Configuration/Configuration.swift
@@ -57,6 +57,18 @@ extension Configuration.ConfigurationError: LocalizedError {
 }
 
 extension Configuration {
+    var usesProcessConditions: Bool {
+        schemes.contains { scheme in
+            scheme.if?.contains { condition in
+                condition.app != nil ||
+                    condition.parentApp != nil ||
+                    condition.groupApp != nil ||
+                    condition.processName != nil ||
+                    condition.processPath != nil
+            } ?? false
+        }
+    }
+
     static func load(from string: String) throws -> Configuration {
         do {
             let jsonPatcher = try JSONPatcher(original: string)

--- a/LinearMouse/UI/ButtonsSettings/ButtonMappingsSection/ButtonMappingButtonRecorder.swift
+++ b/LinearMouse/UI/ButtonsSettings/ButtonMappingsSection/ButtonMappingButtonRecorder.swift
@@ -59,12 +59,14 @@ struct ButtonMappingButtonRecorder: View {
     private func updateSharedRecordingState(force: Bool? = nil) {
         let shouldRecord = force ?? recording
         if shouldRecord {
-            settingsState.beginVirtualButtonRecordingPreparation(for: logitechMonitorDeviceIDs())
+            let monitorDevices = logitechMonitorDevices()
+            settingsState.beginVirtualButtonRecordingPreparation(for: Set(monitorDevices.map(\.id)))
+            settingsState.recording = shouldRecord
+            monitorDevices.forEach { $0.prepareLogitechControlsRecording() }
         } else {
             settingsState.endVirtualButtonRecordingPreparation()
+            settingsState.recording = shouldRecord
         }
-
-        settingsState.recording = shouldRecord
     }
 
     private func recordingUpdated() {
@@ -119,13 +121,13 @@ struct ButtonMappingButtonRecorder: View {
         recordedButtonCancellable = nil
     }
 
-    private func logitechMonitorDeviceIDs() -> Set<Int32> {
+    private func logitechMonitorDevices() -> [Device] {
         guard let currentDevice = DeviceState.shared.currentDeviceRef?.value,
               currentDevice.hasLogitechControlsMonitor else {
             return []
         }
 
-        return [currentDevice.id]
+        return [currentDevice]
     }
 
     private func virtualButtonReceived(_ event: SettingsState.RecordedVirtualButtonEvent) {

--- a/LinearMouse/Utilities/WindowInfo.swift
+++ b/LinearMouse/Utilities/WindowInfo.swift
@@ -4,36 +4,99 @@
 import CoreGraphics
 import Foundation
 
-extension CGPoint {
-    /// Returns the owner pid of the topmost normal-level window that contains this point.
-    var topmostWindowOwnerPid: pid_t? {
+final class WindowInfoCache {
+    static let shared = WindowInfoCache()
+
+    private struct WindowInfo {
+        let ownerPid: pid_t
+        let bounds: CGRect
+        let alpha: Double
+    }
+
+    private static let cacheLifetime: TimeInterval = 0.05
+
+    private let lock = NSLock()
+    private var cachedAt: TimeInterval?
+    private var cachedWindows = [WindowInfo]()
+    private var generation = 0
+
+    func topmostWindowOwnerPid(at point: CGPoint) -> pid_t? {
+        for window in windowListSnapshot() {
+            guard window.alpha > 0, window.bounds.contains(point) else {
+                continue
+            }
+            return window.ownerPid
+        }
+
+        return nil
+    }
+
+    func invalidate() {
+        lock.lock()
+        generation += 1
+        cachedAt = nil
+        cachedWindows.removeAll()
+        lock.unlock()
+    }
+
+    private func windowListSnapshot() -> [WindowInfo] {
+        let now = ProcessInfo.processInfo.systemUptime
+
+        lock.lock()
+        if let cachedAt, now - cachedAt < Self.cacheLifetime {
+            let cachedWindows = cachedWindows
+            lock.unlock()
+            return cachedWindows
+        }
+        let generation = generation
+        lock.unlock()
+
+        let windows = Self.copyWindowList()
+        let updatedAt = ProcessInfo.processInfo.systemUptime
+
+        lock.lock()
+        if self.generation == generation {
+            cachedAt = updatedAt
+            cachedWindows = windows
+        }
+        lock.unlock()
+
+        return windows
+    }
+
+    private static func copyWindowList() -> [WindowInfo] {
         let options = CGWindowListOption(arrayLiteral: [.excludeDesktopElements, .optionOnScreenOnly])
         guard let windowListInfo = CGWindowListCopyWindowInfo(options, kCGNullWindowID) as NSArray? as? [[String: Any]]
         else {
-            return nil
+            return []
         }
 
-        for windowInfo in windowListInfo {
+        return windowListInfo.compactMap { windowInfo in
             // Only consider normal application windows (NSWindow.Level.normal == 0) so that
             // overlays such as the menu bar, Dock, status-bar panels, and click-through HUDs
             // (including our own auto-scroll indicator) don't take precedence.
             guard let layer = windowInfo[kCGWindowLayer as String] as? Int, layer == 0 else {
-                continue
+                return nil
             }
 
             guard let boundsDictionary = windowInfo[kCGWindowBounds as String] as? NSDictionary,
-                  let bounds = CGRect(dictionaryRepresentation: boundsDictionary),
-                  bounds.contains(self) else {
-                continue
+                  let bounds = CGRect(dictionaryRepresentation: boundsDictionary) else {
+                return nil
             }
 
-            if let alpha = windowInfo[kCGWindowAlpha as String] as? Double, alpha <= 0 {
-                continue
+            guard let ownerPid = windowInfo[kCGWindowOwnerPID as String] as? pid_t else {
+                return nil
             }
 
-            return windowInfo[kCGWindowOwnerPID as String] as? pid_t
+            let alpha = windowInfo[kCGWindowAlpha as String] as? Double ?? 1
+            return WindowInfo(ownerPid: ownerPid, bounds: bounds, alpha: alpha)
         }
+    }
+}
 
-        return nil
+extension CGPoint {
+    /// Returns the owner pid of the topmost normal-level window that contains this point.
+    var topmostWindowOwnerPid: pid_t? {
+        WindowInfoCache.shared.topmostWindowOwnerPid(at: self)
     }
 }

--- a/LinearMouseUnitTests/Model/ConfigurationTests.swift
+++ b/LinearMouseUnitTests/Model/ConfigurationTests.swift
@@ -9,6 +9,14 @@ final class ConfigurationTests: XCTestCase {
         try print(Configuration(schemes: []).dump())
     }
 
+    func testUsesProcessConditions() {
+        XCTAssertFalse(Configuration(schemes: []).usesProcessConditions)
+        XCTAssertFalse(Configuration(schemes: [Scheme(if: [.init(display: "Built-in Display")])]).usesProcessConditions)
+        XCTAssertTrue(Configuration(schemes: [Scheme(if: [.init(app: "com.apple.finder")])]).usesProcessConditions)
+        XCTAssertTrue(Configuration(schemes: [Scheme(if: [.init(processPath: "/Applications/Foo.app/Foo")])])
+            .usesProcessConditions)
+    }
+
     func testMergeScheme() {
         var scheme = Scheme()
 


### PR DESCRIPTION
## Summary
- reduce idle CPU usage from Logitech receiver/control monitoring by avoiding fixed 10ms polling loops and starting the Logitech controls monitor only when needed
- avoid resolving the mouse-location window owner when no scheme uses process conditions
- cache short-lived `CGWindowList` snapshots for process-conditioned schemes to reduce topmost window owner lookup cost during high-frequency mouse movement

## Testing
- `xcodebuild -project LinearMouse.xcodeproj -scheme LinearMouse -configuration Debug -destination 'platform=macOS' build`
- `xcodebuild -project LinearMouse.xcodeproj -scheme LinearMouse -destination 'platform=macOS' -only-testing:LinearMouseUnitTests/ConfigurationTests/testUsesProcessConditions test`

Related to #1166, #1168
