### PR TITLE
Preserve target app for Logitech control actions

### DIFF
--- a/LinearMouse/Device/VendorSpecific/Logitech/LogitechHIDPPDeviceMetadataProvider.swift
+++ b/LinearMouse/Device/VendorSpecific/Logitech/LogitechHIDPPDeviceMetadataProvider.swift
@@ -1208,7 +1208,6 @@ final class LogitechReceiverChannel: VendorSpecificDeviceContext {
         if let responseType = strategy.responseType {
             return performGetReportRequest(
                 report,
-                timeout: timeout,
                 matching: matching,
                 requestType: strategy.requestType,
                 responseType: responseType
@@ -1245,7 +1244,6 @@ final class LogitechReceiverChannel: VendorSpecificDeviceContext {
 
     private func performGetReportRequest(
         _ report: Data,
-        timeout _: TimeInterval,
         matching: @escaping (Data) -> Bool,
         requestType: IOHIDReportType,
         responseType: IOHIDReportType
@@ -1983,12 +1981,9 @@ final class LogitechReprogrammableControlsMonitor {
                         continue
                     }
 
-                    let usesProcessConditions = ConfigurationState.shared.configuration.usesProcessConditions
                     let mouseLocation = CGEvent(source: nil)?.location ?? .zero
-                    let mouseLocationPid = usesProcessConditions
-                        ? mouseLocation.topmostWindowOwnerPid
+                    let mouseLocationPid = mouseLocation.topmostWindowOwnerPid
                         ?? NSWorkspace.shared.frontmostApplication?.processIdentifier
-                        : nil
                     let display = ScreenManager.shared.currentScreenNameSnapshot
 
                     let logitechContext = LogitechEventContext(
@@ -2372,12 +2367,9 @@ final class LogitechReprogrammableControlsMonitor {
             return Set(availableControls.map(\.controlID))
         }
 
-        let usesProcessConditions = ConfigurationState.shared.configuration.usesProcessConditions
         let mouseLocation = CGEvent(source: nil)?.location ?? .zero
-        let mouseLocationPid = usesProcessConditions
-            ? mouseLocation.topmostWindowOwnerPid
+        let mouseLocationPid = mouseLocation.topmostWindowOwnerPid
             ?? NSWorkspace.shared.frontmostApplication?.processIdentifier
-            : nil
         let scheme = ConfigurationState.shared.configuration.matchScheme(
             withDevice: device,
             withPid: mouseLocationPid,

--- a/LinearMouse/EventTransformer/EventTransformerManager.swift
+++ b/LinearMouse/EventTransformer/EventTransformerManager.swift
@@ -158,7 +158,8 @@ class EventTransformerManager {
     }
 
     private func handleLogitechControlEventOnCurrentThread(_ context: LogitechEventContext) -> Bool {
-        let transformer = get(withDevice: context.device, withPid: context.pid, withDisplay: context.display)
+        let pid = ConfigurationState.shared.configuration.usesProcessConditions ? context.pid : nil
+        let transformer = get(withDevice: context.device, withPid: pid, withDisplay: context.display)
         return (transformer as? LogitechControlEventHandling)?.handleLogitechControlEvent(context) ?? false
     }
 


### PR DESCRIPTION
## Summary
- keep Logitech control handling on the same topmost-window owner lookup path used before the performance gate, since Logitech control notifications are not the high-frequency mouse-move hot path
- preserve universal back/forward behavior for Logitech control mappings without changing the event tap optimization from #1170
- keep Logitech control events and mouse-move events on the same transformer cache key when process conditions are not used, so Logitech gesture tracking keeps its movement state
- remove the unused timeout parameter from the synchronous GetReport helper, since that path performs a single synchronous `IOHIDDeviceGetReport` call

## Testing
- `xcodebuild -project LinearMouse.xcodeproj -scheme LinearMouse -configuration Debug -destination 'platform=macOS' build`\n