### PR TITLE
Add bouncing toggle for smoothed scrolling

### DIFF
--- a/Documentation/Configuration.d.ts
+++ b/Documentation/Configuration.d.ts
@@ -248,7 +248,7 @@ declare namespace Scheme {
 
       /**
        * @description The preset curve to use.
-       * @default "natural"
+       * @default "easeInOut"
        */
       preset?: Smoothed.Preset;
 
@@ -271,6 +271,12 @@ declare namespace Scheme {
        * @description The scrolling inertia.
        */
       inertia?: number;
+
+      /**
+       * @description Set to `false` to avoid rubber-band overscroll when smoothed scrolling emits synthetic continuous scroll events.
+       * @default true
+       */
+      bouncing?: boolean;
     };
 
     namespace Smoothed {
@@ -280,7 +286,6 @@ declare namespace Scheme {
         | "easeIn"
         | "easeOut"
         | "easeInOut"
-        | "easeOutIn"
         | "quadratic"
         | "cubic"
         | "quartic"
@@ -288,18 +293,7 @@ declare namespace Scheme {
         | "easeInOutCubic"
         | "easeOutQuartic"
         | "easeInOutQuartic"
-        | "quintic"
-        | "sine"
-        | "exponential"
-        | "circular"
-        | "back"
-        | "bounce"
-        | "elastic"
-        | "spring"
-        | "natural"
-        | "smooth"
-        | "snappy"
-        | "gentle";
+        | "smooth";
     }
 
     type Modifiers = {

--- a/Documentation/Configuration.json
+++ b/Documentation/Configuration.json
@@ -1495,6 +1495,11 @@
           "description": "The scrolling acceleration.",
           "type": "number"
         },
+        "bouncing": {
+          "default": true,
+          "description": "Set to `false` to avoid rubber-band overscroll when smoothed scrolling emits synthetic continuous scroll events.",
+          "type": "boolean"
+        },
         "enabled": {
           "default": true,
           "description": "Set to `false` to explicitly disable inherited smoothed scrolling for this direction.",
@@ -1506,7 +1511,7 @@
         },
         "preset": {
           "$ref": "#/definitions/Scheme.Scrolling.Smoothed.Preset",
-          "default": "natural",
+          "default": "easeInOut",
           "description": "The preset curve to use."
         },
         "response": {
@@ -1527,7 +1532,6 @@
         "easeIn",
         "easeOut",
         "easeInOut",
-        "easeOutIn",
         "quadratic",
         "cubic",
         "quartic",
@@ -1535,18 +1539,7 @@
         "easeInOutCubic",
         "easeOutQuartic",
         "easeInOutQuartic",
-        "quintic",
-        "sine",
-        "exponential",
-        "circular",
-        "back",
-        "bounce",
-        "elastic",
-        "spring",
-        "natural",
-        "smooth",
-        "snappy",
-        "gentle"
+        "smooth"
       ],
       "type": "string"
     },

--- a/Documentation/Configuration.md
+++ b/Documentation/Configuration.md
@@ -86,6 +86,10 @@ vertical and horizontal scrolling. You can choose a preset such as `easeIn`, `ea
 Set `enabled` to `false` to explicitly disable an inherited smoothed scrolling configuration for a
 direction.
 
+Set `bouncing` to `false` to avoid rubber-band overscroll when smoothed scrolling emits synthetic
+continuous scroll events. This keeps the smoothed momentum tail, but sends it without scroll
+phase/momentum phase markers so apps are less likely to treat it like a trackpad gesture.
+
 For example, to use a smoother scrolling profile for a mouse:
 
 ```json
@@ -104,7 +108,8 @@ For example, to use a smoother scrolling profile for a mouse:
           "response": 0.45,
           "speed": 1,
           "acceleration": 1.2,
-          "inertia": 0.65
+          "inertia": 0.65,
+          "bouncing": false
         }
       }
     }

--- a/LinearMouse/EventTransformer/SmoothedScrollingTransformer.swift
+++ b/LinearMouse/EventTransformer/SmoothedScrollingTransformer.swift
@@ -142,8 +142,14 @@ final class SmoothedScrollingTransformer: EventTransformer, Deactivatable {
             )
         }
 
+        let shouldResetAfterNativePhase = view.scrollPhase == .ended || view.momentumPhase == .end
+        let appliesPhases = allowsBouncingForConfiguredAxes(interceptsX: interceptsX, interceptsY: interceptsY)
+
         if let emission = engine.advance(to: now()) {
-            delivery.apply(phases: delivery.phasesFor(emission.phase), to: view)
+            delivery.apply(
+                phases: delivery.phasesFor(emission.phase, appliesPhases: appliesPhases),
+                to: view
+            )
 
             if interceptsX {
                 delivery.setHorizontal(handlesX ? emission.deltaX : 0, on: view)
@@ -160,8 +166,7 @@ final class SmoothedScrollingTransformer: EventTransformer, Deactivatable {
             }
         }
 
-        let shouldReset = view.scrollPhase == .ended || view.momentumPhase == .end
-        if shouldReset {
+        if shouldResetAfterNativePhase {
             engine = SmoothedScrollingEngine(smoothed: smoothed)
             stopTimer()
         }
@@ -207,7 +212,14 @@ final class SmoothedScrollingTransformer: EventTransformer, Deactivatable {
         view.continuous = true
         delivery.setHorizontal(emission.deltaX, on: view)
         delivery.setVertical(emission.deltaY, on: view)
-        delivery.apply(phases: delivery.phasesFor(emission.phase), to: view)
+        delivery.apply(
+            phases: delivery.phasesFor(emission.phase, appliesPhases: allowsBouncingForConfiguredAxes()),
+            to: view
+        )
+        guard view.scrollPhase != nil || view.momentumPhase != .none || emission.deltaX != 0 || emission.deltaY != 0
+        else {
+            return
+        }
         event.isLinearMouseSyntheticEvent = true
         event.flags = lastFlags
         eventSink(event)
@@ -221,6 +233,19 @@ final class SmoothedScrollingTransformer: EventTransformer, Deactivatable {
             String(describing: view.scrollPhase),
             String(describing: view.momentumPhase)
         )
+    }
+
+    private func allowsBouncingForConfiguredAxes(
+        interceptsX: Bool = true,
+        interceptsY: Bool = true
+    ) -> Bool {
+        if interceptsX, smoothed.horizontal?.allowsBouncing == false {
+            return false
+        }
+        if interceptsY, smoothed.vertical?.allowsBouncing == false {
+            return false
+        }
+        return true
     }
 }
 
@@ -236,8 +261,14 @@ private struct SmoothedScrollEventDelivery {
         view.momentumPhase = phases.momentumPhase
     }
 
-    func phasesFor(_ phase: SmoothedScrollingEngine
-        .Phase) -> (scrollPhase: CGScrollPhase?, momentumPhase: CGMomentumScrollPhase) {
+    func phasesFor(
+        _ phase: SmoothedScrollingEngine.Phase,
+        appliesPhases: Bool = true
+    ) -> (scrollPhase: CGScrollPhase?, momentumPhase: CGMomentumScrollPhase) {
+        guard appliesPhases else {
+            return (nil, .none)
+        }
+
         switch phase {
         case .touchBegan:
             return (.began, .none)

--- a/LinearMouse/Localizable.xcstrings
+++ b/LinearMouse/Localizable.xcstrings
@@ -5253,6 +5253,214 @@
         }
       }
     },
+    "Allow scroll bouncing" : {
+      "localizations" : {
+        "af" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Laat rol-terugspring toe"
+          }
+        },
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "السماح بارتداد التمرير"
+          }
+        },
+        "bs" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dozvoli odbijanje pri skrolovanju"
+          }
+        },
+        "ca" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Permet el rebot del desplaçament"
+          }
+        },
+        "cs" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Povolit odskakování při posouvání"
+          }
+        },
+        "da" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tillad hop ved rulning"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Scroll-Bounce erlauben"
+          }
+        },
+        "el" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Να επιτρέπεται η αναπήδηση κύλισης"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Permitir rebote al desplazarse"
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Salli vierityksen kimmahdus"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Autoriser le rebond du défilement"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "אפשר קפיצת גלילה"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Görgetési visszapattanás engedélyezése"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Izinkan pantulan gulir"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Consenti rimbalzo dello scorrimento"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "スクロールのバウンスを許可"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "스크롤 바운스 허용"
+          }
+        },
+        "my" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "လှိမ့်ခြင်း ပြန်ခုန်မှုကို ခွင့်ပြုရန်"
+          }
+        },
+        "nb-NO" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tillat sprett ved rulling"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Scroll-terugveren toestaan"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Zezwalaj na odbijanie przewijania"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Permitir ressalto da rolagem"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Permitir ressalto da rolagem"
+          }
+        },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Permite ricoșeul la derulare"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Разрешить отскок при прокрутке"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Povoliť odskakovanie pri posúvaní"
+          }
+        },
+        "sr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Дозволи одскакање при померању"
+          }
+        },
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tillåt studs vid rullning"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kaydırma sekmesine izin ver"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Дозволити відскок під час прокручування"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cho phép nảy khi cuộn"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "允许滚动回弹"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "允許捲動回彈"
+          }
+        },
+        "zh-Hant-HK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "允許捲動回彈"
+          }
+        }
+      }
+    },
     "Alter orientation" : {
       "extractionState" : "manual",
       "localizations" : {
@@ -30034,6 +30242,214 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "左鍵"
+          }
+        }
+      }
+    },
+    "Let apps apply rubber-band overscroll at content edges." : {
+      "localizations" : {
+        "af" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Laat programme elastiese oorrol by inhoudsrande toepas."
+          }
+        },
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "السماح للتطبيقات بتطبيق التمرير المطاطي الزائد عند حواف المحتوى."
+          }
+        },
+        "bs" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dozvoli aplikacijama da primijene gumeno prekoračenje skrolovanja na ivicama sadržaja."
+          }
+        },
+        "ca" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Permet que les apps apliquin sobredesplaçament elàstic a les vores del contingut."
+          }
+        },
+        "cs" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Umožnit aplikacím použít pružné přetažení na okrajích obsahu."
+          }
+        },
+        "da" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Lad apps anvende elastisk overrulning ved indholdets kanter."
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Apps dürfen an Inhaltsrändern elastisches Überscrollen anwenden."
+          }
+        },
+        "el" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Να επιτρέπεται στις εφαρμογές να εφαρμόζουν ελαστική υπερκύλιση στα άκρα του περιεχομένου."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Permite que las apps apliquen sobredesplazamiento elástico en los bordes del contenido."
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Anna appien käyttää joustavaa ylivieritystä sisällön reunoilla."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Autorise les apps à appliquer un surdéfilement élastique aux bords du contenu."
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "אפשר ליישומים להחיל גלילת יתר גמישה בקצות התוכן."
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Engedélyezi, hogy az appok rugalmas túlgörgetést alkalmazzanak a tartalom szélein."
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Biarkan app menerapkan gulir lebih bergaya karet di tepi konten."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Consenti alle app di applicare lo scorrimento elastico oltre i bordi del contenuto."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "コンテンツの端でアプリによるラバーバンド状のオーバースクロールを許可します。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "앱이 콘텐츠 가장자리에서 고무줄처럼 당겨지는 오버스크롤을 적용하도록 허용합니다."
+          }
+        },
+        "my" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "အက်ပ်များကို အကြောင်းအရာအစွန်းများတွင် ရော်ဘာကြိုးပုံစံ အလွန်လှိမ့်ခြင်း အသုံးပြုခွင့်ပြုရန်။"
+          }
+        },
+        "nb-NO" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "La apper bruke elastisk overrulling ved innholdskanter."
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sta apps toe elastisch overscrollen toe te passen aan de randen van de inhoud."
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pozwól aplikacjom stosować elastyczne przewijanie poza krawędziami treści."
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Permitir que as apps apliquem deslocamento elástico além dos limites do conteúdo."
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Permitir que apps apliquem rolagem elástica além das bordas do conteúdo."
+          }
+        },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Permite aplicațiilor să aplice supraderulare elastică la marginile conținutului."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Разрешить приложениям применять эластичную прокрутку за границами содержимого."
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Umožniť aplikáciám použiť pružné posúvanie za okrajmi obsahu."
+          }
+        },
+        "sr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Дозволи апликацијама да примене еластично померање преко ивица садржаја."
+          }
+        },
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Låt appar använda elastisk överrullning vid innehållskanter."
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Uygulamaların içerik kenarlarında lastik bant tarzı aşırı kaydırma uygulamasına izin ver."
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Дозволити програмам застосовувати еластичне прокручування за межі на краях вмісту."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cho phép ứng dụng áp dụng cuộn quá mức kiểu dây cao su ở mép nội dung."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "允许 App 在内容边缘应用橡皮筋式过度滚动。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "允許 App 在內容邊緣套用橡皮筋式過度捲動。"
+          }
+        },
+        "zh-Hant-HK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "允許 App 在內容邊緣套用橡筋式過度捲動。"
           }
         }
       }

--- a/LinearMouse/Model/Configuration/Scheme/Scrolling/Smoothed.swift
+++ b/LinearMouse/Model/Configuration/Scheme/Scrolling/Smoothed.swift
@@ -40,6 +40,7 @@ extension Scheme.Scrolling {
         var speed: Decimal?
         var acceleration: Decimal?
         var inertia: Decimal?
+        var bouncing: Bool?
 
         init() {}
 
@@ -49,7 +50,8 @@ extension Scheme.Scrolling {
             response: Decimal? = nil,
             speed: Decimal? = nil,
             acceleration: Decimal? = nil,
-            inertia: Decimal? = nil
+            inertia: Decimal? = nil,
+            bouncing: Bool? = nil
         ) {
             self.enabled = enabled
             self.preset = preset
@@ -57,6 +59,7 @@ extension Scheme.Scrolling {
             self.speed = speed
             self.acceleration = acceleration
             self.inertia = inertia
+            self.bouncing = bouncing
         }
     }
 }
@@ -77,6 +80,10 @@ extension Scheme.Scrolling.Smoothed {
 
     var isEnabled: Bool {
         enabled ?? true
+    }
+
+    var allowsBouncing: Bool {
+        bouncing ?? true
     }
 
     func merge(into smoothed: inout Self) {
@@ -102,6 +109,10 @@ extension Scheme.Scrolling.Smoothed {
 
         if let inertia {
             smoothed.inertia = inertia
+        }
+
+        if let bouncing {
+            smoothed.bouncing = bouncing
         }
     }
 
@@ -247,7 +258,8 @@ extension Scheme.Scrolling.Smoothed.Preset {
             response: values.response,
             speed: values.speed,
             acceleration: values.acceleration,
-            inertia: values.inertia
+            inertia: values.inertia,
+            bouncing: true
         )
     }
 }

--- a/LinearMouse/UI/ScrollingSettings/ScrollingSettingsState.swift
+++ b/LinearMouse/UI/ScrollingSettings/ScrollingSettingsState.swift
@@ -193,6 +193,15 @@ extension ScrollingSettingsState {
         decimalFormatter(maxFractionDigits: 2)
     }
 
+    var smoothedBouncing: Bool {
+        get { currentSmoothedConfiguration?.allowsBouncing ?? true }
+        set {
+            updateSmoothedConfiguration {
+                $0.bouncing = newValue
+            }
+        }
+    }
+
     var scrollingDisabled: Bool {
         switch scrollingMode {
         case .accelerated:
@@ -266,7 +275,9 @@ extension ScrollingSettingsState {
         if preset == .custom {
             setSmoothedConfiguration(makeCustomSmoothedConfiguration())
         } else {
-            setSmoothedConfiguration(preset.defaultConfiguration)
+            var configuration = preset.defaultConfiguration
+            configuration.bouncing = makeEditableSmoothedConfiguration().allowsBouncing
+            setSmoothedConfiguration(configuration)
         }
     }
 

--- a/LinearMouse/UI/ScrollingSettings/SmoothedScrollingSection.swift
+++ b/LinearMouse/UI/ScrollingSettings/SmoothedScrollingSection.swift
@@ -76,6 +76,13 @@ extension ScrollingSettings {
                     formatter: state.smoothedInertiaFormatter
                 )
 
+                Toggle(isOn: $state.smoothedBouncing) {
+                    withDescription {
+                        Text("Allow scroll bouncing")
+                        Text("Let apps apply rubber-band overscroll at content edges.")
+                    }
+                }
+
                 HStack(spacing: 10) {
                     Button("Restore default preset") {
                         state.scrollingMode = .smoothed

--- a/LinearMouseUnitTests/EventTransformer/SmoothedScrollingTransformerTests.swift
+++ b/LinearMouseUnitTests/EventTransformer/SmoothedScrollingTransformerTests.swift
@@ -270,6 +270,69 @@ final class SmoothedScrollingTransformerTests: XCTestCase {
         XCTAssertEqual(transformedView.scrollPhase, .began)
     }
 
+    func testDiscreteSmoothedScrollingCanSuppressBouncingPhases() throws {
+        var emittedEvents: [CGEvent] = []
+        var now = 0.0
+        var configuration = Scheme.Scrolling.Smoothed.Preset.smooth.defaultConfiguration
+        configuration.bouncing = false
+        let transformer = SmoothedScrollingTransformer(
+            smoothed: .init(vertical: configuration),
+            now: { now },
+            eventSink: { emittedEvents.append($0.copy() ?? $0) }
+        )
+
+        let originalEvent = try XCTUnwrap(CGEvent(
+            scrollWheelEvent2Source: nil,
+            units: .line,
+            wheelCount: 2,
+            wheel1: 1,
+            wheel2: 0,
+            wheel3: 0
+        ))
+
+        XCTAssertNil(transformer.transform(originalEvent))
+
+        now = 1.0 / 120.0
+        transformer.tick()
+
+        let emittedEvent = try XCTUnwrap(emittedEvents.first)
+        let emittedView = ScrollWheelEventView(emittedEvent)
+        XCTAssertTrue(emittedEvent.isLinearMouseSyntheticEvent)
+        XCTAssertGreaterThan(abs(emittedView.deltaYPt), 0)
+        XCTAssertEqual(emittedView.scrollPhase, nil)
+        XCTAssertEqual(emittedView.momentumPhase, .none)
+    }
+
+    func testContinuousTrackpadInputCanSuppressBouncingPhases() throws {
+        var now = 0.0
+        var configuration = Scheme.Scrolling.Smoothed.Preset.easeInOut.defaultConfiguration
+        configuration.bouncing = false
+        let transformer = SmoothedScrollingTransformer(
+            smoothed: .init(vertical: configuration)
+        ) { now }
+
+        let originalEvent = try XCTUnwrap(CGEvent(
+            scrollWheelEvent2Source: nil,
+            units: .pixel,
+            wheelCount: 2,
+            wheel1: 0,
+            wheel2: 0,
+            wheel3: 0
+        ))
+        let originalView = ScrollWheelEventView(originalEvent)
+        originalView.continuous = true
+        originalView.deltaYPt = 9
+        originalView.deltaYFixedPt = 9
+        originalView.scrollPhase = .began
+
+        let transformedEvent = try XCTUnwrap(transformer.transform(originalEvent))
+        let transformedView = ScrollWheelEventView(transformedEvent)
+        XCTAssertGreaterThan(transformedView.deltaYFixedPt, 0)
+        XCTAssertLessThan(transformedView.deltaYFixedPt, 9)
+        XCTAssertEqual(transformedView.scrollPhase, nil)
+        XCTAssertEqual(transformedView.momentumPhase, .none)
+    }
+
     func testExtendedSpeedRangeProducesMuchStrongerInitialEmission() throws {
         let baseline = try firstDiscreteEmission(
             configuration: .init(

--- a/LinearMouseUnitTests/Model/ConfigurationTests.swift
+++ b/LinearMouseUnitTests/Model/ConfigurationTests.swift
@@ -219,7 +219,8 @@ final class ConfigurationTests: XCTestCase {
                         response: Decimal(string: "0.45"),
                         speed: 1,
                         acceleration: Decimal(string: "1.2"),
-                        inertia: Decimal(string: "0.65")
+                        inertia: Decimal(string: "0.65"),
+                        bouncing: true
                     )
                 )
             )
@@ -241,5 +242,18 @@ final class ConfigurationTests: XCTestCase {
         XCTAssertEqual(scheme.scrolling.smoothed.vertical?.speed, 1)
         XCTAssertEqual(scheme.scrolling.smoothed.vertical?.acceleration, Decimal(string: "1.2"))
         XCTAssertEqual(scheme.scrolling.smoothed.vertical?.inertia, 8)
+        XCTAssertEqual(scheme.scrolling.smoothed.vertical?.bouncing, true)
+
+        Scheme(
+            scrolling: .init(
+                smoothed: .init(
+                    vertical: .init(
+                        bouncing: false
+                    )
+                )
+            )
+        ).merge(into: &scheme)
+
+        XCTAssertEqual(scheme.scrolling.smoothed.vertical?.bouncing, false)
     }
 }


### PR DESCRIPTION
## Summary
- Add a `scrolling.smoothed.bouncing` option that defaults to enabled for existing behavior.
- Suppress scroll phase and momentum phase markers when bouncing is disabled, while keeping smoothed pixel deltas and the inertia tail.
- Add the UI toggle, localized strings, documentation/schema updates, and tests.
- Align the documented smoothed scrolling presets with the presets supported by the Swift model.

Closes #44
Closes #1162
Closes #1137

## Testing
- `node -e "JSON.parse(require('fs').readFileSync('LinearMouse/Localizable.xcstrings','utf8')); JSON.parse(require('fs').readFileSync('Documentation/Configuration.json','utf8')); console.log('json ok')"`
- `xcodebuild test -scheme LinearMouse -destination 'platform=macOS' -only-testing:LinearMouseUnitTests/SmoothedScrollingTransformerTests -only-testing:LinearMouseUnitTests/ConfigurationTests`