### PR TITLE
Add reversed zoom modifier actions

### DIFF
--- a/Documentation/Configuration.d.ts
+++ b/Documentation/Configuration.d.ts
@@ -367,6 +367,13 @@ declare namespace Scheme {
       };
 
       /**
+       * @description Zoom in and out using reversed ⌘+ and ⌘-.
+       */
+      type ZoomReversed = {
+        type: "zoomReversed";
+      };
+
+      /**
        * @description Zoom in and out using pinch gestures.
        */
       type PinchZoom = {
@@ -388,6 +395,7 @@ declare namespace Scheme {
         | AlterOrientation
         | ChangeSpeed
         | Zoom
+        | ZoomReversed
         | PinchZoom
         | PinchZoomReversed;
     }

--- a/Documentation/Configuration.d.ts
+++ b/Documentation/Configuration.d.ts
@@ -373,6 +373,13 @@ declare namespace Scheme {
         type: "pinchZoom";
       };
 
+      /**
+       * @description Zoom in and out using reversed pinch gestures.
+       */
+      type PinchZoomReversed = {
+        type: "pinchZoomReversed";
+      };
+
       type Action =
         | None
         | Auto
@@ -381,7 +388,8 @@ declare namespace Scheme {
         | AlterOrientation
         | ChangeSpeed
         | Zoom
-        | PinchZoom;
+        | PinchZoom
+        | PinchZoomReversed;
     }
   }
 

--- a/Documentation/Configuration.json
+++ b/Documentation/Configuration.json
@@ -1367,6 +1367,9 @@
         },
         {
           "$ref": "#/definitions/Scheme.Scrolling.Modifiers.PinchZoom"
+        },
+        {
+          "$ref": "#/definitions/Scheme.Scrolling.Modifiers.PinchZoomReversed"
         }
       ]
     },
@@ -1452,6 +1455,20 @@
       "properties": {
         "type": {
           "const": "pinchZoom",
+          "type": "string"
+        }
+      },
+      "required": [
+        "type"
+      ],
+      "type": "object"
+    },
+    "Scheme.Scrolling.Modifiers.PinchZoomReversed": {
+      "additionalProperties": false,
+      "description": "Zoom in and out using reversed pinch gestures.",
+      "properties": {
+        "type": {
+          "const": "pinchZoomReversed",
           "type": "string"
         }
       },

--- a/Documentation/Configuration.json
+++ b/Documentation/Configuration.json
@@ -1366,6 +1366,9 @@
           "$ref": "#/definitions/Scheme.Scrolling.Modifiers.Zoom"
         },
         {
+          "$ref": "#/definitions/Scheme.Scrolling.Modifiers.ZoomReversed"
+        },
+        {
           "$ref": "#/definitions/Scheme.Scrolling.Modifiers.PinchZoom"
         },
         {
@@ -1497,6 +1500,20 @@
       "properties": {
         "type": {
           "const": "zoom",
+          "type": "string"
+        }
+      },
+      "required": [
+        "type"
+      ],
+      "type": "object"
+    },
+    "Scheme.Scrolling.Modifiers.ZoomReversed": {
+      "additionalProperties": false,
+      "description": "Zoom in and out using reversed ⌘+ and ⌘-.",
+      "properties": {
+        "type": {
+          "const": "zoomReversed",
           "type": "string"
         }
       },

--- a/LinearMouse/EventTransformer/ModifierActionsTransformer.swift
+++ b/LinearMouse/EventTransformer/ModifierActionsTransformer.swift
@@ -75,10 +75,13 @@ extension ModifierActionsTransformer: EventTransformer {
             scrollWheelEventView.swapXY()
         case let .changeSpeed(scale: scale):
             scrollWheelEventView.scale(factor: scale.asTruncatedDouble)
-        case .zoom:
+        case .zoom, .zoomReversed:
             let scrollWheelEventView = ScrollWheelEventView(event)
-            let deltaSignum = scrollWheelEventView.deltaYSignum != 0 ? scrollWheelEventView
+            var deltaSignum = scrollWheelEventView.deltaYSignum != 0 ? scrollWheelEventView
                 .deltaYSignum : scrollWheelEventView.deltaXSignum
+            if action == .zoomReversed {
+                deltaSignum *= -1
+            }
             if deltaSignum == 0 {
                 return event
             }

--- a/LinearMouse/EventTransformer/ModifierActionsTransformer.swift
+++ b/LinearMouse/EventTransformer/ModifierActionsTransformer.swift
@@ -20,6 +20,7 @@ class ModifierActionsTransformer {
     private let modifiers: Modifiers
 
     private var pinchZoomBegan = false
+    private var pinchZoomReversed = false
 
     init(modifiers: Modifiers) {
         self.modifiers = modifiers
@@ -29,7 +30,7 @@ class ModifierActionsTransformer {
 extension ModifierActionsTransformer: EventTransformer {
     func transform(_ event: CGEvent) -> CGEvent? {
         if pinchZoomBegan {
-            return handlePinchZoom(event)
+            return handlePinchZoom(event, reverse: pinchZoomReversed)
         }
 
         guard event.type == .scrollWheel else {
@@ -88,19 +89,24 @@ extension ModifierActionsTransformer: EventTransformer {
             }
             return nil
         case .pinchZoom:
-            return handlePinchZoom(event)
+            pinchZoomReversed = false
+            return handlePinchZoom(event, reverse: false)
+        case .pinchZoomReversed:
+            pinchZoomReversed = true
+            return handlePinchZoom(event, reverse: true)
         }
 
         return event
     }
 
-    private func handlePinchZoom(_ event: CGEvent) -> CGEvent? {
+    private func handlePinchZoom(_ event: CGEvent, reverse: Bool) -> CGEvent? {
         guard event.type == .scrollWheel || event.type == .flagsChanged else {
             return event
         }
 
         if event.type == .flagsChanged {
             pinchZoomBegan = false
+            pinchZoomReversed = false
             GestureEvent(zoomSource: nil, phase: .ended, magnification: 0)?.post(tap: .cgSessionEventTap)
             os_log("pinch zoom ended", log: Self.log, type: .info)
             return event
@@ -113,7 +119,8 @@ extension ModifierActionsTransformer: EventTransformer {
         }
 
         let scrollWheelEventView = ScrollWheelEventView(event)
-        let magnification = Double(scrollWheelEventView.deltaYPt) * 0.005
+        let direction = reverse ? -1.0 : 1.0
+        let magnification = Double(scrollWheelEventView.deltaYPt) * 0.005 * direction
         GestureEvent(zoomSource: nil, phase: .changed, magnification: magnification)?.post(tap: .cgSessionEventTap)
         os_log("pinch zoom changed: magnification=%f", log: Self.log, type: .info, magnification)
 
@@ -125,6 +132,7 @@ extension ModifierActionsTransformer: Deactivatable {
     func deactivate() {
         if pinchZoomBegan {
             pinchZoomBegan = false
+            pinchZoomReversed = false
             GestureEvent(zoomSource: nil, phase: .ended, magnification: 0)?.post(tap: .cgSessionEventTap)
             os_log("ModifierActionsTransformer is inactive, pinch zoom ended", log: Self.log, type: .info)
         }

--- a/LinearMouse/Localizable.xcstrings
+++ b/LinearMouse/Localizable.xcstrings
@@ -37121,6 +37121,220 @@
         }
       }
     },
+    "Pinch zoom (reversed)" : {
+      "localizations" : {
+        "af" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Knyp-zoom (omgekeerd)"
+          }
+        },
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "تكبير/تصغير بالقرص (معكوس)"
+          }
+        },
+        "bs" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Zumiranje spajanjem prstiju (obrnuto)"
+          }
+        },
+        "ca" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Zoom de pessic (invertit)"
+          }
+        },
+        "cs" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Přiblížit sevřením (obráceně)"
+          }
+        },
+        "da" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Knib for at zoome (omvendt)"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Zoomen mit zwei Fingern (umgekehrt)"
+          }
+        },
+        "el" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Μεγέθυνση τσιμπήματος (αντίστροφα)"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pinch zoom (reversed)"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pellizcar para acercar (invertido)"
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nipistyszoomaus (käänteinen)"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Zoom par pincement (inversé)"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "הגדל בצביטה (הפוך)"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Csippentéses zoom (fordított)"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cubit untuk zoom (terbalik)"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Zoom con due dita (invertito)"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ピンチズーム（反転）"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "핀치 줌(반전)"
+          }
+        },
+        "my" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Zoom ချဲ့/ချုံ့ ရန် (ပြောင်းပြန်)"
+          }
+        },
+        "nb-NO" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Klypezoom (reversert)"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Knijp zoom (omgekeerd)"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Powiększanie przez ściskanie (odwrócone)"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ampliação com dois dedos (invertida)"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Zoom com 2 dedos (invertido)"
+          }
+        },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Zoom prin pensetă (inversat)"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Масштабирование щипком (обратное)"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Zväčšenie priblížením prstov (obrátené)"
+          }
+        },
+        "sr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Зумирање стискањем (обрнуто)"
+          }
+        },
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nypa-zoomning (omvänd)"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kıstırarak yakınlaştırma (ters)"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Масштабування щипком (зворотне)"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Thu phóng (đảo ngược)"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "手势缩放（反向）"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "手勢縮放（反向）"
+          }
+        },
+        "zh-Hant-HK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "手勢縮放（反向）"
+          }
+        }
+      }
+    },
     "Play / pause" : {
       "localizations" : {
         "af" : {

--- a/LinearMouse/Localizable.xcstrings
+++ b/LinearMouse/Localizable.xcstrings
@@ -59839,6 +59839,220 @@
           }
         }
       }
+    },
+    "Zoom (reversed)" : {
+      "localizations" : {
+        "af" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Zoem (omgekeerd)"
+          }
+        },
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "تكبير/تصغير (معكوس)"
+          }
+        },
+        "bs" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Zumiranje (obrnuto)"
+          }
+        },
+        "ca" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Zoom (invertit)"
+          }
+        },
+        "cs" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Přiblížit (obráceně)"
+          }
+        },
+        "da" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Zoom (omvendt)"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Zoom (umgekehrt)"
+          }
+        },
+        "el" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Μεγέθυνση (αντίστροφα)"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Zoom (reversed)"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Zoom (invertido)"
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Zoomaus (käänteinen)"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Zoom (inversé)"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "הגדל/הקטן (הפוך)"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nagyítás (fordított)"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Zoom (terbalik)"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ingrandimento (invertito)"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "拡大（反転）"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "확대(반전)"
+          }
+        },
+        "my" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Zoom (ပြောင်းပြန်)"
+          }
+        },
+        "nb-NO" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Zoom (reversert)"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Zoom (omgekeerd)"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Powiększanie (odwrócone)"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ampliação (invertida)"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Zoom (invertido)"
+          }
+        },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Zoom (inversat)"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Масштабирование (обратное)"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Zväčšiť (obrátené)"
+          }
+        },
+        "sr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Зум (обрнуто)"
+          }
+        },
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Zoom (omvänd)"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Yakınlaştır (ters)"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Масштабування (зворотне)"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Thu phóng (đảo ngược)"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "缩放（反向）"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "縮放（反向）"
+          }
+        },
+        "zh-Hant-HK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "縮放（反向）"
+          }
+        }
+      }
     }
   },
   "version" : "1.1"

--- a/LinearMouse/Model/Configuration/Scheme/Scrolling/Modifiers+Kind.swift
+++ b/LinearMouse/Model/Configuration/Scheme/Scrolling/Modifiers+Kind.swift
@@ -13,6 +13,7 @@ extension Scheme.Scrolling.Modifiers.Action {
         case alterOrientation
         case changeSpeed
         case zoom
+        case zoomReversed
         case pinchZoom
         case pinchZoomReversed
     }
@@ -31,6 +32,8 @@ extension Scheme.Scrolling.Modifiers.Action {
             return .changeSpeed
         case .zoom:
             return .zoom
+        case .zoomReversed:
+            return .zoomReversed
         case .pinchZoom:
             return .pinchZoom
         case .pinchZoomReversed:
@@ -52,6 +55,8 @@ extension Scheme.Scrolling.Modifiers.Action {
             self = .changeSpeed(scale: 1)
         case .zoom:
             self = .zoom
+        case .zoomReversed:
+            self = .zoomReversed
         case .pinchZoom:
             self = .pinchZoom
         case .pinchZoomReversed:

--- a/LinearMouse/Model/Configuration/Scheme/Scrolling/Modifiers+Kind.swift
+++ b/LinearMouse/Model/Configuration/Scheme/Scrolling/Modifiers+Kind.swift
@@ -14,6 +14,7 @@ extension Scheme.Scrolling.Modifiers.Action {
         case changeSpeed
         case zoom
         case pinchZoom
+        case pinchZoomReversed
     }
 
     var kind: Kind {
@@ -32,6 +33,8 @@ extension Scheme.Scrolling.Modifiers.Action {
             return .zoom
         case .pinchZoom:
             return .pinchZoom
+        case .pinchZoomReversed:
+            return .pinchZoomReversed
         }
     }
 
@@ -51,6 +54,8 @@ extension Scheme.Scrolling.Modifiers.Action {
             self = .zoom
         case .pinchZoom:
             self = .pinchZoom
+        case .pinchZoomReversed:
+            self = .pinchZoomReversed
         }
     }
 }

--- a/LinearMouse/Model/Configuration/Scheme/Scrolling/Modifiers.swift
+++ b/LinearMouse/Model/Configuration/Scheme/Scrolling/Modifiers.swift
@@ -20,6 +20,7 @@ extension Scheme.Scrolling.Modifiers {
         case alterOrientation
         case changeSpeed(scale: Decimal)
         case zoom
+        case zoomReversed
         case pinchZoom
         case pinchZoomReversed
     }
@@ -67,6 +68,7 @@ extension Scheme.Scrolling.Modifiers.Action: Codable {
         case alterOrientation
         case changeSpeed
         case zoom
+        case zoomReversed
         case pinchZoom
         case pinchZoomReversed
     }
@@ -89,6 +91,8 @@ extension Scheme.Scrolling.Modifiers.Action: Codable {
             self = .changeSpeed(scale: scale)
         case .zoom:
             self = .zoom
+        case .zoomReversed:
+            self = .zoomReversed
         case .pinchZoom:
             self = .pinchZoom
         case .pinchZoomReversed:
@@ -113,6 +117,8 @@ extension Scheme.Scrolling.Modifiers.Action: Codable {
             try container.encode(scale, forKey: .scale)
         case .zoom:
             try container.encode(ActionType.zoom, forKey: .type)
+        case .zoomReversed:
+            try container.encode(ActionType.zoomReversed, forKey: .type)
         case .pinchZoom:
             try container.encode(ActionType.pinchZoom, forKey: .type)
         case .pinchZoomReversed:

--- a/LinearMouse/Model/Configuration/Scheme/Scrolling/Modifiers.swift
+++ b/LinearMouse/Model/Configuration/Scheme/Scrolling/Modifiers.swift
@@ -21,6 +21,7 @@ extension Scheme.Scrolling.Modifiers {
         case changeSpeed(scale: Decimal)
         case zoom
         case pinchZoom
+        case pinchZoomReversed
     }
 }
 
@@ -67,6 +68,7 @@ extension Scheme.Scrolling.Modifiers.Action: Codable {
         case changeSpeed
         case zoom
         case pinchZoom
+        case pinchZoomReversed
     }
 
     init(from decoder: Decoder) throws {
@@ -89,6 +91,8 @@ extension Scheme.Scrolling.Modifiers.Action: Codable {
             self = .zoom
         case .pinchZoom:
             self = .pinchZoom
+        case .pinchZoomReversed:
+            self = .pinchZoomReversed
         }
     }
 
@@ -111,6 +115,8 @@ extension Scheme.Scrolling.Modifiers.Action: Codable {
             try container.encode(ActionType.zoom, forKey: .type)
         case .pinchZoom:
             try container.encode(ActionType.pinchZoom, forKey: .type)
+        case .pinchZoomReversed:
+            try container.encode(ActionType.pinchZoomReversed, forKey: .type)
         }
     }
 }

--- a/LinearMouse/UI/ScrollingSettings/ModifierKeysSection/ModifierAction+Binding.swift
+++ b/LinearMouse/UI/ScrollingSettings/ModifierKeysSection/ModifierAction+Binding.swift
@@ -56,6 +56,8 @@ extension Scheme.Scrolling.Modifiers.Action.Kind {
             Text("Change speed")
         case .zoom:
             Text("Zoom")
+        case .zoomReversed:
+            Text("Zoom (reversed)")
         case .pinchZoom:
             Text("Pinch zoom")
         case .pinchZoomReversed:

--- a/LinearMouse/UI/ScrollingSettings/ModifierKeysSection/ModifierAction+Binding.swift
+++ b/LinearMouse/UI/ScrollingSettings/ModifierKeysSection/ModifierAction+Binding.swift
@@ -58,6 +58,8 @@ extension Scheme.Scrolling.Modifiers.Action.Kind {
             Text("Zoom")
         case .pinchZoom:
             Text("Pinch zoom")
+        case .pinchZoomReversed:
+            Text("Pinch zoom (reversed)")
         }
     }
 }

--- a/LinearMouseUnitTests/Model/Scheme/Scrolling/ModifiersKindTests.swift
+++ b/LinearMouseUnitTests/Model/Scheme/Scrolling/ModifiersKindTests.swift
@@ -12,4 +12,32 @@ final class ModifiersKindTests: XCTestCase {
     func testInitFromDefaultActionKindCreatesAutoAction() {
         XCTAssertEqual(Scheme.Scrolling.Modifiers.Action(kind: .defaultAction), .auto)
     }
+
+    func testActionKindMapsPinchZoomReversed() {
+        XCTAssertEqual(Scheme.Scrolling.Modifiers.Action.pinchZoomReversed.kind, .pinchZoomReversed)
+    }
+
+    func testInitFromPinchZoomReversedKindCreatesPinchZoomReversedAction() {
+        XCTAssertEqual(Scheme.Scrolling.Modifiers.Action(kind: .pinchZoomReversed), .pinchZoomReversed)
+    }
+
+    func testPinchZoomReversedCodable() throws {
+        typealias Action = Scheme.Scrolling.Modifiers.Action
+
+        let decoder = JSONDecoder()
+        let action = try decoder.decode(
+            Action.self,
+            from: Data(#"{"type":"pinchZoomReversed"}"#.utf8)
+        )
+
+        XCTAssertEqual(action, .pinchZoomReversed)
+
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = .sortedKeys
+
+        XCTAssertEqual(
+            try String(data: encoder.encode(action), encoding: .utf8),
+            #"{"type":"pinchZoomReversed"}"#
+        )
+    }
 }

--- a/LinearMouseUnitTests/Model/Scheme/Scrolling/ModifiersKindTests.swift
+++ b/LinearMouseUnitTests/Model/Scheme/Scrolling/ModifiersKindTests.swift
@@ -13,6 +13,34 @@ final class ModifiersKindTests: XCTestCase {
         XCTAssertEqual(Scheme.Scrolling.Modifiers.Action(kind: .defaultAction), .auto)
     }
 
+    func testActionKindMapsZoomReversed() {
+        XCTAssertEqual(Scheme.Scrolling.Modifiers.Action.zoomReversed.kind, .zoomReversed)
+    }
+
+    func testInitFromZoomReversedKindCreatesZoomReversedAction() {
+        XCTAssertEqual(Scheme.Scrolling.Modifiers.Action(kind: .zoomReversed), .zoomReversed)
+    }
+
+    func testZoomReversedCodable() throws {
+        typealias Action = Scheme.Scrolling.Modifiers.Action
+
+        let decoder = JSONDecoder()
+        let action = try decoder.decode(
+            Action.self,
+            from: Data(#"{"type":"zoomReversed"}"#.utf8)
+        )
+
+        XCTAssertEqual(action, .zoomReversed)
+
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = .sortedKeys
+
+        XCTAssertEqual(
+            try String(data: encoder.encode(action), encoding: .utf8),
+            #"{"type":"zoomReversed"}"#
+        )
+    }
+
     func testActionKindMapsPinchZoomReversed() {
         XCTAssertEqual(Scheme.Scrolling.Modifiers.Action.pinchZoomReversed.kind, .pinchZoomReversed)
     }


### PR DESCRIPTION
## Summary
- Add new `Zoom (reversed)` and `Pinch zoom (reversed)` modifier actions.
- Persist the actions as `{"type":"zoomReversed"}` and `{"type":"pinchZoomReversed"}` in the configuration schema.
- Reverse the generated zoom direction for the new actions while keeping the existing `Zoom` and `Pinch zoom` actions unchanged.
- Localize the new action labels.

## Related issues
- Related to #1023
- Related to #1178

## Testing
- `xcodebuild clean test -project LinearMouse.xcodeproj -scheme LinearMouse -destination "platform=macOS" -only-testing:LinearMouseUnitTests/ModifiersKindTests -only-testing:LinearMouseUnitTests/ModifierActionsTransformerTests`
- `xcstringstool compile --dry-run --output-directory /tmp/linearmouse-xcstrings-check LinearMouse/Localizable.xcstrings`
- `json_pp -json_opt pretty,canonical < LinearMouse/Localizable.xcstrings > /tmp/linearmouse-localizable-json-check.json`