### PR TITLE
Fix HID++ receiver monitor retry loop and receiver whitelist

### DIFF
--- a/LinearMouse/Device/DeviceManager.swift
+++ b/LinearMouse/Device/DeviceManager.swift
@@ -407,15 +407,11 @@ class DeviceManager: ObservableObject {
     }
 
     private func shouldMonitorReceiver(_ device: Device) -> Bool {
-        guard let vendorID = device.vendorID,
-              vendorID == LogitechHIDPPDeviceMetadataProvider.Constants.vendorID,
-              device.pointerDevice.transport == PointerDeviceTransportName.usb
-        else {
-            return false
-        }
-
-        let productName = device.productName ?? device.name
-        return productName.localizedCaseInsensitiveContains("receiver")
+        LogitechHIDPPDeviceMetadataProvider.supportsReceiverMonitoring(
+            vendorID: device.vendorID,
+            productID: device.productID,
+            transport: device.pointerDevice.transport
+        )
     }
 
     private func receiverPointingDevicesChanged(locationID: Int, identities: [ReceiverLogicalDeviceIdentity]) {

--- a/LinearMouse/Device/ReceiverMonitor.swift
+++ b/LinearMouse/Device/ReceiverMonitor.swift
@@ -7,6 +7,7 @@ import os.log
 final class ReceiverMonitor {
     static let log = OSLog(subsystem: Bundle.main.bundleIdentifier!, category: "ReceiverMonitor")
     static let initialDiscoveryTimeout: TimeInterval = 3
+    static let channelOpenRetryInterval: TimeInterval = 0.5
     static let refreshInterval: TimeInterval = 15
 
     private let provider = LogitechHIDPPDeviceMetadataProvider()
@@ -161,6 +162,7 @@ private final class ReceiverContext {
     private var lastPublishedIdentities = [ReceiverLogicalDeviceIdentity]()
     private var stateStore = ReceiverSlotStateStore()
     private var currentChannel: LogitechReceiverChannel?
+    private let retrySemaphore = DispatchSemaphore(value: 0)
 
     var onDiscoveryTimedOut: (() -> Void)?
     var onSlotsChanged: (([ReceiverLogicalDeviceIdentity]) -> Void)?
@@ -198,6 +200,7 @@ private final class ReceiverContext {
         stateLock.unlock()
 
         channel?.wake()
+        retrySemaphore.signal()
         thread?.cancel()
     }
 
@@ -205,8 +208,11 @@ private final class ReceiverContext {
         let initialDeadline = Date().addingTimeInterval(ReceiverMonitor.initialDiscoveryTimeout)
         var hasPublishedInitialState = false
         var hasCompletedInitialDiscovery = false
+        var hasLoggedMissingChannel = false
+        var hasOpenedChannel = false
         defer {
             setCurrentChannel(nil)
+            markStopped()
         }
 
         while shouldContinueRunning() {
@@ -222,13 +228,16 @@ private final class ReceiverContext {
             }
 
             guard let receiverChannel = currentChannelSnapshot() else {
-                os_log(
-                    "Receiver monitor is waiting for channel: locationID=%{public}d device=%{public}@",
-                    log: ReceiverMonitor.log,
-                    type: .info,
-                    locationID,
-                    String(describing: device)
-                )
+                if !hasLoggedMissingChannel {
+                    os_log(
+                        "Receiver channel is unavailable, will retry briefly: locationID=%{public}d device=%{public}@",
+                        log: ReceiverMonitor.log,
+                        type: .info,
+                        locationID,
+                        String(describing: device)
+                    )
+                    hasLoggedMissingChannel = true
+                }
 
                 if !hasPublishedInitialState, Date() >= initialDeadline {
                     DispatchQueue.main.async { [weak self] in
@@ -237,9 +246,27 @@ private final class ReceiverContext {
                     hasPublishedInitialState = true
                 }
 
-                CFRunLoopRunInMode(.defaultMode, 0.5, true)
+                if Date() >= initialDeadline {
+                    if hasOpenedChannel {
+                        waitBeforeRetryingChannelOpen()
+                    } else {
+                        os_log(
+                            "Receiver channel unavailable after initial timeout, stopping monitor: locationID=%{public}d device=%{public}@",
+                            log: ReceiverMonitor.log,
+                            type: .info,
+                            locationID,
+                            String(describing: device)
+                        )
+                        break
+                    }
+                } else {
+                    waitBeforeRetryingChannelOpen(until: initialDeadline)
+                }
+
                 continue
             }
+            hasLoggedMissingChannel = false
+            hasOpenedChannel = true
 
             // Full discovery only once per channel open
             if !hasCompletedInitialDiscovery {
@@ -379,6 +406,28 @@ private final class ReceiverContext {
         stateLock.lock()
         defer { stateLock.unlock() }
         return isRunning
+    }
+
+    private func markStopped() {
+        stateLock.lock()
+        isRunning = false
+        workerThread = nil
+        stateLock.unlock()
+    }
+
+    private func waitBeforeRetryingChannelOpen(until deadline: Date? = nil) {
+        let retryDelay: TimeInterval
+        if let deadline {
+            retryDelay = min(ReceiverMonitor.channelOpenRetryInterval, max(0, deadline.timeIntervalSinceNow))
+        } else {
+            retryDelay = ReceiverMonitor.channelOpenRetryInterval
+        }
+
+        guard retryDelay > 0 else {
+            return
+        }
+
+        _ = retrySemaphore.wait(timeout: .now() + retryDelay)
     }
 
     private func setCurrentChannel(_ channel: LogitechReceiverChannel?) {

--- a/LinearMouse/Device/VendorSpecific/ConnectedBatteryDeviceInventory.swift
+++ b/LinearMouse/Device/VendorSpecific/ConnectedBatteryDeviceInventory.swift
@@ -143,7 +143,7 @@ enum ConnectedBatteryDeviceInventory {
 
         let name: String = getProperty(kIOHIDProductKey, from: hidDevice) ?? "(unknown)"
 
-        if isGenericLogitechReceiver(name: name, hidDevice: hidDevice) {
+        if isGenericLogitechReceiver(hidDevice: hidDevice) {
             return nil
         }
 
@@ -161,14 +161,17 @@ enum ConnectedBatteryDeviceInventory {
         )
     }
 
-    private static func isGenericLogitechReceiver(name: String, hidDevice: IOHIDDevice) -> Bool {
+    private static func isGenericLogitechReceiver(hidDevice: IOHIDDevice) -> Bool {
         guard let vendorID: NSNumber = getProperty(kIOHIDVendorIDKey, from: hidDevice),
-              vendorID.intValue == 0x046D
+              let productID: NSNumber = getProperty(kIOHIDProductIDKey, from: hidDevice)
         else {
             return false
         }
 
-        return name.localizedCaseInsensitiveContains("receiver")
+        return LogitechHIDPPDeviceMetadataProvider.isKnownReceiver(
+            vendorID: vendorID.intValue,
+            productID: productID.intValue
+        )
     }
 
     private static func getProperty<T>(_ key: String, from device: IOHIDDevice) -> T? {

--- a/LinearMouse/Device/VendorSpecific/ConnectedLogitechDeviceInventory.swift
+++ b/LinearMouse/Device/VendorSpecific/ConnectedLogitechDeviceInventory.swift
@@ -21,9 +21,10 @@ enum ConnectedLogitechDeviceInventory {
                 continue
             }
 
-            let productName = device.product ?? device.name
-            if device.transport == PointerDeviceTransportName.usb,
-               productName.localizedCaseInsensitiveContains("receiver") {
+            if LogitechHIDPPDeviceMetadataProvider.isKnownReceiver(
+                vendorID: device.vendorID,
+                productID: device.productID
+            ) {
                 continue
             }
 
@@ -33,6 +34,7 @@ enum ConnectedLogitechDeviceInventory {
                 continue
             }
 
+            let productName = device.product ?? device.name
             let name = metadata.name ?? productName
             let identity = ConnectedBatteryDeviceInfo.directIdentity(
                 vendorID: device.vendorID,

--- a/LinearMouse/Device/VendorSpecific/Logitech/LogitechHIDPPDeviceMetadataProvider.swift
+++ b/LinearMouse/Device/VendorSpecific/Logitech/LogitechHIDPPDeviceMetadataProvider.swift
@@ -31,6 +31,59 @@ struct LogitechHIDPPDeviceMetadataProvider: VendorSpecificDeviceMetadataProvider
         static let receiverInfoRegister: UInt8 = 0xB5
         static let receiverWirelessNotifications: UInt32 = 0x000100
         static let receiverSoftwarePresentNotifications: UInt32 = 0x000800
+        /// Receiver PID source:
+        /// - Solaar receiver catalog: https://pwr-solaar.github.io/Solaar/devices/
+        /// - Linux receiver driver IDs: https://codebrowser.dev/linux/linux/drivers/hid/hid-logitech-dj.c.html
+        ///
+        /// Receiver monitoring currently uses the classic Unifying/DJ HID++ path:
+        /// vendor HID application 0xFF000001, receiver index 0xFF, and HID++ 1.0
+        /// receiver registers 0x00/0x02/0xB5. Keep this whitelist limited to
+        /// receiver kinds covered by that implementation.
+        static let monitorableReceiverProductIDs: Set<Int> = [
+            0xC52B, // Unifying receiver
+            0xC532 // Unifying receiver
+        ]
+        /// These are recognized as receiver dongles, but receiver monitoring is
+        /// intentionally disabled until their protocol/transport path is implemented.
+        static let knownReceiverProductIDsWithoutMonitoringSupport: Set<Int> = [
+            // 27 MHz / early HID++ receivers.
+            0xC513,
+            0xC517,
+            0xC51B,
+            // Nano receivers. Some are partial HID++ 1.0 devices, and C52F is
+            // mouse-only, so they need receiver-kind-specific handling.
+            0xC518,
+            0xC51A,
+            0xC521,
+            0xC525,
+            0xC526,
+            0xC52E,
+            0xC52F,
+            0xC534,
+            0xC535,
+            0xC542,
+            // Gaming / Lightspeed receiver kinds use different Linux driver data
+            // and have not been validated against this monitor path.
+            0xC531,
+            0xC537,
+            0xC539,
+            0xC53A,
+            0xC53D,
+            0xC53F,
+            0xC541,
+            0xC543,
+            0xC545,
+            0xC547,
+            0xC54D,
+            // Bolt receivers are a different receiver family.
+            0xC548
+        ]
+        static let knownReceiverProductIDs: Set<Int> = [
+            monitorableReceiverProductIDs,
+            knownReceiverProductIDsWithoutMonitoringSupport
+        ].reduce(into: []) { result, productIDs in
+            result.formUnion(productIDs)
+        }
     }
 
     enum FeatureID: UInt16 {
@@ -167,6 +220,27 @@ struct LogitechHIDPPDeviceMetadataProvider: VendorSpecificDeviceMetadataProvider
         productIDs: nil,
         transports: [PointerDeviceTransportName.bluetoothLowEnergy, PointerDeviceTransportName.usb]
     )
+
+    static func supportsReceiverMonitoring(vendorID: Int?, productID: Int?, transport: String?) -> Bool {
+        guard vendorID == Constants.vendorID,
+              transport == PointerDeviceTransportName.usb,
+              let productID
+        else {
+            return false
+        }
+
+        return Constants.monitorableReceiverProductIDs.contains(productID)
+    }
+
+    static func isKnownReceiver(vendorID: Int?, productID: Int?) -> Bool {
+        guard vendorID == Constants.vendorID,
+              let productID
+        else {
+            return false
+        }
+
+        return Constants.knownReceiverProductIDs.contains(productID)
+    }
 
     func matches(device: VendorSpecificDeviceContext) -> Bool {
         let maxInputReportSize = device.maxInputReportSize ?? 0
@@ -333,7 +407,7 @@ struct LogitechHIDPPDeviceMetadataProvider: VendorSpecificDeviceMetadataProvider
 
             let deadline = Date().addingTimeInterval(timeout)
             while shouldContinue(), Date() < deadline {
-                CFRunLoopRunInMode(.defaultMode, 0.1, true)
+                Thread.sleep(forTimeInterval: min(0.1, max(0, deadline.timeIntervalSinceNow)))
             }
             return [:]
         }
@@ -1388,7 +1462,11 @@ final class LogitechReceiverChannel: VendorSpecificDeviceContext {
                 break
             }
 
-            CFRunLoopRunInMode(.defaultMode, remaining, true)
+            // Pump the HID++ channel run loop; semaphore-only waiting would block input-report delivery.
+            let result = CFRunLoopRunInMode(.defaultMode, remaining, true)
+            if result == .finished {
+                break
+            }
         }
 
         clearPendingRequest()

--- a/LinearMouseUnitTests/Device/VendorSpecificDeviceMetadataTests.swift
+++ b/LinearMouseUnitTests/Device/VendorSpecificDeviceMetadataTests.swift
@@ -65,6 +65,75 @@ final class VendorSpecificDeviceMetadataTests: XCTestCase {
         XCTAssertTrue(provider.matches(device: device))
     }
 
+    func testLogitechReceiverMonitoringAllowsSupportedUnifyingReceiverProductIDs() {
+        XCTAssertTrue(
+            LogitechHIDPPDeviceMetadataProvider.supportsReceiverMonitoring(
+                vendorID: 0x046D,
+                productID: 0xC52B,
+                transport: PointerDeviceTransportName.usb
+            )
+        )
+        XCTAssertTrue(
+            LogitechHIDPPDeviceMetadataProvider.supportsReceiverMonitoring(
+                vendorID: 0x046D,
+                productID: 0xC532,
+                transport: PointerDeviceTransportName.usb
+            )
+        )
+    }
+
+    func testLogitechReceiverMonitoringRejectsReceiversWithoutImplementedProtocolSupport() {
+        XCTAssertFalse(
+            LogitechHIDPPDeviceMetadataProvider.supportsReceiverMonitoring(
+                vendorID: 0x046D,
+                productID: 0xC52F,
+                transport: PointerDeviceTransportName.usb
+            )
+        )
+        XCTAssertFalse(
+            LogitechHIDPPDeviceMetadataProvider.supportsReceiverMonitoring(
+                vendorID: 0x046D,
+                productID: 0xC539,
+                transport: PointerDeviceTransportName.usb
+            )
+        )
+        XCTAssertFalse(
+            LogitechHIDPPDeviceMetadataProvider.supportsReceiverMonitoring(
+                vendorID: 0x046D,
+                productID: 0xC548,
+                transport: PointerDeviceTransportName.usb
+            )
+        )
+        XCTAssertFalse(
+            LogitechHIDPPDeviceMetadataProvider.supportsReceiverMonitoring(
+                vendorID: 0x046D,
+                productID: 0xC52B,
+                transport: PointerDeviceTransportName.bluetoothLowEnergy
+            )
+        )
+    }
+
+    func testLogitechKnownReceiverDetectionIncludesNanoReceivers() {
+        XCTAssertTrue(
+            LogitechHIDPPDeviceMetadataProvider.isKnownReceiver(
+                vendorID: 0x046D,
+                productID: 0xC52F
+            )
+        )
+        XCTAssertTrue(
+            LogitechHIDPPDeviceMetadataProvider.isKnownReceiver(
+                vendorID: 0x046D,
+                productID: 0xC548
+            )
+        )
+        XCTAssertFalse(
+            LogitechHIDPPDeviceMetadataProvider.isKnownReceiver(
+                vendorID: 0x046D,
+                productID: 0xB015
+            )
+        )
+    }
+
     func testConnectedLogitechInventoryDoesNotQueryBluetoothLowEnergyDevices() {
         let device = MockVendorSpecificDeviceContext(
             vendorID: 0x046D,
@@ -72,6 +141,23 @@ final class VendorSpecificDeviceMetadataTests: XCTestCase {
             product: "Logi M650",
             name: "Logi M650",
             transport: PointerDeviceTransportName.bluetoothLowEnergy,
+            maxInputReportSize: 20,
+            maxOutputReportSize: 20
+        )
+
+        let devices = ConnectedLogitechDeviceInventory.devices(from: [device])
+
+        XCTAssertTrue(devices.isEmpty)
+        XCTAssertEqual(device.outputReportRequestCount, 0)
+    }
+
+    func testConnectedLogitechInventoryDoesNotQueryKnownUsbReceivers() {
+        let device = MockVendorSpecificDeviceContext(
+            vendorID: 0x046D,
+            productID: 0xC52F,
+            product: "Logitech USB Device",
+            name: "Logitech USB Device",
+            transport: PointerDeviceTransportName.usb,
             maxInputReportSize: 20,
             maxOutputReportSize: 20
         )

--- a/Modules/KeyKit/Sources/KeyKit/SymbolicHotKey.swift
+++ b/Modules/KeyKit/Sources/KeyKit/SymbolicHotKey.swift
@@ -181,8 +181,12 @@ private func waitUntilCGEventsBeingHandled() {
     CGEvent.tapEnable(tap: eventTap, enable: true)
 
     for _ in 0 ..< 10 {
-        CFRunLoopRunInMode(.defaultMode, 0.01, true)
+        // Process the event-tap source we just installed; sleep would prevent the mark event from being observed.
+        let result = CFRunLoopRunInMode(.defaultMode, 0.01, true)
         if seenMark {
+            break
+        }
+        if result == .finished {
             break
         }
     }

--- a/Modules/PointerKit/Sources/PointerKit/PointerDevice.swift
+++ b/Modules/PointerKit/Sources/PointerKit/PointerDevice.swift
@@ -535,7 +535,11 @@ extension PointerDevice {
                     break
                 }
 
-                CFRunLoopRunInMode(.defaultMode, 0.01, true)
+                // Pump the run loop that owns IOHIDDevice; sleep would block the input-report callback.
+                let result = CFRunLoopRunInMode(.defaultMode, 0.01, true)
+                if result == .finished {
+                    break
+                }
             }
         } else {
             _ = semaphore.wait(timeout: .now() + timeout)


### PR DESCRIPTION
## Summary
- Replace the receiver-channel retry loop's run-loop sleep with a semaphore-backed retry that can be woken on stop.
- Gate receiver monitoring by Logitech USB receiver VID/PID whitelist instead of product-name matching.
- Keep unsupported receiver PIDs recognized but out of monitoring until their protocol/transport paths are implemented.
- Guard remaining run-loop waits and document why they are needed for IOHID/CGEvent callback delivery.

## Related issue
Refs #1185

## Testing
- `swiftformat --lint LinearMouse/Device/VendorSpecific/Logitech/LogitechHIDPPDeviceMetadataProvider.swift LinearMouseUnitTests/Device/VendorSpecificDeviceMetadataTests.swift LinearMouse/Device/ReceiverMonitor.swift LinearMouse/Device/DeviceManager.swift LinearMouse/Device/VendorSpecific/ConnectedBatteryDeviceInventory.swift LinearMouse/Device/VendorSpecific/ConnectedLogitechDeviceInventory.swift Modules/PointerKit/Sources/PointerKit/PointerDevice.swift Modules/KeyKit/Sources/KeyKit/SymbolicHotKey.swift`
- `git diff --check`
- `xcodebuild test -project LinearMouse.xcodeproj -scheme LinearMouse -quiet`