### PR TITLE
Fix Settings content overlapping toolbar

### DIFF
--- a/LinearMouse/UI/SettingsWindowController.swift
+++ b/LinearMouse/UI/SettingsWindowController.swift
@@ -29,12 +29,6 @@ class SettingsWindowController: NSWindowController {
         window.title = LinearMouse.appName
         window.minSize = NSSize(width: 850, height: 600)
 
-        if #available(macOS 26.0, *) {
-            // On macOS 26+, keep titlebar opaque to enable scroll edge effect (progressive blur)
-        } else {
-            window.titlebarAppearsTransparent = true
-        }
-
         // Setup split view controller
         let splitVC = SettingsSplitViewController()
         splitViewController = splitVC


### PR DESCRIPTION
Fixes Settings content showing through the toolbar/titlebar while scrolling.

Closes #1188