### PR TITLE
Fix config hot reload after directory recreation

### DIFF
--- a/LinearMouse/State/ConfigurationState.swift
+++ b/LinearMouse/State/ConfigurationState.swift
@@ -3,7 +3,6 @@
 
 import AppKit
 import Combine
-import Darwin
 import Defaults
 import Foundation
 import os.log
@@ -39,7 +38,7 @@ class ConfigurationState: ObservableObject {
     }
 
     var configurationPath: URL {
-        configurationPaths.first { FileManager.default.fileExists(atPath: $0.absoluteString) } ?? configurationPaths
+        configurationPaths.first { FileManager.default.fileExists(atPath: $0.path) } ?? configurationPaths
             .last!
     }
 
@@ -47,7 +46,7 @@ class ConfigurationState: ObservableObject {
     @Published var configuration = Configuration() {
         didSet {
             configurationSaveDebounceTimer?.invalidate()
-            guard !loading else {
+            guard !loading, ProcessEnvironment.isRunningApp else {
                 return
             }
 
@@ -74,12 +73,7 @@ class ConfigurationState: ObservableObject {
 
     private var subscriptions = Set<AnyCancellable>()
 
-    // Hot reload support (watch parent directory and resolved target file)
-    private var configDirFD: CInt?
-    private var configDirSource: DispatchSourceFileSystemObject?
-    private var configFileFD: CInt?
-    private var configFileSource: DispatchSourceFileSystemObject?
-    private var watchedFilePath: String?
+    private var configurationFileWatcher: FileWatcher?
     private var reloadDebounceWorkItem: DispatchWorkItem?
 }
 
@@ -119,61 +113,23 @@ extension ConfigurationState {
     func startHotReload() {
         stopHotReload()
 
-        // Directory watcher
-        let directoryURL = configurationPath.deletingLastPathComponent()
-        let dirFD = open(directoryURL.path, O_EVTONLY)
-        guard dirFD >= 0 else {
-            return
-        }
-        configDirFD = dirFD
-
-        let dirSource = DispatchSource.makeFileSystemObjectSource(
-            fileDescriptor: dirFD,
-            eventMask: [.write, .attrib, .rename, .link, .delete, .extend, .revoke],
+        configurationFileWatcher = FileWatcher(
+            fileURLsProvider: { [weak self] in
+                self?.configurationPaths ?? []
+            },
             queue: .main
-        )
-
-        dirSource.setEventHandler { [weak self] in
-            guard let self else {
-                return
-            }
-            // Any directory entry change may indicate symlink retarget, file replace, create/delete, etc.
-            self.updateFileWatcherIfNeeded()
-            self.scheduleReloadFromExternalChange()
+        ) { [weak self] in
+            self?.scheduleReloadFromExternalChange()
         }
-
-        dirSource.setCancelHandler { [weak self] in
-            if let fd = self?.configDirFD {
-                close(fd)
-            }
-            self?.configDirFD = nil
-        }
-
-        configDirSource = dirSource
-        dirSource.resume()
-
-        // File watcher for resolved target (or the file itself if not a symlink)
-        updateFileWatcherIfNeeded()
+        configurationFileWatcher?.start()
     }
 
     func stopHotReload() {
         reloadDebounceWorkItem?.cancel()
         reloadDebounceWorkItem = nil
 
-        configDirSource?.cancel()
-        configDirSource = nil
-        if let fd = configDirFD {
-            close(fd)
-        }
-        configDirFD = nil
-
-        configFileSource?.cancel()
-        configFileSource = nil
-        if let fd = configFileFD {
-            close(fd)
-        }
-        configFileFD = nil
-        watchedFilePath = nil
+        configurationFileWatcher?.stop()
+        configurationFileWatcher = nil
     }
 
     private func scheduleReloadFromExternalChange() {
@@ -183,83 +139,6 @@ extension ConfigurationState {
         }
         reloadDebounceWorkItem = work
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.25, execute: work)
-    }
-
-    private func updateFileWatcherIfNeeded() {
-        // Watch resolved target file (or the file itself if not a symlink)
-        let linkPath = configurationPath.path
-        let resolvedPath = (linkPath as NSString).resolvingSymlinksInPath
-
-        // If path unchanged, nothing to do
-        if watchedFilePath == resolvedPath, configFileSource != nil {
-            // Still ensure file exists; if gone, drop watcher so directory watcher can recreate later
-            if !FileManager.default.fileExists(atPath: resolvedPath) {
-                configFileSource?.cancel()
-                configFileSource = nil
-                if let fd = configFileFD {
-                    close(fd)
-                }
-                configFileFD = nil
-                watchedFilePath = nil
-            }
-            return
-        }
-
-        // Path changed or no watcher; rebuild
-        configFileSource?.cancel()
-        configFileSource = nil
-        if let fd = configFileFD {
-            close(fd)
-        }
-        configFileFD = nil
-        watchedFilePath = nil
-
-        guard FileManager.default.fileExists(atPath: resolvedPath) else {
-            return
-        }
-
-        let fd = open(resolvedPath, O_EVTONLY)
-        guard fd >= 0 else {
-            return
-        }
-        configFileFD = fd
-
-        let fileSource = DispatchSource.makeFileSystemObjectSource(
-            fileDescriptor: fd,
-            eventMask: [.write, .attrib, .extend, .delete, .rename, .revoke, .link],
-            queue: .main
-        )
-
-        fileSource.setEventHandler { [weak self] in
-            guard let self else {
-                return
-            }
-            let events = fileSource.data
-            if events.contains(.delete) || events.contains(.rename) || events.contains(.revoke) {
-                // File removed/replaced; drop watcher and rely on directory watcher to re-add
-                self.configFileSource?.cancel()
-                self.configFileSource = nil
-                if let fd = self.configFileFD {
-                    close(fd)
-                }
-                self.configFileFD = nil
-                self.watchedFilePath = nil
-                self.scheduleReloadFromExternalChange()
-            } else {
-                self.scheduleReloadFromExternalChange()
-            }
-        }
-
-        fileSource.setCancelHandler { [weak self] in
-            if let fd = self?.configFileFD {
-                close(fd)
-            }
-            self?.configFileFD = nil
-        }
-
-        configFileSource = fileSource
-        watchedFilePath = resolvedPath
-        fileSource.resume()
     }
 
     func revealInFinder() {
@@ -292,6 +171,10 @@ extension ConfigurationState {
     }
 
     func save() {
+        guard ProcessEnvironment.isRunningApp else {
+            return
+        }
+
         do {
             try configuration.dump(to: configurationPath)
         } catch {

--- a/LinearMouse/Utilities/FileWatcher.swift
+++ b/LinearMouse/Utilities/FileWatcher.swift
@@ -1,0 +1,345 @@
+// MIT License
+// Copyright (c) 2021-2026 LinearMouse
+
+import CoreServices
+import Foundation
+
+final class FileWatcher {
+    private let fileURLsProvider: () -> [URL]
+    private let queue: DispatchQueue
+    private let onChange: () -> Void
+
+    private var stream: FSEventStreamRef?
+    private var isRunning = false
+    private var watchedRootPaths: [String] = []
+
+    init(
+        fileURLsProvider: @escaping () -> [URL],
+        queue: DispatchQueue,
+        onChange: @escaping () -> Void
+    ) {
+        self.fileURLsProvider = fileURLsProvider
+        self.queue = queue
+        self.onChange = onChange
+    }
+
+    deinit {
+        stop()
+    }
+
+    func start() {
+        isRunning = true
+        updateStream(force: true)
+    }
+
+    func stop() {
+        isRunning = false
+        stopStream()
+        watchedRootPaths = []
+    }
+
+    private func updateStream(force: Bool = false) {
+        guard isRunning else {
+            return
+        }
+
+        let rootPaths = Self.rootPaths(for: fileURLsProvider())
+        guard force || rootPaths != watchedRootPaths else {
+            return
+        }
+
+        stopStream()
+        watchedRootPaths = rootPaths
+
+        guard !rootPaths.isEmpty else {
+            return
+        }
+
+        var context = FSEventStreamContext(
+            version: 0,
+            info: Unmanaged.passUnretained(self).toOpaque(),
+            retain: nil,
+            release: nil,
+            copyDescription: nil
+        )
+
+        let flags = FSEventStreamCreateFlags(
+            kFSEventStreamCreateFlagFileEvents |
+                kFSEventStreamCreateFlagNoDefer |
+                kFSEventStreamCreateFlagWatchRoot
+        )
+
+        guard let stream = FSEventStreamCreate(
+            kCFAllocatorDefault,
+            Self.handleEvents,
+            &context,
+            rootPaths as CFArray,
+            FSEventStreamEventId(kFSEventStreamEventIdSinceNow),
+            0.2,
+            flags
+        ) else {
+            watchedRootPaths = []
+            return
+        }
+
+        self.stream = stream
+        FSEventStreamSetDispatchQueue(stream, queue)
+
+        guard FSEventStreamStart(stream) else {
+            stopStream()
+            watchedRootPaths = []
+            return
+        }
+    }
+
+    private func stopStream() {
+        guard let stream else {
+            return
+        }
+
+        FSEventStreamStop(stream)
+        FSEventStreamInvalidate(stream)
+        FSEventStreamRelease(stream)
+        self.stream = nil
+    }
+
+    private static let handleEvents: FSEventStreamCallback = { _, context, eventCount, eventPaths, eventFlags, _ in
+        guard let context else {
+            return
+        }
+
+        let watcher = Unmanaged<FileWatcher>
+            .fromOpaque(context)
+            .takeUnretainedValue()
+        let eventPathPointers = eventPaths.assumingMemoryBound(to: UnsafePointer<CChar>.self)
+
+        let shouldNotify = (0 ..< eventCount).contains { index in
+            let eventPath = String(cString: eventPathPointers[index])
+            return watcher.shouldNotify(for: eventPath, flags: eventFlags[index])
+        }
+
+        if shouldNotify {
+            watcher.onChange()
+        }
+
+        watcher.queue.async { [weak watcher] in
+            watcher?.updateStream()
+        }
+    }
+
+    private func shouldNotify(for eventPath: String, flags: FSEventStreamEventFlags) -> Bool {
+        if Self.isRelevant(eventPath: eventPath, to: fileURLsProvider()) {
+            return true
+        }
+
+        let requiresRescan = Self.hasAny(
+            flags,
+            [
+                FSEventStreamEventFlags(kFSEventStreamEventFlagMustScanSubDirs),
+                FSEventStreamEventFlags(kFSEventStreamEventFlagUserDropped),
+                FSEventStreamEventFlags(kFSEventStreamEventFlagKernelDropped),
+                FSEventStreamEventFlags(kFSEventStreamEventFlagRootChanged)
+            ]
+        )
+        guard requiresRescan else {
+            return false
+        }
+
+        let canonicalEventPath = Self.canonicalPath(eventPath)
+        return watchedRootPaths.contains {
+            Self.pathsOverlap(canonicalEventPath, $0)
+        }
+    }
+
+    private static func rootPaths(for fileURLs: [URL]) -> [String] {
+        Array(Set(fileURLs.flatMap(rootPaths(for:)))).sorted()
+    }
+
+    private static func rootPaths(for fileURL: URL) -> [String] {
+        var rootPaths: [String] = []
+        let filePath = filePathPreservingLastSymlink(fileURL.path)
+        let fileDirectory = URL(fileURLWithPath: filePath).deletingLastPathComponent()
+        let parentDirectory = fileDirectory.deletingLastPathComponent()
+
+        if let rootPath = existingDirectory(atOrAbove: parentDirectory) {
+            rootPaths.append(rootPath)
+        }
+
+        let resolvedFilePath = canonicalPath(fileURL.path)
+        if resolvedFilePath != filePath {
+            let resolvedDirectory = URL(fileURLWithPath: resolvedFilePath).deletingLastPathComponent()
+            if let rootPath = existingDirectory(atOrAbove: resolvedDirectory) {
+                rootPaths.append(rootPath)
+            }
+        }
+
+        return rootPaths
+    }
+
+    private static func existingDirectory(atOrAbove url: URL) -> String? {
+        var currentURL = url.standardizedFileURL
+
+        while currentURL.path != "/" {
+            var isDirectory: ObjCBool = false
+            if FileManager.default.fileExists(atPath: currentURL.path, isDirectory: &isDirectory),
+               isDirectory.boolValue {
+                return canonicalPath(currentURL.path)
+            }
+            currentURL.deleteLastPathComponent()
+        }
+
+        return "/"
+    }
+
+    private static func isRelevant(eventPath: String, to fileURLs: [URL]) -> Bool {
+        let eventPath = canonicalPath(eventPath)
+
+        return fileURLs.contains { fileURL in
+            let filePath = filePathPreservingLastSymlink(fileURL.path)
+            let fileDirectoryPath = canonicalPath(fileURL.deletingLastPathComponent().path)
+            let parentDirectoryPath = canonicalPath(
+                fileURL.deletingLastPathComponent().deletingLastPathComponent().path
+            )
+
+            if pathsOverlap(eventPath, filePath) ||
+                pathsOverlap(eventPath, fileDirectoryPath) ||
+                eventPath == parentDirectoryPath {
+                return true
+            }
+
+            let resolvedFilePath = canonicalPath(fileURL.path)
+            if resolvedFilePath != filePath {
+                let resolvedDirectoryPath = canonicalPath(
+                    URL(fileURLWithPath: resolvedFilePath).deletingLastPathComponent().path
+                )
+                return pathsOverlap(eventPath, resolvedFilePath) ||
+                    eventPath == resolvedDirectoryPath
+            }
+
+            return false
+        }
+    }
+
+    private static func hasAny(_ flags: FSEventStreamEventFlags, _ candidates: [FSEventStreamEventFlags]) -> Bool {
+        candidates.contains {
+            flags & $0 != 0
+        }
+    }
+
+    private static func pathsOverlap(_ lhs: String, _ rhs: String) -> Bool {
+        isSameOrDescendant(lhs, of: rhs) || isSameOrDescendant(rhs, of: lhs)
+    }
+
+    private static func isSameOrDescendant(_ path: String, of rootPath: String) -> Bool {
+        let path = path.trimmedTrailingSlashes()
+        let rootPath = rootPath.trimmedTrailingSlashes()
+
+        if rootPath == "/" {
+            return path.hasPrefix("/")
+        }
+
+        return path == rootPath || path.hasPrefix(rootPath + "/")
+    }
+
+    private static func filePathPreservingLastSymlink(_ path: String) -> String {
+        let url = URL(fileURLWithPath: lexicallyStandardizedPath(path))
+        let directoryPath = canonicalPath(url.deletingLastPathComponent().path)
+        return URL(fileURLWithPath: directoryPath, isDirectory: true)
+            .appendingPathComponent(url.lastPathComponent)
+            .path
+    }
+
+    private static func canonicalPath(_ path: String) -> String {
+        resolveSymlinks(in: lexicallyStandardizedPath(path), seenPaths: [])
+    }
+
+    private static func resolveSymlinks(in path: String, seenPaths: Set<String>) -> String {
+        let standardizedPath = lexicallyStandardizedPath(path)
+        guard standardizedPath.hasPrefix("/") else {
+            return standardizedPath
+        }
+
+        let components = standardizedPath.split(separator: "/").map(String.init)
+        guard !components.isEmpty else {
+            return "/"
+        }
+
+        var resolvedComponents: [String] = []
+        for (index, component) in components.enumerated() {
+            let candidatePath = pathString(from: resolvedComponents + [component], isAbsolute: true)
+            guard let destination = try? FileManager.default.destinationOfSymbolicLink(atPath: candidatePath) else {
+                resolvedComponents.append(component)
+                continue
+            }
+
+            let destinationPath: String
+            if destination.hasPrefix("/") {
+                destinationPath = lexicallyStandardizedPath(destination)
+            } else {
+                let parentPath = pathString(from: resolvedComponents, isAbsolute: true)
+                destinationPath = lexicallyStandardizedPath(parentPath + "/" + destination)
+            }
+
+            let remainingPath = components.dropFirst(index + 1).joined(separator: "/")
+            let nextPath = remainingPath.isEmpty
+                ? destinationPath
+                : lexicallyStandardizedPath(destinationPath + "/" + remainingPath)
+
+            guard !seenPaths.contains(nextPath) else {
+                return standardizedPath
+            }
+
+            return resolveSymlinks(
+                in: nextPath,
+                seenPaths: seenPaths.union([standardizedPath])
+            )
+        }
+
+        return pathString(from: resolvedComponents, isAbsolute: true)
+    }
+
+    private static func lexicallyStandardizedPath(_ path: String) -> String {
+        let path = (path as NSString).expandingTildeInPath
+        let isAbsolute = path.hasPrefix("/")
+        var components: [String] = []
+
+        for component in path.split(separator: "/").map(String.init) {
+            switch component {
+            case ".", "":
+                continue
+            case "..":
+                if !components.isEmpty, components.last != ".." {
+                    components.removeLast()
+                } else if !isAbsolute {
+                    components.append(component)
+                }
+            default:
+                components.append(component)
+            }
+        }
+
+        let result = pathString(from: components, isAbsolute: isAbsolute)
+        if result.isEmpty {
+            return isAbsolute ? "/" : "."
+        }
+        return result
+    }
+
+    private static func pathString(from components: [String], isAbsolute: Bool) -> String {
+        let joinedComponents = components.joined(separator: "/")
+        if isAbsolute {
+            return joinedComponents.isEmpty ? "/" : "/" + joinedComponents
+        }
+        return joinedComponents
+    }
+}
+
+private extension String {
+    func trimmedTrailingSlashes() -> String {
+        var path = self
+        while path.count > 1, path.hasSuffix("/") {
+            path.removeLast()
+        }
+        return path
+    }
+}

--- a/LinearMouse/Utilities/ProcessEnvironment.swift
+++ b/LinearMouse/Utilities/ProcessEnvironment.swift
@@ -14,7 +14,18 @@ enum ProcessEnvironment {
 
     static var isRunningTest: Bool {
         #if DEBUG
-            return ProcessInfo.processInfo.environment["XCTestConfigurationFilePath"] != nil
+            let environment = ProcessInfo.processInfo.environment
+            let testEnvironmentKeys = [
+                "XCTestConfigurationFilePath",
+                "XCTestSessionIdentifier",
+                "XCInjectBundle",
+                "XCInjectBundleInto"
+            ]
+
+            return testEnvironmentKeys.contains { environment[$0] != nil } ||
+                Bundle.allBundles.contains { $0.bundlePath.hasSuffix(".xctest") } ||
+                NSClassFromString("XCTestCase") != nil ||
+                NSClassFromString("XCTest.XCTestCase") != nil
         #else
             return false
         #endif

--- a/LinearMouseUnitTests/Utilities/FileWatcherTests.swift
+++ b/LinearMouseUnitTests/Utilities/FileWatcherTests.swift
@@ -1,0 +1,72 @@
+// MIT License
+// Copyright (c) 2021-2026 LinearMouse
+
+@testable import LinearMouse
+import XCTest
+
+final class FileWatcherTests: XCTestCase {
+    private var temporaryDirectory: URL!
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+
+        temporaryDirectory = FileManager.default
+            .temporaryDirectory
+            .appendingPathComponent("linearmouse-file-watcher-tests-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: temporaryDirectory, withIntermediateDirectories: true)
+    }
+
+    override func tearDownWithError() throws {
+        if let temporaryDirectory,
+           FileManager.default.fileExists(atPath: temporaryDirectory.path) {
+            try FileManager.default.removeItem(at: temporaryDirectory)
+        }
+        temporaryDirectory = nil
+
+        try super.tearDownWithError()
+    }
+
+    func testReportsChangesAfterWatchedDirectoryIsRecreated() throws {
+        let watchedDirectory = try XCTUnwrap(temporaryDirectory)
+            .appendingPathComponent("config", isDirectory: true)
+        let watchedFile = watchedDirectory.appendingPathComponent("linearmouse.json")
+
+        try FileManager.default.createDirectory(at: watchedDirectory, withIntermediateDirectories: true)
+        try "{}".write(to: watchedFile, atomically: true, encoding: .utf8)
+
+        let removedDirectory = expectation(description: "Report watched directory removal")
+        let recreatedFile = expectation(description: "Report file write after watched directory is recreated")
+        var didReportRemovedDirectory = false
+        var didReportRecreatedFile = false
+
+        let watcher = FileWatcher(
+            fileURLsProvider: { [watchedFile] },
+            queue: .main
+        ) {
+            if !didReportRemovedDirectory,
+               !FileManager.default.fileExists(atPath: watchedDirectory.path) {
+                didReportRemovedDirectory = true
+                removedDirectory.fulfill()
+                return
+            }
+
+            if didReportRemovedDirectory,
+               !didReportRecreatedFile,
+               FileManager.default.fileExists(atPath: watchedFile.path) {
+                didReportRecreatedFile = true
+                recreatedFile.fulfill()
+            }
+        }
+        watcher.start()
+        defer {
+            watcher.stop()
+        }
+
+        try FileManager.default.removeItem(at: watchedDirectory)
+        wait(for: [removedDirectory], timeout: 5)
+
+        try FileManager.default.createDirectory(at: watchedDirectory, withIntermediateDirectories: true)
+        try "{\"recreated\":true}".write(to: watchedFile, atomically: true, encoding: .utf8)
+        wait(for: [recreatedFile], timeout: 5)
+    }
+}

--- a/LinearMouseUnitTests/Utilities/ProcessEnvironmentTests.swift
+++ b/LinearMouseUnitTests/Utilities/ProcessEnvironmentTests.swift
@@ -1,0 +1,11 @@
+// MIT License
+// Copyright (c) 2021-2026 LinearMouse
+
+@testable import LinearMouse
+import XCTest
+
+final class ProcessEnvironmentTests: XCTestCase {
+    func testUnitTestHostIsDetectedAsRunningTest() {
+        XCTAssertTrue(ProcessEnvironment.isRunningTest)
+    }
+}


### PR DESCRIPTION
## Summary
- Replace the configuration-specific DispatchSource watchers with a generic FSEvents-backed FileWatcher.
- Watch stable parent roots so deleting and recreating the configuration directory still triggers reloads.
- Keep configuration saves disabled outside the app runtime so unit tests do not write to the user config file.

## Testing
- swiftformat --lint LinearMouse/Utilities/FileWatcher.swift LinearMouse/State/ConfigurationState.swift LinearMouse/Utilities/ProcessEnvironment.swift LinearMouseUnitTests/Utilities/FileWatcherTests.swift LinearMouseUnitTests/Utilities/ProcessEnvironmentTests.swift
- swiftlint lint --quiet LinearMouse/Utilities/FileWatcher.swift LinearMouse/State/ConfigurationState.swift LinearMouse/Utilities/ProcessEnvironment.swift LinearMouseUnitTests/Utilities/FileWatcherTests.swift LinearMouseUnitTests/Utilities/ProcessEnvironmentTests.swift
- xcodebuild test -project LinearMouse.xcodeproj -scheme LinearMouse -destination 'platform=macOS' -only-testing:LinearMouseUnitTests/ProcessEnvironmentTests -only-testing:LinearMouseUnitTests/FileWatcherTests

Closes #1205
