### PR TITLE
Allow Logitech gesture buttons to preserve click fallback

### DIFF
--- a/LinearMouse/Device/VendorSpecific/Logitech/LogitechHIDPPDeviceMetadataProvider.swift
+++ b/LinearMouse/Device/VendorSpecific/Logitech/LogitechHIDPPDeviceMetadataProvider.swift
@@ -2133,11 +2133,11 @@ final class LogitechReprogrammableControlsMonitor {
                             modifierFlags: modifierFlags
                         )
 
-                        let handledInternally = EventThread.shared.performAndWait {
+                        let handlingResult = EventThread.shared.performAndWait {
                             EventTransformerManager.shared.handleLogitechControlEvent(logitechContext)
-                        } ?? false
+                        } ?? .notHandled
 
-                        guard !handledInternally else {
+                        guard !handlingResult.suppressesSyntheticFallback else {
                             continue
                         }
 

--- a/LinearMouse/EventTransformer/AutoScrollTransformer.swift
+++ b/LinearMouse/EventTransformer/AutoScrollTransformer.swift
@@ -837,28 +837,28 @@ private struct ActivationProbe {
 }
 
 extension AutoScrollTransformer: LogitechControlEventHandling {
-    func handleLogitechControlEvent(_ context: LogitechEventContext) -> Bool {
+    func handleLogitechControlEvent(_ context: LogitechEventContext) -> LogitechControlEventHandlingResult {
         guard let triggerLogitechControl = trigger.button?.logitechControl,
               context.matches(triggerLogitechControl) else {
-            return false
+            return .notHandled
         }
 
         if context.isPressed {
             // If already active in toggle mode, deactivate on re-press
             if case let .active(_, _, session) = state, session == .toggle {
                 guard hasToggleMode else {
-                    return true
+                    return .handled
                 }
                 deactivate()
-                return true
+                return .handled
             }
 
             guard trigger.matches(modifierFlags: context.modifierFlags) else {
-                return true
+                return .handled
             }
 
             activate(at: context.mouseLocation, session: activationSession)
-            return true
+            return .handled
         }
 
         switch state {
@@ -879,7 +879,7 @@ extension AutoScrollTransformer: LogitechControlEventHandling {
             break
         }
 
-        return true
+        return .handled
     }
 }
 

--- a/LinearMouse/EventTransformer/ButtonActionsTransformer.swift
+++ b/LinearMouse/EventTransformer/ButtonActionsTransformer.swift
@@ -38,15 +38,19 @@ class ButtonActionsTransformer {
 
     private func timer(for slot: TimerSlot) -> EventThreadTimer? {
         switch slot {
-        case .standard: repeatTimer
-        case .logitech: logitechRepeatTimer
+        case .standard:
+            repeatTimer
+        case .logitech:
+            logitechRepeatTimer
         }
     }
 
     private func setTimer(_ slot: TimerSlot, _ timer: EventThreadTimer?) {
         switch slot {
-        case .standard: repeatTimer = timer
-        case .logitech: logitechRepeatTimer = timer
+        case .standard:
+            repeatTimer = timer
+        case .logitech:
+            logitechRepeatTimer = timer
         }
     }
 }
@@ -201,13 +205,13 @@ extension ButtonActionsTransformer: EventTransformer, LogitechControlEventHandli
         return (mapping, action)
     }
 
-    func handleLogitechControlEvent(_ context: LogitechEventContext) -> Bool {
+    func handleLogitechControlEvent(_ context: LogitechEventContext) -> LogitechControlEventHandlingResult {
         guard let (mapping, action) = findLogitechMapping(for: context) else {
-            return false
+            return .notHandled
         }
 
         if handleLogitechKeyPressHold(mapping: mapping, action: action, context: context) {
-            return true
+            return .handled
         }
 
         logitechRepeatTimer?.invalidate()
@@ -219,7 +223,7 @@ extension ButtonActionsTransformer: EventTransformer, LogitechControlEventHandli
         let shouldExecute = keyRepeatEnabled ? context.isPressed : !context.isPressed
 
         guard shouldExecute else {
-            return true
+            return .handled
         }
 
         queueLogitechActions(
@@ -230,7 +234,7 @@ extension ButtonActionsTransformer: EventTransformer, LogitechControlEventHandli
             keyRepeatDelay: keyRepeatDelay,
             keyRepeatInterval: keyRepeatInterval
         )
-        return true
+        return .handled
     }
 
     private func shouldHoldKeys(

--- a/LinearMouse/EventTransformer/EventTransformer.swift
+++ b/LinearMouse/EventTransformer/EventTransformer.swift
@@ -9,8 +9,18 @@ protocol EventTransformer {
     func transform(_ event: CGEvent) -> CGEvent?
 }
 
+enum LogitechControlEventHandlingResult {
+    case notHandled
+    case handled
+    case handledAllowingSyntheticFallback
+
+    var suppressesSyntheticFallback: Bool {
+        self == .handled
+    }
+}
+
 protocol LogitechControlEventHandling {
-    func handleLogitechControlEvent(_ context: LogitechEventContext) -> Bool
+    func handleLogitechControlEvent(_ context: LogitechEventContext) -> LogitechControlEventHandlingResult
 }
 
 extension [EventTransformer]: EventTransformer {
@@ -26,10 +36,16 @@ extension [EventTransformer]: EventTransformer {
 }
 
 extension [EventTransformer]: LogitechControlEventHandling {
-    func handleLogitechControlEvent(_ context: LogitechEventContext) -> Bool {
-        contains { eventTransformer in
-            (eventTransformer as? LogitechControlEventHandling)?.handleLogitechControlEvent(context) == true
+    func handleLogitechControlEvent(_ context: LogitechEventContext) -> LogitechControlEventHandlingResult {
+        for eventTransformer in self {
+            let result = (eventTransformer as? LogitechControlEventHandling)?.handleLogitechControlEvent(context)
+                ?? .notHandled
+            if result != .notHandled {
+                return result
+            }
         }
+
+        return .notHandled
     }
 }
 

--- a/LinearMouse/EventTransformer/EventTransformerManager.swift
+++ b/LinearMouse/EventTransformer/EventTransformerManager.swift
@@ -143,24 +143,26 @@ class EventTransformerManager {
         get(withDevice: device, withPid: pid, withDisplay: display, updateActiveCacheKey: false)
     }
 
-    func handleLogitechControlEvent(_ context: LogitechEventContext) -> Bool {
+    func handleLogitechControlEvent(_ context: LogitechEventContext) -> LogitechControlEventHandlingResult {
         if EventThread.shared.isCurrent {
             return handleLogitechControlEventOnCurrentThread(context)
         }
 
-        if let handled = EventThread.shared.performAndWait({
+        if let result = EventThread.shared.performAndWait({
             self.handleLogitechControlEventOnCurrentThread(context)
         }) {
-            return handled
+            return result
         }
 
         return handleLogitechControlEventOnCurrentThread(context)
     }
 
-    private func handleLogitechControlEventOnCurrentThread(_ context: LogitechEventContext) -> Bool {
+    private func handleLogitechControlEventOnCurrentThread(
+        _ context: LogitechEventContext
+    ) -> LogitechControlEventHandlingResult {
         let pid = ConfigurationState.shared.configuration.usesProcessConditions ? context.pid : nil
         let transformer = get(withDevice: context.device, withPid: pid, withDisplay: context.display)
-        return (transformer as? LogitechControlEventHandling)?.handleLogitechControlEvent(context) ?? false
+        return (transformer as? LogitechControlEventHandling)?.handleLogitechControlEvent(context) ?? .notHandled
     }
 
     private func get(

--- a/LinearMouse/EventTransformer/GestureButtonTransformer.swift
+++ b/LinearMouse/EventTransformer/GestureButtonTransformer.swift
@@ -285,37 +285,41 @@ extension GestureButtonTransformer: EventTransformer {
 }
 
 extension GestureButtonTransformer: LogitechControlEventHandling {
-    func handleLogitechControlEvent(_ context: LogitechEventContext) -> Bool {
+    func handleLogitechControlEvent(_ context: LogitechEventContext) -> LogitechControlEventHandlingResult {
         guard let triggerLogitechControl = trigger.button?.logitechControl,
               context.matches(triggerLogitechControl) else {
-            return false
+            return .notHandled
         }
 
-        if case let .cooldown(until, _) = state {
+        if case let .cooldown(until, released) = state {
             if DispatchTime.now().uptimeNanoseconds < until {
-                return true
+                if context.isPressed || released {
+                    return .handled
+                }
+
+                state = .cooldown(until: until, released: true)
+                return .handledAllowingSyntheticFallback
             }
             state = .idle
         }
 
         if context.isPressed {
             guard trigger.matches(modifierFlags: context.modifierFlags) else {
-                return true
+                return .notHandled
             }
             state = .tracking(startTime: DispatchTime.now().uptimeNanoseconds, deltaX: 0, deltaY: 0)
             os_log("Started tracking gesture (Logitech control)", log: Self.log, type: .info)
-        } else {
-            switch state {
-            case .tracking:
-                state = .idle
-            case .cooldown:
-                break
-            default:
-                break
-            }
+            return .handledAllowingSyntheticFallback
         }
 
-        return true
+        switch state {
+        case .tracking:
+            state = .idle
+        default:
+            break
+        }
+
+        return .notHandled
     }
 }
 

--- a/LinearMouseUnitTests/EventTransformer/ButtonActionsTransformerTests.swift
+++ b/LinearMouseUnitTests/EventTransformer/ButtonActionsTransformerTests.swift
@@ -164,8 +164,14 @@ final class ButtonActionsTransformerTests: XCTestCase {
             keySimulator: simulator
         )
 
-        XCTAssertTrue(transformer.handleLogitechControlEvent(logitechContext(0x0001, pressed: true)))
-        XCTAssertTrue(transformer.handleLogitechControlEvent(logitechContext(0x0001, pressed: false)))
+        XCTAssertEqual(
+            transformer.handleLogitechControlEvent(logitechContext(0x0001, pressed: true)),
+            .handled
+        )
+        XCTAssertEqual(
+            transformer.handleLogitechControlEvent(logitechContext(0x0001, pressed: false)),
+            .handled
+        )
 
         XCTAssertEqual(simulator.events, [.down([.a]), .up([.a]), .reset])
     }

--- a/LinearMouseUnitTests/EventTransformer/GestureButtonTransformerTests.swift
+++ b/LinearMouseUnitTests/EventTransformer/GestureButtonTransformerTests.swift
@@ -1,0 +1,112 @@
+// MIT License
+// Copyright (c) 2021-2026 LinearMouse
+
+import CoreGraphics
+@testable import LinearMouse
+import XCTest
+
+private let testLogitechControlID = 0x0001
+private let testGestureThreshold = 10.0
+private let testGestureDeadZone = 40.0
+private let testGestureCooldownMs = 500
+
+private func logitechContext(
+    pressed: Bool,
+    modifierFlags: CGEventFlags = []
+) -> LogitechEventContext {
+    .init(
+        device: nil,
+        pid: nil,
+        display: nil,
+        mouseLocation: .zero,
+        controlIdentity: .init(controlID: testLogitechControlID),
+        isPressed: pressed,
+        modifierFlags: modifierFlags
+    )
+}
+
+private func makeLogitechGestureTransformer(
+    trigger: Scheme.Buttons.Mapping = .init(
+        button: .logitechControl(.init(controlID: testLogitechControlID))
+    )
+) -> GestureButtonTransformer {
+    GestureButtonTransformer(
+        trigger: trigger,
+        threshold: testGestureThreshold,
+        deadZone: testGestureDeadZone,
+        cooldownMs: testGestureCooldownMs,
+        actions: .init(right: Scheme.Buttons.Gesture.GestureAction.none)
+    )
+}
+
+private func makeMouseMovedEvent(deltaX: Double, deltaY: Double = 0) throws -> CGEvent {
+    let event = try XCTUnwrap(CGEvent(
+        mouseEventSource: nil,
+        mouseType: .mouseMoved,
+        mouseCursorPosition: .zero,
+        mouseButton: .center
+    ))
+    event.setDoubleValueField(.mouseEventDeltaX, value: deltaX)
+    event.setDoubleValueField(.mouseEventDeltaY, value: deltaY)
+    return event
+}
+
+final class GestureButtonTransformerTests: XCTestCase {
+    func testLogitechControlClickAllowsSyntheticFallbackWhenGestureDoesNotTrigger() {
+        let transformer = makeLogitechGestureTransformer()
+
+        XCTAssertEqual(
+            transformer.handleLogitechControlEvent(logitechContext(pressed: true)),
+            .handledAllowingSyntheticFallback
+        )
+        XCTAssertEqual(
+            transformer.handleLogitechControlEvent(logitechContext(pressed: false)),
+            .notHandled
+        )
+    }
+
+    func testLogitechControlModifierMismatchAllowsSyntheticFallback() {
+        let transformer = makeLogitechGestureTransformer(trigger: .init(
+            button: .logitechControl(.init(controlID: testLogitechControlID)),
+            shift: true
+        ))
+
+        XCTAssertEqual(
+            transformer.handleLogitechControlEvent(logitechContext(pressed: true)),
+            .notHandled
+        )
+    }
+
+    func testLogitechControlGestureAllowsSyntheticFallbackForCleanupRelease() throws {
+        let transformer = makeLogitechGestureTransformer()
+
+        XCTAssertEqual(
+            transformer.handleLogitechControlEvent(logitechContext(pressed: true)),
+            .handledAllowingSyntheticFallback
+        )
+
+        XCTAssertNil(try transformer.transform(makeMouseMovedEvent(deltaX: testGestureThreshold)))
+        XCTAssertEqual(
+            transformer.handleLogitechControlEvent(logitechContext(pressed: false)),
+            .handledAllowingSyntheticFallback
+        )
+    }
+
+    func testLogitechControlCooldownConsumesAdditionalPressesAfterCleanupRelease() throws {
+        let transformer = makeLogitechGestureTransformer()
+
+        XCTAssertEqual(
+            transformer.handleLogitechControlEvent(logitechContext(pressed: true)),
+            .handledAllowingSyntheticFallback
+        )
+        XCTAssertNil(try transformer.transform(makeMouseMovedEvent(deltaX: testGestureThreshold)))
+        XCTAssertEqual(
+            transformer.handleLogitechControlEvent(logitechContext(pressed: false)),
+            .handledAllowingSyntheticFallback
+        )
+        XCTAssertEqual(
+            transformer.handleLogitechControlEvent(logitechContext(pressed: true)),
+            .handled
+        )
+    }
+}


### PR DESCRIPTION
## Summary

Allow Logitech gesture-button controls to behave like regular mouse buttons when no gesture is detected.

Previously, Logitech virtual/gesture controls were treated as fully handled as soon as the gesture transformer saw them. That prevented the Logitech fallback synthetic click from being posted, so a configured gesture button could trigger gestures but would not preserve normal click behavior.

This changes Logitech control handling from a boolean handled/not-handled result to a small enum so handlers can distinguish between:

- controls that are fully handled internally
- controls that are not handled
- gesture controls that are handled for gesture tracking but should still allow synthetic fallback click events

With this, a Logitech gesture button can:

- fall through as a click when released without crossing the gesture threshold
- trigger the configured gesture when dragged past the threshold
- suppress the click action after a gesture fires

## Testing

- `xcodebuild test -project LinearMouse.xcodeproj -scheme LinearMouse`
- `swiftformat --lint` on changed Swift files
- `swiftlint --strict` on changed non-legacy Swift files
