### PR TITLE
Fix smooth scrolling in Apple Calendar with scroll bounce enabled

### DIFF
--- a/LinearMouse/EventTransformer/SmoothedScrollingTransformer.swift
+++ b/LinearMouse/EventTransformer/SmoothedScrollingTransformer.swift
@@ -2,6 +2,7 @@
 // Copyright (c) 2021-2026 LinearMouse
 
 import Foundation
+import GestureKit
 import os.log
 
 final class SmoothedScrollingTransformer: EventTransformer, Deactivatable {
@@ -17,6 +18,7 @@ final class SmoothedScrollingTransformer: EventTransformer, Deactivatable {
     private var engine: SmoothedScrollingEngine
     private var timer: EventThreadTimer?
     private var lastFlags: CGEventFlags = []
+    private var syntheticGestureScrollSeriesActive = false
 
     init(
         smoothed: Scheme.Scrolling.Bidirectional<Scheme.Scrolling.Smoothed>,
@@ -96,6 +98,7 @@ final class SmoothedScrollingTransformer: EventTransformer, Deactivatable {
     }
 
     func deactivate() {
+        endSyntheticGestureScrollSeriesIfNeeded(phase: .cancelled)
         stopTimer()
         engine = SmoothedScrollingEngine(smoothed: smoothed)
         lastFlags = []
@@ -212,16 +215,19 @@ final class SmoothedScrollingTransformer: EventTransformer, Deactivatable {
         view.continuous = true
         delivery.setHorizontal(emission.deltaX, on: view)
         delivery.setVertical(emission.deltaY, on: view)
-        delivery.apply(
-            phases: delivery.phasesFor(emission.phase, appliesPhases: allowsBouncingForConfiguredAxes()),
-            to: view
-        )
+        let phases = delivery.phasesFor(emission.phase, appliesPhases: allowsBouncingForConfiguredAxes())
+        delivery.apply(phases: phases, to: view)
         guard view.scrollPhase != nil || view.momentumPhase != .none || emission.deltaX != 0 || emission.deltaY != 0
         else {
             return
         }
         event.isLinearMouseSyntheticEvent = true
         event.flags = lastFlags
+        postGestureScrollCompanionsIfNeeded(
+            scrollPhase: phases.scrollPhase,
+            deltaX: emission.deltaX,
+            deltaY: emission.deltaY
+        )
         eventSink(event)
 
         os_log(
@@ -235,6 +241,69 @@ final class SmoothedScrollingTransformer: EventTransformer, Deactivatable {
         )
     }
 
+    private func postGestureScrollCompanionsIfNeeded(
+        scrollPhase: CGScrollPhase?,
+        deltaX: Double,
+        deltaY: Double
+    ) {
+        guard let scrollPhase, let gesturePhase = CGSGesturePhase(scrollPhase: scrollPhase) else {
+            return
+        }
+
+        if scrollPhase == .began, !syntheticGestureScrollSeriesActive {
+            GestureEvent(
+                scrollSource: nil,
+                phase: .mayBegin,
+                deltaX: 0,
+                deltaY: 0,
+                flags: lastFlags
+            )?.send(to: eventSink)
+            GestureEvent(
+                scrollSeriesSource: nil,
+                started: true,
+                flags: lastFlags
+            )?.send(to: eventSink)
+            syntheticGestureScrollSeriesActive = true
+        }
+
+        GestureEvent(
+            scrollSource: nil,
+            phase: gesturePhase,
+            deltaX: deltaX,
+            deltaY: deltaY,
+            flags: lastFlags
+        )?.send(to: eventSink)
+
+        if scrollPhase == .ended || scrollPhase == .cancelled {
+            GestureEvent(
+                scrollSeriesSource: nil,
+                started: false,
+                flags: lastFlags
+            )?.send(to: eventSink)
+            syntheticGestureScrollSeriesActive = false
+        }
+    }
+
+    private func endSyntheticGestureScrollSeriesIfNeeded(phase: CGSGesturePhase) {
+        guard syntheticGestureScrollSeriesActive else {
+            return
+        }
+
+        GestureEvent(
+            scrollSource: nil,
+            phase: phase,
+            deltaX: 0,
+            deltaY: 0,
+            flags: lastFlags
+        )?.send(to: eventSink)
+        GestureEvent(
+            scrollSeriesSource: nil,
+            started: false,
+            flags: lastFlags
+        )?.send(to: eventSink)
+        syntheticGestureScrollSeriesActive = false
+    }
+
     private func allowsBouncingForConfiguredAxes(
         interceptsX: Bool = true,
         interceptsY: Bool = true
@@ -246,6 +315,15 @@ final class SmoothedScrollingTransformer: EventTransformer, Deactivatable {
             return false
         }
         return true
+    }
+}
+
+private extension CGSGesturePhase {
+    init?(scrollPhase: CGScrollPhase) {
+        guard let rawValue = UInt8(exactly: scrollPhase.rawValue) else {
+            return nil
+        }
+        self.init(rawValue: rawValue)
     }
 }
 

--- a/LinearMouseUnitTests/EventTransformer/SmoothedScrollingTransformerTests.swift
+++ b/LinearMouseUnitTests/EventTransformer/SmoothedScrollingTransformerTests.swift
@@ -1,8 +1,13 @@
 // MIT License
 // Copyright (c) 2021-2026 LinearMouse
 
+@testable import GestureKit
 @testable import LinearMouse
 import XCTest
+
+private let gestureHIDTypeField = CGEventField(rawValue: 110)!
+private let gestureStartEndSeriesTypeField = CGEventField(rawValue: 117)!
+private let gesturePhaseField = CGEventField(rawValue: 132)!
 
 final class SmoothedScrollingTransformerTests: XCTestCase {
     func testModifierAlterOrientationAppliesBeforeDiscreteSmoothedScrolling() throws {
@@ -91,8 +96,8 @@ final class SmoothedScrollingTransformerTests: XCTestCase {
         baselineTransformer.tick()
         scaledTransformer.tick()
 
-        let baselineView = try ScrollWheelEventView(XCTUnwrap(baselineEmittedEvents.first))
-        let scaledView = try ScrollWheelEventView(XCTUnwrap(scaledEmittedEvents.first))
+        let baselineView = try ScrollWheelEventView(XCTUnwrap(baselineEmittedEvents.firstScrollWheelEvent))
+        let scaledView = try ScrollWheelEventView(XCTUnwrap(scaledEmittedEvents.firstScrollWheelEvent))
         XCTAssertGreaterThan(abs(scaledView.deltaYPt), abs(baselineView.deltaYPt))
     }
 
@@ -132,7 +137,7 @@ final class SmoothedScrollingTransformerTests: XCTestCase {
         for _ in 0 ..< 30 {
             now += 1.0 / 120.0
             smoothedTransformer.tick()
-            if let view = emittedEvents.last.map(ScrollWheelEventView.init), abs(view.deltaYPt) > 0.01 {
+            if let view = emittedEvents.lastScrollWheelEvent.map(ScrollWheelEventView.init), abs(view.deltaYPt) > 0.01 {
                 sawVerticalMomentum = true
             }
         }
@@ -152,7 +157,7 @@ final class SmoothedScrollingTransformerTests: XCTestCase {
         now += 1.0 / 120.0
         smoothedTransformer.tick()
 
-        let switchedView = try ScrollWheelEventView(XCTUnwrap(emittedEvents.last))
+        let switchedView = try ScrollWheelEventView(XCTUnwrap(emittedEvents.lastScrollWheelEvent))
         XCTAssertGreaterThan(abs(switchedView.deltaXPt), 0.01)
         XCTAssertEqual(switchedView.deltaYPt, 0, accuracy: 0.001)
     }
@@ -193,7 +198,7 @@ final class SmoothedScrollingTransformerTests: XCTestCase {
         now = 1.0 / 120.0
         transformer.tick()
 
-        let emittedEvent = try XCTUnwrap(emittedEvents.first)
+        let emittedEvent = try XCTUnwrap(emittedEvents.firstScrollWheelEvent)
         let emittedView = ScrollWheelEventView(emittedEvent)
         XCTAssertTrue(emittedEvent.isLinearMouseSyntheticEvent)
         XCTAssertEqual(emittedView.deltaX, 0)
@@ -201,6 +206,26 @@ final class SmoothedScrollingTransformerTests: XCTestCase {
         XCTAssertEqual(emittedView.momentumPhase, .none)
         XCTAssertGreaterThan(abs(emittedView.deltaYPt), 0)
         XCTAssertEqual(emittedEvent.flags, [.maskAlternate])
+
+        let gestureEventType = try XCTUnwrap(CGEventType(nsEventType: .gesture))
+        let gestureEvents = emittedEvents.filter { $0.type == gestureEventType }
+        XCTAssertEqual(gestureEvents.count, 3)
+        XCTAssertEqual(gestureEvents[0].getIntegerValueField(gestureHIDTypeField), 6)
+        XCTAssertEqual(
+            gestureEvents[0].getIntegerValueField(gesturePhaseField),
+            Int64(CGSGesturePhase.mayBegin.rawValue)
+        )
+        XCTAssertEqual(gestureEvents[1].getIntegerValueField(gestureHIDTypeField), 61)
+        XCTAssertEqual(
+            gestureEvents[1].getIntegerValueField(gestureStartEndSeriesTypeField),
+            6
+        )
+        XCTAssertEqual(gestureEvents[2].getIntegerValueField(gestureHIDTypeField), 6)
+        XCTAssertEqual(
+            gestureEvents[2].getIntegerValueField(gesturePhaseField),
+            Int64(CGSGesturePhase.began.rawValue)
+        )
+        XCTAssertTrue(gestureEvents[2].flags.contains(.maskAlternate))
     }
 
     func testDiscreteWheelInputUsesLineDeltaForStartupEvenWhenPointDeltaExists() throws {
@@ -232,7 +257,7 @@ final class SmoothedScrollingTransformerTests: XCTestCase {
         now = 1.0 / 120.0
         transformer.tick()
 
-        let emittedEvent = try XCTUnwrap(emittedEvents.first)
+        let emittedEvent = try XCTUnwrap(emittedEvents.firstScrollWheelEvent)
         let emittedView = ScrollWheelEventView(emittedEvent)
         XCTAssertGreaterThan(abs(emittedView.deltaYPt), 3)
         XCTAssertEqual(emittedView.scrollPhase, .began)
@@ -295,12 +320,14 @@ final class SmoothedScrollingTransformerTests: XCTestCase {
         now = 1.0 / 120.0
         transformer.tick()
 
-        let emittedEvent = try XCTUnwrap(emittedEvents.first)
+        let emittedEvent = try XCTUnwrap(emittedEvents.firstScrollWheelEvent)
         let emittedView = ScrollWheelEventView(emittedEvent)
         XCTAssertTrue(emittedEvent.isLinearMouseSyntheticEvent)
         XCTAssertGreaterThan(abs(emittedView.deltaYPt), 0)
-        XCTAssertEqual(emittedView.scrollPhase, nil)
+        XCTAssertNil(emittedView.scrollPhase)
         XCTAssertEqual(emittedView.momentumPhase, .none)
+        let gestureEventType = try XCTUnwrap(CGEventType(nsEventType: .gesture))
+        XCTAssertFalse(emittedEvents.contains { $0.type == gestureEventType })
     }
 
     func testContinuousTrackpadInputCanSuppressBouncingPhases() throws {
@@ -329,7 +356,7 @@ final class SmoothedScrollingTransformerTests: XCTestCase {
         let transformedView = ScrollWheelEventView(transformedEvent)
         XCTAssertGreaterThan(transformedView.deltaYFixedPt, 0)
         XCTAssertLessThan(transformedView.deltaYFixedPt, 9)
-        XCTAssertEqual(transformedView.scrollPhase, nil)
+        XCTAssertNil(transformedView.scrollPhase)
         XCTAssertEqual(transformedView.momentumPhase, .none)
     }
 
@@ -408,6 +435,16 @@ final class SmoothedScrollingTransformerTests: XCTestCase {
         now = 1.0 / 120.0
         transformer.tick()
 
-        return try ScrollWheelEventView(XCTUnwrap(emittedEvents.first))
+        return try ScrollWheelEventView(XCTUnwrap(emittedEvents.firstScrollWheelEvent))
+    }
+}
+
+private extension [CGEvent] {
+    var firstScrollWheelEvent: CGEvent? {
+        first { $0.type == .scrollWheel }
+    }
+
+    var lastScrollWheelEvent: CGEvent? {
+        last { $0.type == .scrollWheel }
     }
 }

--- a/Modules/GestureKit/Sources/GestureKit/CGEventField+Extensions.swift
+++ b/Modules/GestureKit/Sources/GestureKit/CGEventField+Extensions.swift
@@ -9,7 +9,11 @@ extension CGEventField {
     static let gestureHIDType = Self(rawValue: 110)!
     static let gestureZoomValue = Self(rawValue: 113)!
     static let gestureSwipeValue = Self(rawValue: 115)!
+    static let gestureStartEndSeriesType = Self(rawValue: 117)!
+    static let gestureScrollX = Self(rawValue: 118)!
+    static let gestureScrollY = Self(rawValue: 119)!
     static let gesturePhase = Self(rawValue: 132)!
+    static let scrollGestureFlagBits = Self(rawValue: 135)!
 }
 
 /// - SeeAlso:
@@ -36,6 +40,8 @@ enum IOHIDEventType: UInt32 {
     case navigationSwipe = 16
     case zoomToggle = 22
     case force = 32
+    case gestureStarted = 61
+    case gestureEnded = 62
 }
 
 /// - SeeAlso:

--- a/Modules/GestureKit/Sources/GestureKit/GestureEvent+Scroll.swift
+++ b/Modules/GestureKit/Sources/GestureKit/GestureEvent+Scroll.swift
@@ -1,0 +1,51 @@
+// MIT License
+// Copyright (c) 2021-2026 LinearMouse
+
+import CoreGraphics
+
+public extension GestureEvent {
+    convenience init?(
+        scrollSource: CGEventSource?,
+        phase: CGSGesturePhase,
+        deltaX: Double,
+        deltaY: Double,
+        flags: CGEventFlags = []
+    ) {
+        guard let event = CGEvent(source: scrollSource) else {
+            return nil
+        }
+
+        event.type = .init(nsEventType: .gesture)!
+        event.flags = flags
+        event.setIntegerValueField(.gestureHIDType, value: Int64(IOHIDEventType.scroll.rawValue))
+        event.setIntegerValueField(.gesturePhase, value: Int64(phase.rawValue))
+        event.setIntegerValueField(.scrollGestureFlagBits, value: 1)
+        event.setDoubleValueField(.gestureScrollX, value: deltaX)
+        event.setDoubleValueField(.gestureScrollY, value: deltaY)
+
+        self.init(cgEvents: [event])
+    }
+
+    convenience init?(
+        scrollSeriesSource: CGEventSource?,
+        started: Bool,
+        flags: CGEventFlags = []
+    ) {
+        guard let event = CGEvent(source: scrollSeriesSource) else {
+            return nil
+        }
+
+        event.type = .init(nsEventType: .gesture)!
+        event.flags = flags
+        event.setIntegerValueField(
+            .gestureHIDType,
+            value: Int64((started ? IOHIDEventType.gestureStarted : .gestureEnded).rawValue)
+        )
+        event.setIntegerValueField(
+            .gestureStartEndSeriesType,
+            value: Int64(IOHIDEventType.scroll.rawValue)
+        )
+
+        self.init(cgEvents: [event])
+    }
+}

--- a/Modules/GestureKit/Sources/GestureKit/GestureEvent.swift
+++ b/Modules/GestureKit/Sources/GestureKit/GestureEvent.swift
@@ -16,4 +16,10 @@ public class GestureEvent {
             cgEvent.post(tap: tap)
         }
     }
+
+    public func send(to sink: (CGEvent) -> Void) {
+        for cgEvent in cgEvents {
+            sink(cgEvent)
+        }
+    }
 }

--- a/Modules/GestureKit/Tests/GestureKitTests/GestureKitTests.swift
+++ b/Modules/GestureKit/Tests/GestureKitTests/GestureKitTests.swift
@@ -27,4 +27,55 @@ final class GestureKitTests: XCTestCase {
             }
         }
     }
+
+    func testScrollGesture() throws {
+        guard let event = GestureEvent(
+            scrollSource: nil,
+            phase: .began,
+            deltaX: 4,
+            deltaY: -2,
+            flags: [.maskShift]
+        ) else {
+            XCTFail("event should not be nil")
+            return
+        }
+
+        let cgEvent = try XCTUnwrap(event.cgEvents.first)
+        let gestureType = try XCTUnwrap(CGEventType(nsEventType: .gesture))
+        XCTAssertEqual(cgEvent.type, gestureType)
+        XCTAssertEqual(cgEvent.flags, [.maskShift])
+        XCTAssertEqual(cgEvent.getIntegerValueField(.gestureHIDType), Int64(IOHIDEventType.scroll.rawValue))
+        XCTAssertEqual(cgEvent.getIntegerValueField(.gesturePhase), Int64(CGSGesturePhase.began.rawValue))
+        XCTAssertEqual(cgEvent.getIntegerValueField(.scrollGestureFlagBits), 1)
+        XCTAssertEqual(cgEvent.getDoubleValueField(.gestureScrollX), 4)
+        XCTAssertEqual(cgEvent.getDoubleValueField(.gestureScrollY), -2)
+    }
+
+    func testScrollGestureSeriesBoundary() throws {
+        let started = try XCTUnwrap(GestureEvent(scrollSeriesSource: nil, started: true))
+        let ended = try XCTUnwrap(GestureEvent(scrollSeriesSource: nil, started: false))
+
+        let startedEvent = try XCTUnwrap(started.cgEvents.first)
+        let gestureType = try XCTUnwrap(CGEventType(nsEventType: .gesture))
+        XCTAssertEqual(startedEvent.type, gestureType)
+        XCTAssertEqual(
+            startedEvent.getIntegerValueField(.gestureHIDType),
+            Int64(IOHIDEventType.gestureStarted.rawValue)
+        )
+        XCTAssertEqual(
+            startedEvent.getIntegerValueField(.gestureStartEndSeriesType),
+            Int64(IOHIDEventType.scroll.rawValue)
+        )
+
+        let endedEvent = try XCTUnwrap(ended.cgEvents.first)
+        XCTAssertEqual(endedEvent.type, gestureType)
+        XCTAssertEqual(
+            endedEvent.getIntegerValueField(.gestureHIDType),
+            Int64(IOHIDEventType.gestureEnded.rawValue)
+        )
+        XCTAssertEqual(
+            endedEvent.getIntegerValueField(.gestureStartEndSeriesType),
+            Int64(IOHIDEventType.scroll.rawValue)
+        )
+    }
 }


### PR DESCRIPTION
## Summary

This PR adds a clean-room experiment for smoother scrolling compatibility with apps that appear to expect trackpad-style gesture boundary events.

Changes:
- Add GestureKit helpers for synthetic scroll gesture and scroll gesture-series CGEvents.
- Emit type 29 gesture companion events around phaseful smooth-scroll wheel events.
- Keep momentum-only scrolling and `bouncing = false` behavior unchanged.
- Cancel any open synthetic gesture series when smooth scrolling is deactivated.
- Add unit coverage for the new GestureKit fields and smooth-scroll event sequence.

## Motivation

Closes #1217.

Some macOS apps, notably Calendar, do not behave correctly when LinearMouse emits only synthetic `.scrollWheel` events with scroll phases while scroll bounce is enabled. Disabling bounce avoids the issue, which suggests these apps may rely on additional trackpad-style gesture transaction events to manage elastic scrolling state.

This PR tries to reproduce the higher-level CoreGraphics/AppKit event sequence used by trackpad scrolling: a gesture may-begin event, a gesture-series start, per-scroll gesture companions, and a gesture-series end.

## Implementation Notes

The implementation is based on publicly inspectable WebKit test infrastructure and existing CoreGraphics/AppKit behavior, not on Mac Mouse Fix code.

For phaseful smooth scrolling, the transformer now emits:

```text
MayBegin gesture
GestureStarted series
Began/Changed scroll gesture
ScrollWheel
Ended/Cancelled scroll gesture
GestureEnded series
ScrollWheel ended
```

The synthetic gesture companions are only emitted when a normal scroll phase is present. When bounce is disabled, the transformer continues to emit only the existing scroll-wheel events.

## Test Plan

- `swift test` in `Modules/GestureKit`
- `xcodebuild test -project LinearMouse.xcodeproj -scheme LinearMouse CODE_SIGN_IDENTITY=-`
- `swiftformat --lint`
- `git diff --check`

## Caveats

This simulates the CoreGraphics/AppKit gesture event stream, not raw hardware touch events. Calendar and other AppKit apps should still be manually validated with scroll bounce enabled.