### PR TITLE
Cancel smoothed scroll momentum on direction reversal

### DIFF
--- a/LinearMouse/EventTransformer/SmoothedScrollingEngine.swift
+++ b/LinearMouse/EventTransformer/SmoothedScrollingEngine.swift
@@ -248,7 +248,14 @@ final class SmoothedScrollingEngine {
         }
     }
 
-    func feed(deltaX: Double, deltaY: Double, timestamp: TimeInterval) {
+    func feed(deltaX rawDeltaX: Double, deltaY rawDeltaY: Double, timestamp: TimeInterval) {
+        var deltaX = rawDeltaX
+        var deltaY = rawDeltaY
+
+        if sessionState == .momentum {
+            cancelOpposingMomentum(deltaX: &deltaX, deltaY: &deltaY)
+        }
+
         pendingInputX += deltaX
         pendingInputY += deltaY
         lastInputTimestamp = timestamp
@@ -267,6 +274,24 @@ final class SmoothedScrollingEngine {
         if lastTickTimestamp == nil {
             lastTickTimestamp = timestamp
         }
+    }
+
+    private func cancelOpposingMomentum(deltaX: inout Double, deltaY: inout Double) {
+        if opposesMomentum(input: deltaX, velocity: velocityX) {
+            desiredVelocityX = 0
+            velocityX = 0
+            deltaX = 0
+        }
+
+        if opposesMomentum(input: deltaY, velocity: velocityY) {
+            desiredVelocityY = 0
+            velocityY = 0
+            deltaY = 0
+        }
+    }
+
+    private func opposesMomentum(input: Double, velocity: Double) -> Bool {
+        input != 0 && velocity != 0 && input.sign != velocity.sign
     }
 
     func advance(to timestamp: TimeInterval) -> Emission? {

--- a/LinearMouseUnitTests/EventTransformer/SmoothedScrollingEngineTests.swift
+++ b/LinearMouseUnitTests/EventTransformer/SmoothedScrollingEngineTests.swift
@@ -121,6 +121,43 @@ final class SmoothedScrollingEngineTests: XCTestCase {
         XCTAssertLessThan(abs(reengagedEmission.deltaY), abs(baseline.deltaY) * 2.6)
     }
 
+    func testMomentumReengagementInOppositeDirectionFirstCancelsCarryThenScrolls() throws {
+        let engine = SmoothedScrollingEngine(smoothed: .init(
+            vertical: Scheme.Scrolling.Smoothed.Preset.easeInOut.defaultConfiguration
+        ))
+
+        var latestMomentumEmission: SmoothedScrollingEngine.Emission?
+
+        for step in 0 ..< 6 {
+            let timestamp = Double(step) / 120
+            engine.feed(deltaX: 0, deltaY: 40, timestamp: timestamp)
+            _ = engine.advance(to: timestamp + 1.0 / 120)
+        }
+
+        for step in 6 ..< 24 {
+            let timestamp = Double(step + 1) / 120
+            if let emission = engine.advance(to: timestamp), emission.phase == .momentumChanged {
+                latestMomentumEmission = emission
+            }
+        }
+
+        let baseline = try XCTUnwrap(latestMomentumEmission)
+        XCTAssertGreaterThan(baseline.deltaY, 0)
+
+        let reengagementTimestamp = 25.0 / 120.0
+        engine.feed(deltaX: 0, deltaY: -36, timestamp: reengagementTimestamp)
+        let cancellationEmission = try XCTUnwrap(engine.advance(to: reengagementTimestamp + 1.0 / 120.0))
+
+        XCTAssertEqual(cancellationEmission.phase, .momentumEnded)
+        XCTAssertEqual(cancellationEmission.deltaY, 0, accuracy: 0.001)
+
+        engine.feed(deltaX: 0, deltaY: -36, timestamp: reengagementTimestamp + 2.0 / 120.0)
+        let reengagedEmission = try XCTUnwrap(engine.advance(to: reengagementTimestamp + 3.0 / 120.0))
+
+        XCTAssertEqual(reengagedEmission.phase, .touchBegan)
+        XCTAssertLessThan(reengagedEmission.deltaY, 0)
+    }
+
     func testMomentumTailReengagementRecoversTowardFreshPickup() throws {
         let configuration = Scheme.Scrolling.Smoothed.Preset.easeInOut.defaultConfiguration
         let engine = SmoothedScrollingEngine(smoothed: .init(vertical: configuration))


### PR DESCRIPTION
## Summary

This PR adjusts smoothed scrolling re-engagement when the user reverses scroll direction during momentum.

Changes:
- Treat the first opposite-direction wheel tick during momentum as a brake.
- Clear the active momentum velocity on the affected axis and consume that first opposite-direction input.
- Start scrolling in the new direction on the next wheel tick.
- Preserve the existing smooth re-engagement behavior for additional input in the same direction.
- Add regression coverage for the direction reversal behavior.

## Motivation

Closes #1181.

When smoothed scrolling was still decaying in one direction, the first wheel tick in the opposite direction could still produce output in the old direction. This made direction changes feel buffered or delayed, especially near the end of a page where the remaining momentum was not visually obvious.

## Test Plan

- `xcodebuild test -project LinearMouse.xcodeproj -scheme LinearMouse -only-testing:LinearMouseUnitTests/SmoothedScrollingEngineTests CODE_SIGN_IDENTITY=-`
- `xcodebuild test -project LinearMouse.xcodeproj -scheme LinearMouse -only-testing:LinearMouseUnitTests/SmoothedScrollingTransformerTests CODE_SIGN_IDENTITY=-`
- `xcodebuild test -project LinearMouse.xcodeproj -scheme LinearMouse CODE_SIGN_IDENTITY=-`
- `swiftformat --lint LinearMouse/EventTransformer/SmoothedScrollingEngine.swift LinearMouseUnitTests/EventTransformer/SmoothedScrollingEngineTests.swift`
- `git diff --check`