### PR TITLE
Fix scroll button mappings with smooth scrolling enabled

### DIFF
--- a/LinearMouse/Device/Device.swift
+++ b/LinearMouse/Device/Device.swift
@@ -185,7 +185,7 @@ class Device {
             .store(in: &logitechControlsMonitorSubscriptions)
 
         SettingsState.shared
-            .$recording
+            .$buttonMappingRecordingSession
             .dropFirst()
             .receive(on: DispatchQueue.main)
             .sink { [weak self] _ in

--- a/LinearMouse/Device/VendorSpecific/Logitech/LogitechHIDPPDeviceMetadataProvider.swift
+++ b/LinearMouse/Device/VendorSpecific/Logitech/LogitechHIDPPDeviceMetadataProvider.swift
@@ -1813,7 +1813,7 @@ final class LogitechReprogrammableControlsMonitor {
             guard let monitorTarget = resolveMonitorTarget() else {
                 finishVirtualButtonRecordingPreparationIfNeeded(
                     sessionID: readMainThreadSnapshotFromWorker {
-                        SettingsState.shared.virtualButtonRecordingSessionID
+                        SettingsState.shared.buttonMappingRecordingSessionID
                     }
                 )
                 os_log(
@@ -2054,7 +2054,8 @@ final class LogitechReprogrammableControlsMonitor {
                         )
 
                         if newControlSnapshot.desiredControlIDs != desiredControlIDs
-                            || newControlSnapshot.isRecording != isRecording {
+                            || newControlSnapshot.isRecording != isRecording
+                            || newControlSnapshot.recordingSessionID != recordingSessionID {
                             os_log(
                                 "Restart Logitech control monitor to refresh diverted controls: locationID=%{public}d slot=%{public}u device=%{public}@",
                                 log: Self.log,
@@ -2117,9 +2118,10 @@ final class LogitechReprogrammableControlsMonitor {
                                         return
                                     }
 
-                                    SettingsState.shared.recordedVirtualButtonEvent = .init(
+                                    SettingsState.shared.recordedButtonMappingEvent = .init(
                                         recordingSessionID: recordingSessionID,
                                         button: .logitechControl(controlIdentity),
+                                        scroll: nil,
                                         modifierFlags: modifierFlags
                                     )
                                 }
@@ -2176,7 +2178,7 @@ final class LogitechReprogrammableControlsMonitor {
     ) -> (desiredControlIDs: Set<UInt16>, isRecording: Bool, recordingSessionID: UUID?) {
         readMainThreadSnapshotFromWorker {
             let isRecording = SettingsState.shared.recording
-            let recordingSessionID = isRecording ? SettingsState.shared.virtualButtonRecordingSessionID : nil
+            let recordingSessionID = SettingsState.shared.buttonMappingRecordingSessionID
             let mouseLocation = CGEvent(source: nil)?.location ?? .zero
             let pid = mouseLocation.topmostWindowOwnerPid
                 ?? NSWorkspace.shared.frontmostApplication?.processIdentifier
@@ -2501,7 +2503,7 @@ final class LogitechReprogrammableControlsMonitor {
             .store(in: &subscriptions)
 
         SettingsState.shared
-            .$recording
+            .$buttonMappingRecordingSession
             .dropFirst()
             .sink { [weak self] _ in
                 self?.requestReconfiguration()

--- a/LinearMouse/Device/VendorSpecific/Logitech/LogitechHIDPPDeviceMetadataProvider.swift
+++ b/LinearMouse/Device/VendorSpecific/Logitech/LogitechHIDPPDeviceMetadataProvider.swift
@@ -2110,9 +2110,15 @@ final class LogitechReprogrammableControlsMonitor {
                         )
 
                         if isRecording {
-                            if isPressed {
+                            if isPressed, let recordingSessionID {
                                 DispatchQueue.main.async {
+                                    guard SettingsState.shared
+                                        .isCurrentButtonMappingRecordingSession(recordingSessionID) else {
+                                        return
+                                    }
+
                                     SettingsState.shared.recordedVirtualButtonEvent = .init(
+                                        recordingSessionID: recordingSessionID,
                                         button: .logitechControl(controlIdentity),
                                         modifierFlags: modifierFlags
                                     )

--- a/LinearMouse/EventTransformer/ButtonActionsTransformer.swift
+++ b/LinearMouse/EventTransformer/ButtonActionsTransformer.swift
@@ -11,18 +11,30 @@ import os.log
 class ButtonActionsTransformer {
     static let log = OSLog(subsystem: Bundle.main.bundleIdentifier!, category: "ButtonActions")
 
+    final class RuntimeState {
+        var repeatTimer: EventThreadTimer?
+        var logitechRepeatTimer: EventThreadTimer?
+        var heldKeysByButton = [Scheme.Buttons.Mapping.Button: [Key]]()
+    }
+
     let mappings: [Scheme.Buttons.Mapping]
     let universalBackForward: Scheme.Buttons.UniversalBackForward?
     let ignoresLinearMouseSyntheticScrollEvents: Bool
+    let runtimeState: RuntimeState
 
     private enum TimerSlot {
         case standard
         case logitech
     }
 
-    var repeatTimer: EventThreadTimer?
-    private var logitechRepeatTimer: EventThreadTimer?
-    private var heldKeysByButton = [Scheme.Buttons.Mapping.Button: [Key]]()
+    var repeatTimer: EventThreadTimer? {
+        get {
+            runtimeState.repeatTimer
+        }
+        set {
+            runtimeState.repeatTimer = newValue
+        }
+    }
 
     private static let defaultKeySimulator = KeySimulator()
     let keySimulator: KeySimulating
@@ -31,29 +43,31 @@ class ButtonActionsTransformer {
         mappings: [Scheme.Buttons.Mapping],
         universalBackForward: Scheme.Buttons.UniversalBackForward? = nil,
         ignoresLinearMouseSyntheticScrollEvents: Bool = false,
+        runtimeState: RuntimeState = .init(),
         keySimulator: KeySimulating? = nil
     ) {
         self.mappings = mappings
         self.universalBackForward = universalBackForward
         self.ignoresLinearMouseSyntheticScrollEvents = ignoresLinearMouseSyntheticScrollEvents
+        self.runtimeState = runtimeState
         self.keySimulator = keySimulator ?? Self.defaultKeySimulator
     }
 
     private func timer(for slot: TimerSlot) -> EventThreadTimer? {
         switch slot {
         case .standard:
-            repeatTimer
+            runtimeState.repeatTimer
         case .logitech:
-            logitechRepeatTimer
+            runtimeState.logitechRepeatTimer
         }
     }
 
     private func setTimer(_ slot: TimerSlot, _ timer: EventThreadTimer?) {
         switch slot {
         case .standard:
-            repeatTimer = timer
+            runtimeState.repeatTimer = timer
         case .logitech:
-            logitechRepeatTimer = timer
+            runtimeState.logitechRepeatTimer = timer
         }
     }
 }
@@ -110,8 +124,8 @@ extension ButtonActionsTransformer: EventTransformer, LogitechControlEventHandli
 
         // FIXME: Temporary fix for "repeat on hold"
         if !mouseDraggedEventTypes.contains(event.type) {
-            repeatTimer?.invalidate()
-            repeatTimer = nil
+            runtimeState.repeatTimer?.invalidate()
+            runtimeState.repeatTimer = nil
         }
 
         if ignoresLinearMouseSyntheticScrollEvents,
@@ -223,8 +237,8 @@ extension ButtonActionsTransformer: EventTransformer, LogitechControlEventHandli
             return .handled
         }
 
-        logitechRepeatTimer?.invalidate()
-        logitechRepeatTimer = nil
+        runtimeState.logitechRepeatTimer?.invalidate()
+        runtimeState.logitechRepeatTimer = nil
 
         let keyRepeatDelay = mapping.repeat == true ? KeyboardSettingsSnapshot.shared.keyRepeatDelay : 0
         let keyRepeatInterval = mapping.repeat == true ? KeyboardSettingsSnapshot.shared.keyRepeatInterval : 0
@@ -683,18 +697,18 @@ extension ButtonActionsTransformer: EventTransformer, LogitechControlEventHandli
         // to a different mapping (e.g. modifier flags changed mid-hold and matched another rule)
         // would overwrite `heldKeysByButton[button]` without releasing the originally pressed
         // keys, leaving them stuck until something else clears them.
-        if heldKeysByButton[button] != nil {
+        if runtimeState.heldKeysByButton[button] != nil {
             return
         }
 
-        heldKeysByButton[button] = keys
+        runtimeState.heldKeysByButton[button] = keys
 
         os_log("Down keys: %{public}@", log: Self.log, type: .info, String(describing: keys))
         try? keySimulator.down(keys: keys, tap: .cgSessionEventTap)
     }
 
     private func releaseHeldKeys(for button: Scheme.Buttons.Mapping.Button, fallbackKeys: [Key]) {
-        let keys = heldKeysByButton.removeValue(forKey: button) ?? fallbackKeys
+        let keys = runtimeState.heldKeysByButton.removeValue(forKey: button) ?? fallbackKeys
 
         os_log("Up keys: %{public}@", log: Self.log, type: .info, String(describing: keys))
         try? keySimulator.up(keys: keys.reversed(), tap: .cgSessionEventTap)
@@ -703,7 +717,7 @@ extension ButtonActionsTransformer: EventTransformer, LogitechControlEventHandli
         // overlapping hold on another button would have its modifier state forgotten, which then
         // leaks into the next synthetic event we emit (event.flags would be missing the still-held
         // modifier and the OS would interpret it as released).
-        if heldKeysByButton.isEmpty {
+        if runtimeState.heldKeysByButton.isEmpty {
             keySimulator.reset()
         }
     }
@@ -742,19 +756,19 @@ extension ButtonActionsTransformer: EventTransformer, LogitechControlEventHandli
 
 extension ButtonActionsTransformer: Deactivatable {
     func deactivate() {
-        if let repeatTimer {
+        if let repeatTimer = runtimeState.repeatTimer {
             os_log("ButtonActionsTransformer is inactive, invalidate the repeat timer", log: Self.log, type: .info)
             repeatTimer.invalidate()
-            self.repeatTimer = nil
+            runtimeState.repeatTimer = nil
         }
 
-        if let logitechRepeatTimer {
+        if let logitechRepeatTimer = runtimeState.logitechRepeatTimer {
             logitechRepeatTimer.invalidate()
-            self.logitechRepeatTimer = nil
+            runtimeState.logitechRepeatTimer = nil
         }
 
-        let heldKeys = heldKeysByButton.values
-        heldKeysByButton.removeAll()
+        let heldKeys = runtimeState.heldKeysByButton.values
+        runtimeState.heldKeysByButton.removeAll()
         for keys in heldKeys {
             try? keySimulator.up(keys: keys.reversed(), tap: .cgSessionEventTap)
         }

--- a/LinearMouse/EventTransformer/ButtonActionsTransformer.swift
+++ b/LinearMouse/EventTransformer/ButtonActionsTransformer.swift
@@ -13,6 +13,7 @@ class ButtonActionsTransformer {
 
     let mappings: [Scheme.Buttons.Mapping]
     let universalBackForward: Scheme.Buttons.UniversalBackForward?
+    let ignoresLinearMouseSyntheticScrollEvents: Bool
 
     private enum TimerSlot {
         case standard
@@ -29,10 +30,12 @@ class ButtonActionsTransformer {
     init(
         mappings: [Scheme.Buttons.Mapping],
         universalBackForward: Scheme.Buttons.UniversalBackForward? = nil,
+        ignoresLinearMouseSyntheticScrollEvents: Bool = false,
         keySimulator: KeySimulating? = nil
     ) {
         self.mappings = mappings
         self.universalBackForward = universalBackForward
+        self.ignoresLinearMouseSyntheticScrollEvents = ignoresLinearMouseSyntheticScrollEvents
         self.keySimulator = keySimulator ?? Self.defaultKeySimulator
     }
 
@@ -109,6 +112,12 @@ extension ButtonActionsTransformer: EventTransformer, LogitechControlEventHandli
         if !mouseDraggedEventTypes.contains(event.type) {
             repeatTimer?.invalidate()
             repeatTimer = nil
+        }
+
+        if ignoresLinearMouseSyntheticScrollEvents,
+           event.type == .scrollWheel,
+           event.isLinearMouseSyntheticEvent {
+            return event
         }
 
         guard let mapping = findMapping(of: event) else {

--- a/LinearMouse/EventTransformer/EventTransformerManager.swift
+++ b/LinearMouse/EventTransformer/EventTransformerManager.swift
@@ -236,6 +236,7 @@ class EventTransformerManager {
         let buttonMappings = scheme.buttons.mappings ?? []
         let scrollButtonMappings = buttonMappings.filter { $0.scroll != nil }
         let otherButtonMappings = buttonMappings.filter { $0.scroll == nil }
+        let buttonActionsRuntimeState = ButtonActionsTransformer.RuntimeState()
 
         func appendScrollButtonMappings() {
             guard !scrollButtonMappings.isEmpty else {
@@ -245,7 +246,8 @@ class EventTransformerManager {
             eventTransformer.append(ButtonActionsTransformer(
                 mappings: scrollButtonMappings,
                 universalBackForward: scheme.buttons.universalBackForward,
-                ignoresLinearMouseSyntheticScrollEvents: true
+                ignoresLinearMouseSyntheticScrollEvents: true,
+                runtimeState: buttonActionsRuntimeState
             ))
         }
 
@@ -339,7 +341,8 @@ class EventTransformerManager {
         if !otherButtonMappings.isEmpty {
             eventTransformer.append(ButtonActionsTransformer(
                 mappings: otherButtonMappings,
-                universalBackForward: scheme.buttons.universalBackForward
+                universalBackForward: scheme.buttons.universalBackForward,
+                runtimeState: buttonActionsRuntimeState
             ))
         }
 
@@ -478,6 +481,7 @@ class EventTransformerManager {
 final class ButtonMappingScrollRecordingTransformer: EventTransformer {
     func transform(_ event: CGEvent) -> CGEvent? {
         guard SettingsState.shared.recording,
+              let recordingSessionID = SettingsState.shared.buttonMappingRecordingSessionID,
               event.type == .scrollWheel,
               !event.isLinearMouseSyntheticEvent,
               let scroll = Self.scrollDirection(of: event) else {
@@ -486,11 +490,12 @@ final class ButtonMappingScrollRecordingTransformer: EventTransformer {
 
         let modifierFlags = event.flags
         DispatchQueue.main.async {
-            guard SettingsState.shared.recording else {
+            guard SettingsState.shared.isCurrentButtonMappingRecordingSession(recordingSessionID) else {
                 return
             }
 
             SettingsState.shared.recordedButtonMappingEvent = .init(
+                recordingSessionID: recordingSessionID,
                 button: nil,
                 scroll: scroll,
                 modifierFlags: modifierFlags

--- a/LinearMouse/EventTransformer/EventTransformerManager.swift
+++ b/LinearMouse/EventTransformer/EventTransformerManager.swift
@@ -233,6 +233,26 @@ class EventTransformerManager {
                 .horizontal : nil
         )
         let hasSmoothedScrolling = smoothed.vertical != nil || smoothed.horizontal != nil
+        let buttonMappings = scheme.buttons.mappings ?? []
+        let scrollButtonMappings = buttonMappings.filter { $0.scroll != nil }
+        let otherButtonMappings = buttonMappings.filter { $0.scroll == nil }
+
+        func appendScrollButtonMappings() {
+            guard !scrollButtonMappings.isEmpty else {
+                return
+            }
+
+            eventTransformer.append(ButtonActionsTransformer(
+                mappings: scrollButtonMappings,
+                universalBackForward: scheme.buttons.universalBackForward,
+                ignoresLinearMouseSyntheticScrollEvents: true
+            ))
+        }
+
+        func appendScrollRecordingAndButtonMappings() {
+            eventTransformer.append(ButtonMappingScrollRecordingTransformer())
+            appendScrollButtonMappings()
+        }
 
         if let modifiers = scheme.scrolling.$modifiers,
            hasSmoothedScrolling {
@@ -240,6 +260,7 @@ class EventTransformerManager {
         }
 
         if hasSmoothedScrolling {
+            appendScrollRecordingAndButtonMappings()
             eventTransformer.append(SmoothedScrollingTransformer(smoothed: smoothed))
         }
 
@@ -290,6 +311,10 @@ class EventTransformerManager {
             eventTransformer.append(ModifierActionsTransformer(modifiers: modifiers))
         }
 
+        if !hasSmoothedScrolling {
+            appendScrollRecordingAndButtonMappings()
+        }
+
         if scheme.buttons.switchPrimaryButtonAndSecondaryButtons == true {
             eventTransformer.append(SwitchPrimaryAndSecondaryButtonsTransformer())
         }
@@ -311,9 +336,9 @@ class EventTransformerManager {
             ))
         }
 
-        if let mappings = scheme.buttons.mappings {
+        if !otherButtonMappings.isEmpty {
             eventTransformer.append(ButtonActionsTransformer(
-                mappings: mappings,
+                mappings: otherButtonMappings,
                 universalBackForward: scheme.buttons.universalBackForward
             ))
         }
@@ -447,5 +472,48 @@ class EventTransformerManager {
         }
 
         (transformer as? Deactivatable)?.reactivate()
+    }
+}
+
+final class ButtonMappingScrollRecordingTransformer: EventTransformer {
+    func transform(_ event: CGEvent) -> CGEvent? {
+        guard SettingsState.shared.recording,
+              event.type == .scrollWheel,
+              !event.isLinearMouseSyntheticEvent,
+              let scroll = Self.scrollDirection(of: event) else {
+            return event
+        }
+
+        let modifierFlags = event.flags
+        DispatchQueue.main.async {
+            guard SettingsState.shared.recording else {
+                return
+            }
+
+            SettingsState.shared.recordedButtonMappingEvent = .init(
+                button: nil,
+                scroll: scroll,
+                modifierFlags: modifierFlags
+            )
+        }
+
+        return nil
+    }
+
+    private static func scrollDirection(of event: CGEvent) -> Scheme.Buttons.Mapping.ScrollDirection? {
+        let view = ScrollWheelEventView(event)
+        if view.deltaYSignum < 0 {
+            return .down
+        }
+        if view.deltaYSignum > 0 {
+            return .up
+        }
+        if view.deltaXSignum < 0 {
+            return .right
+        }
+        if view.deltaXSignum > 0 {
+            return .left
+        }
+        return nil
     }
 }

--- a/LinearMouse/State/SettingsState.swift
+++ b/LinearMouse/State/SettingsState.swift
@@ -8,12 +8,6 @@ import SwiftUI
 class SettingsState: ObservableObject {
     static let shared = SettingsState()
 
-    struct RecordedVirtualButtonEvent {
-        let recordingSessionID: UUID
-        let button: Scheme.Buttons.Mapping.Button
-        let modifierFlags: CGEventFlags
-    }
-
     struct RecordedButtonMappingEvent {
         let recordingSessionID: UUID
         let button: Scheme.Buttons.Mapping.Button?
@@ -21,9 +15,9 @@ class SettingsState: ObservableObject {
         let modifierFlags: CGEventFlags
     }
 
-    struct VirtualButtonRecordingPreparation: Equatable {
-        let sessionID: UUID
-        var pendingDeviceIDs: Set<Int32>
+    struct ButtonMappingRecordingSession: Equatable {
+        let id: UUID
+        var pendingVirtualButtonDeviceIDs: Set<Int32>
     }
 
     enum Navigation: String, CaseIterable, Hashable {
@@ -58,77 +52,65 @@ class SettingsState: ObservableObject {
 
     @Published var navigation: Navigation? = .pointer
 
-    /// When `recording` is true, `ButtonActionsTransformer` should be temporarily disabled.
-    @Published private(set) var recording = false
+    @Published private(set) var buttonMappingRecordingSession: ButtonMappingRecordingSession?
 
-    @Published private(set) var buttonMappingRecordingSessionID: UUID?
-
-    /// A short-lived preparation phase used while Logitech monitors temporarily divert all controls
-    /// for recording. Standard CGEvents can still be recorded immediately.
-    @Published private(set) var virtualButtonRecordingPreparation: VirtualButtonRecordingPreparation?
-
-    /// Set by protocol-backed button monitors when a virtual button is pressed during recording.
-    /// The recorder uses the event-time modifier snapshot to avoid races with later key-up events.
-    @Published var recordedVirtualButtonEvent: RecordedVirtualButtonEvent?
-
-    /// Set by the event transformer pipeline when a transformed scroll gesture is recorded.
+    /// Set by event sources when a button mapping input is recorded.
     @Published var recordedButtonMappingEvent: RecordedButtonMappingEvent?
 
+    /// `@Published` emits before storing the new value, so session guards use this reentrancy-safe storage.
+    private var currentButtonMappingRecordingSession: ButtonMappingRecordingSession?
+
+    /// When `recording` is true, `ButtonActionsTransformer` should be temporarily disabled.
+    var recording: Bool {
+        currentButtonMappingRecordingSession != nil
+    }
+
+    var buttonMappingRecordingSessionID: UUID? {
+        currentButtonMappingRecordingSession?.id
+    }
+
     var isPreparingVirtualButtonRecording: Bool {
-        virtualButtonRecordingPreparation != nil
+        currentButtonMappingRecordingSession?.pendingVirtualButtonDeviceIDs.isEmpty == false
     }
 
-    var virtualButtonRecordingSessionID: UUID? {
-        virtualButtonRecordingPreparation?.sessionID
-    }
-
-    func beginButtonMappingRecording(sessionID: UUID) {
-        buttonMappingRecordingSessionID = sessionID
-        recording = true
+    func beginButtonMappingRecording(
+        sessionID: UUID,
+        pendingVirtualButtonDeviceIDs: Set<Int32> = []
+    ) {
+        let session = ButtonMappingRecordingSession(
+            id: sessionID,
+            pendingVirtualButtonDeviceIDs: pendingVirtualButtonDeviceIDs
+        )
+        currentButtonMappingRecordingSession = session
+        buttonMappingRecordingSession = session
+        recordedButtonMappingEvent = nil
     }
 
     func endButtonMappingRecording(sessionID: UUID? = nil) {
-        guard sessionID == nil || buttonMappingRecordingSessionID == sessionID else {
+        guard sessionID == nil || currentButtonMappingRecordingSession?.id == sessionID else {
             return
         }
 
-        buttonMappingRecordingSessionID = nil
-        recording = false
+        currentButtonMappingRecordingSession = nil
+        buttonMappingRecordingSession = nil
         recordedButtonMappingEvent = nil
-        recordedVirtualButtonEvent = nil
     }
 
     func isCurrentButtonMappingRecordingSession(_ sessionID: UUID) -> Bool {
-        recording && buttonMappingRecordingSessionID == sessionID
-    }
-
-    func beginVirtualButtonRecordingPreparation(for deviceIDs: Set<Int32>, sessionID: UUID = UUID()) {
-        guard !deviceIDs.isEmpty else {
-            virtualButtonRecordingPreparation = nil
-            return
-        }
-
-        virtualButtonRecordingPreparation = .init(
-            sessionID: sessionID,
-            pendingDeviceIDs: deviceIDs
-        )
+        currentButtonMappingRecordingSession?.id == sessionID
     }
 
     func finishVirtualButtonRecordingPreparation(for deviceID: Int32, sessionID: UUID) {
-        guard var preparation = virtualButtonRecordingPreparation,
-              preparation.sessionID == sessionID else {
+        guard var session = currentButtonMappingRecordingSession,
+              session.id == sessionID else {
             return
         }
 
-        preparation.pendingDeviceIDs.remove(deviceID)
-        virtualButtonRecordingPreparation = preparation.pendingDeviceIDs.isEmpty ? nil : preparation
-    }
-
-    func endVirtualButtonRecordingPreparation(sessionID: UUID? = nil) {
-        guard sessionID == nil || virtualButtonRecordingPreparation?.sessionID == sessionID else {
+        guard session.pendingVirtualButtonDeviceIDs.remove(deviceID) != nil else {
             return
         }
 
-        virtualButtonRecordingPreparation = nil
+        currentButtonMappingRecordingSession = session
+        buttonMappingRecordingSession = session
     }
 }

--- a/LinearMouse/State/SettingsState.swift
+++ b/LinearMouse/State/SettingsState.swift
@@ -9,11 +9,13 @@ class SettingsState: ObservableObject {
     static let shared = SettingsState()
 
     struct RecordedVirtualButtonEvent {
+        let recordingSessionID: UUID
         let button: Scheme.Buttons.Mapping.Button
         let modifierFlags: CGEventFlags
     }
 
     struct RecordedButtonMappingEvent {
+        let recordingSessionID: UUID
         let button: Scheme.Buttons.Mapping.Button?
         let scroll: Scheme.Buttons.Mapping.ScrollDirection?
         let modifierFlags: CGEventFlags
@@ -57,7 +59,9 @@ class SettingsState: ObservableObject {
     @Published var navigation: Navigation? = .pointer
 
     /// When `recording` is true, `ButtonActionsTransformer` should be temporarily disabled.
-    @Published var recording = false
+    @Published private(set) var recording = false
+
+    @Published private(set) var buttonMappingRecordingSessionID: UUID?
 
     /// A short-lived preparation phase used while Logitech monitors temporarily divert all controls
     /// for recording. Standard CGEvents can still be recorded immediately.
@@ -78,14 +82,34 @@ class SettingsState: ObservableObject {
         virtualButtonRecordingPreparation?.sessionID
     }
 
-    func beginVirtualButtonRecordingPreparation(for deviceIDs: Set<Int32>) {
+    func beginButtonMappingRecording(sessionID: UUID) {
+        buttonMappingRecordingSessionID = sessionID
+        recording = true
+    }
+
+    func endButtonMappingRecording(sessionID: UUID? = nil) {
+        guard sessionID == nil || buttonMappingRecordingSessionID == sessionID else {
+            return
+        }
+
+        buttonMappingRecordingSessionID = nil
+        recording = false
+        recordedButtonMappingEvent = nil
+        recordedVirtualButtonEvent = nil
+    }
+
+    func isCurrentButtonMappingRecordingSession(_ sessionID: UUID) -> Bool {
+        recording && buttonMappingRecordingSessionID == sessionID
+    }
+
+    func beginVirtualButtonRecordingPreparation(for deviceIDs: Set<Int32>, sessionID: UUID = UUID()) {
         guard !deviceIDs.isEmpty else {
             virtualButtonRecordingPreparation = nil
             return
         }
 
         virtualButtonRecordingPreparation = .init(
-            sessionID: UUID(),
+            sessionID: sessionID,
             pendingDeviceIDs: deviceIDs
         )
     }
@@ -100,7 +124,11 @@ class SettingsState: ObservableObject {
         virtualButtonRecordingPreparation = preparation.pendingDeviceIDs.isEmpty ? nil : preparation
     }
 
-    func endVirtualButtonRecordingPreparation() {
+    func endVirtualButtonRecordingPreparation(sessionID: UUID? = nil) {
+        guard sessionID == nil || virtualButtonRecordingPreparation?.sessionID == sessionID else {
+            return
+        }
+
         virtualButtonRecordingPreparation = nil
     }
 }

--- a/LinearMouse/State/SettingsState.swift
+++ b/LinearMouse/State/SettingsState.swift
@@ -13,6 +13,12 @@ class SettingsState: ObservableObject {
         let modifierFlags: CGEventFlags
     }
 
+    struct RecordedButtonMappingEvent {
+        let button: Scheme.Buttons.Mapping.Button?
+        let scroll: Scheme.Buttons.Mapping.ScrollDirection?
+        let modifierFlags: CGEventFlags
+    }
+
     struct VirtualButtonRecordingPreparation: Equatable {
         let sessionID: UUID
         var pendingDeviceIDs: Set<Int32>
@@ -60,6 +66,9 @@ class SettingsState: ObservableObject {
     /// Set by protocol-backed button monitors when a virtual button is pressed during recording.
     /// The recorder uses the event-time modifier snapshot to avoid races with later key-up events.
     @Published var recordedVirtualButtonEvent: RecordedVirtualButtonEvent?
+
+    /// Set by the event transformer pipeline when a transformed scroll gesture is recorded.
+    @Published var recordedButtonMappingEvent: RecordedButtonMappingEvent?
 
     var isPreparingVirtualButtonRecording: Bool {
         virtualButtonRecordingPreparation != nil

--- a/LinearMouse/UI/ButtonsSettings/ButtonMappingsSection/ButtonMappingButtonRecorder.swift
+++ b/LinearMouse/UI/ButtonsSettings/ButtonMappingsSection/ButtonMappingButtonRecorder.swift
@@ -25,6 +25,7 @@ struct ButtonMappingButtonRecorder: View {
     @State private var recordingObservationToken: ObservationToken?
     @State private var recordedButtonCancellable: AnyCancellable?
     @State private var recordedMappingCancellable: AnyCancellable?
+    @State private var recordingSessionID: UUID?
 
     var body: some View {
         Button {
@@ -55,19 +56,47 @@ struct ButtonMappingButtonRecorder: View {
             recording = false
             updateSharedRecordingState(force: false)
         }
+        .onReceive(settingsState.$buttonMappingRecordingSessionID) { sessionID in
+            guard recording,
+                  let recordingSessionID,
+                  sessionID != recordingSessionID else {
+                return
+            }
+
+            recording = false
+        }
     }
 
     private func updateSharedRecordingState(force: Bool? = nil) {
         let shouldRecord = force ?? recording
         if shouldRecord {
+            let sessionID = currentRecordingSessionID()
             let monitorDevices = logitechMonitorDevices()
-            settingsState.beginVirtualButtonRecordingPreparation(for: Set(monitorDevices.map(\.id)))
-            settingsState.recording = shouldRecord
+            settingsState.beginVirtualButtonRecordingPreparation(
+                for: Set(monitorDevices.map(\.id)),
+                sessionID: sessionID
+            )
+            settingsState.beginButtonMappingRecording(sessionID: sessionID)
             monitorDevices.forEach { $0.prepareLogitechControlsRecording() }
         } else {
-            settingsState.endVirtualButtonRecordingPreparation()
-            settingsState.recording = shouldRecord
+            guard let recordingSessionID else {
+                return
+            }
+
+            settingsState.endVirtualButtonRecordingPreparation(sessionID: recordingSessionID)
+            settingsState.endButtonMappingRecording(sessionID: recordingSessionID)
+            self.recordingSessionID = nil
         }
+    }
+
+    private func currentRecordingSessionID() -> UUID {
+        if let recordingSessionID {
+            return recordingSessionID
+        }
+
+        let recordingSessionID = UUID()
+        self.recordingSessionID = recordingSessionID
+        return recordingSessionID
     }
 
     private func recordingUpdated() {
@@ -107,12 +136,18 @@ struct ButtonMappingButtonRecorder: View {
 
         settingsState.recordedVirtualButtonEvent = nil
         settingsState.recordedButtonMappingEvent = nil
+        let recordingSessionID = recordingSessionID
 
         // Observe Logitech control presses communicated via SettingsState
         // (no synthetic CGEvent needed — the HID++ protocol detects presses directly)
         recordedButtonCancellable = settingsState
             .$recordedVirtualButtonEvent
-            .compactMap(\.self)
+            .compactMap { event in
+                guard event?.recordingSessionID == recordingSessionID else {
+                    return nil
+                }
+                return event
+            }
             .receive(on: DispatchQueue.main)
             .sink { event in
                 virtualButtonReceived(event)
@@ -120,7 +155,12 @@ struct ButtonMappingButtonRecorder: View {
 
         recordedMappingCancellable = settingsState
             .$recordedButtonMappingEvent
-            .compactMap(\.self)
+            .compactMap { event in
+                guard event?.recordingSessionID == recordingSessionID else {
+                    return nil
+                }
+                return event
+            }
             .receive(on: DispatchQueue.main)
             .sink { event in
                 recordedMappingReceived(event)

--- a/LinearMouse/UI/ButtonsSettings/ButtonMappingsSection/ButtonMappingButtonRecorder.swift
+++ b/LinearMouse/UI/ButtonsSettings/ButtonMappingsSection/ButtonMappingButtonRecorder.swift
@@ -24,6 +24,7 @@ struct ButtonMappingButtonRecorder: View {
 
     @State private var recordingObservationToken: ObservationToken?
     @State private var recordedButtonCancellable: AnyCancellable?
+    @State private var recordedMappingCancellable: AnyCancellable?
 
     var body: some View {
         Button {
@@ -76,6 +77,8 @@ struct ButtonMappingButtonRecorder: View {
         }
         recordedButtonCancellable?.cancel()
         recordedButtonCancellable = nil
+        recordedMappingCancellable?.cancel()
+        recordedMappingCancellable = nil
 
         if recording {
             mapping.modifierFlags = []
@@ -90,7 +93,6 @@ struct ButtonMappingButtonRecorder: View {
     private func startEventObservation() {
         recordingObservationToken = try? EventTap.observe([
             .flagsChanged,
-            .scrollWheel,
             .leftMouseDown, .leftMouseUp,
             .rightMouseDown, .rightMouseUp,
             .otherMouseDown, .otherMouseUp
@@ -104,6 +106,7 @@ struct ButtonMappingButtonRecorder: View {
         }
 
         settingsState.recordedVirtualButtonEvent = nil
+        settingsState.recordedButtonMappingEvent = nil
 
         // Observe Logitech control presses communicated via SettingsState
         // (no synthetic CGEvent needed — the HID++ protocol detects presses directly)
@@ -114,11 +117,21 @@ struct ButtonMappingButtonRecorder: View {
             .sink { event in
                 virtualButtonReceived(event)
             }
+
+        recordedMappingCancellable = settingsState
+            .$recordedButtonMappingEvent
+            .compactMap(\.self)
+            .receive(on: DispatchQueue.main)
+            .sink { event in
+                recordedMappingReceived(event)
+            }
     }
 
     private func cancelObservation() {
         recordedButtonCancellable?.cancel()
         recordedButtonCancellable = nil
+        recordedMappingCancellable?.cancel()
+        recordedMappingCancellable = nil
     }
 
     private func logitechMonitorDevices() -> [Device] {
@@ -137,39 +150,47 @@ struct ButtonMappingButtonRecorder: View {
         recording = false
     }
 
+    private func recordedMappingReceived(_ event: SettingsState.RecordedButtonMappingEvent) {
+        mapping.button = event.button
+        mapping.scroll = event.scroll
+        mapping.modifierFlags = event.modifierFlags
+        settingsState.recordedButtonMappingEvent = nil
+        recording = false
+    }
+
     private func eventReceived(_ event: CGEvent) -> CGEvent? {
+        let result = ButtonMappingButtonRecordingEventHandler.record(event, into: &mapping)
+        if result.stopsRecording {
+            recording = false
+        }
+
+        return result.event
+    }
+}
+
+enum ButtonMappingButtonRecordingEventHandler {
+    struct Result {
+        var event: CGEvent?
+        var stopsRecording: Bool
+    }
+
+    static func record(_ event: CGEvent, into mapping: inout Scheme.Buttons.Mapping) -> Result {
         mapping.button = nil
         mapping.scroll = nil
         mapping.modifierFlags = event.flags
 
         switch event.type {
         case .flagsChanged:
-            return nil
-
+            return .init(event: nil, stopsRecording: false)
         case .leftMouseDown, .rightMouseDown, .otherMouseDown:
             mapping.button = .mouse(Int(event.getIntegerValueField(.mouseEventButtonNumber)))
-            return nil
-
+            return .init(event: nil, stopsRecording: false)
         case .leftMouseUp, .rightMouseUp, .otherMouseUp:
             mapping.button = .mouse(Int(event.getIntegerValueField(.mouseEventButtonNumber)))
-
-        case .scrollWheel:
-            let scrollWheelEventView = ScrollWheelEventView(event)
-            if scrollWheelEventView.deltaYSignum < 0 {
-                mapping.scroll = .down
-            } else if scrollWheelEventView.deltaYSignum > 0 {
-                mapping.scroll = .up
-            } else if scrollWheelEventView.deltaXSignum < 0 {
-                mapping.scroll = .right
-            } else if scrollWheelEventView.deltaXSignum > 0 {
-                mapping.scroll = .left
-            }
-
         default:
             break
         }
 
-        recording = false
-        return nil
+        return .init(event: nil, stopsRecording: true)
     }
 }

--- a/LinearMouse/UI/ButtonsSettings/ButtonMappingsSection/ButtonMappingButtonRecorder.swift
+++ b/LinearMouse/UI/ButtonsSettings/ButtonMappingsSection/ButtonMappingButtonRecorder.swift
@@ -23,7 +23,6 @@ struct ButtonMappingButtonRecorder: View {
     }
 
     @State private var recordingObservationToken: ObservationToken?
-    @State private var recordedButtonCancellable: AnyCancellable?
     @State private var recordedMappingCancellable: AnyCancellable?
     @State private var recordingSessionID: UUID?
 
@@ -56,10 +55,10 @@ struct ButtonMappingButtonRecorder: View {
             recording = false
             updateSharedRecordingState(force: false)
         }
-        .onReceive(settingsState.$buttonMappingRecordingSessionID) { sessionID in
+        .onReceive(settingsState.$buttonMappingRecordingSession) { session in
             guard recording,
                   let recordingSessionID,
-                  sessionID != recordingSessionID else {
+                  session?.id != recordingSessionID else {
                 return
             }
 
@@ -72,18 +71,16 @@ struct ButtonMappingButtonRecorder: View {
         if shouldRecord {
             let sessionID = currentRecordingSessionID()
             let monitorDevices = logitechMonitorDevices()
-            settingsState.beginVirtualButtonRecordingPreparation(
-                for: Set(monitorDevices.map(\.id)),
-                sessionID: sessionID
+            settingsState.beginButtonMappingRecording(
+                sessionID: sessionID,
+                pendingVirtualButtonDeviceIDs: Set(monitorDevices.map(\.id))
             )
-            settingsState.beginButtonMappingRecording(sessionID: sessionID)
             monitorDevices.forEach { $0.prepareLogitechControlsRecording() }
         } else {
             guard let recordingSessionID else {
                 return
             }
 
-            settingsState.endVirtualButtonRecordingPreparation(sessionID: recordingSessionID)
             settingsState.endButtonMappingRecording(sessionID: recordingSessionID)
             self.recordingSessionID = nil
         }
@@ -104,8 +101,6 @@ struct ButtonMappingButtonRecorder: View {
             recordingObservationToken.cancel()
             self.recordingObservationToken = nil
         }
-        recordedButtonCancellable?.cancel()
-        recordedButtonCancellable = nil
         recordedMappingCancellable?.cancel()
         recordedMappingCancellable = nil
 
@@ -134,24 +129,12 @@ struct ButtonMappingButtonRecorder: View {
             return
         }
 
-        settingsState.recordedVirtualButtonEvent = nil
-        settingsState.recordedButtonMappingEvent = nil
-        let recordingSessionID = recordingSessionID
+        guard let recordingSessionID else {
+            recording = false
+            return
+        }
 
-        // Observe Logitech control presses communicated via SettingsState
-        // (no synthetic CGEvent needed — the HID++ protocol detects presses directly)
-        recordedButtonCancellable = settingsState
-            .$recordedVirtualButtonEvent
-            .compactMap { event in
-                guard event?.recordingSessionID == recordingSessionID else {
-                    return nil
-                }
-                return event
-            }
-            .receive(on: DispatchQueue.main)
-            .sink { event in
-                virtualButtonReceived(event)
-            }
+        settingsState.recordedButtonMappingEvent = nil
 
         recordedMappingCancellable = settingsState
             .$recordedButtonMappingEvent
@@ -168,8 +151,6 @@ struct ButtonMappingButtonRecorder: View {
     }
 
     private func cancelObservation() {
-        recordedButtonCancellable?.cancel()
-        recordedButtonCancellable = nil
         recordedMappingCancellable?.cancel()
         recordedMappingCancellable = nil
     }
@@ -181,13 +162,6 @@ struct ButtonMappingButtonRecorder: View {
         }
 
         return [currentDevice]
-    }
-
-    private func virtualButtonReceived(_ event: SettingsState.RecordedVirtualButtonEvent) {
-        mapping.button = event.button
-        mapping.modifierFlags = event.modifierFlags
-        settingsState.recordedVirtualButtonEvent = nil
-        recording = false
     }
 
     private func recordedMappingReceived(_ event: SettingsState.RecordedButtonMappingEvent) {

--- a/LinearMouseUnitTests/EventTransformer/ButtonActionsTransformerTests.swift
+++ b/LinearMouseUnitTests/EventTransformer/ButtonActionsTransformerTests.swift
@@ -2,6 +2,7 @@
 // Copyright (c) 2021-2026 LinearMouse
 
 import CoreGraphics
+import Foundation
 import KeyKit
 @testable import LinearMouse
 import XCTest
@@ -54,6 +55,39 @@ private func logitechContext(
 }
 
 final class ButtonActionsTransformerTests: XCTestCase {
+    func testSharedRuntimeStateLetsScrollMappingsCancelButtonRepeatTimer() throws {
+        let runtimeState = ButtonActionsTransformer.RuntimeState()
+        let scrollTransformer = ButtonActionsTransformer(
+            mappings: [
+                .init(scroll: .up, action: .arg0(.none))
+            ],
+            runtimeState: runtimeState
+        )
+        let buttonTransformer = ButtonActionsTransformer(
+            mappings: [
+                .init(button: .mouse(4), repeat: true, action: .arg0(.none))
+            ],
+            runtimeState: runtimeState
+        )
+        buttonTransformer.repeatTimer = EventThreadTimer(
+            timer: Timer(timeInterval: 60, repeats: false) { _ in },
+            eventThread: .shared
+        )
+
+        let event = try XCTUnwrap(CGEvent(
+            scrollWheelEvent2Source: nil,
+            units: .line,
+            wheelCount: 2,
+            wheel1: 1,
+            wheel2: 0,
+            wheel3: 0
+        ))
+
+        XCTAssertNotNil(buttonTransformer.repeatTimer)
+        XCTAssertNil(scrollTransformer.transform(event))
+        XCTAssertNil(buttonTransformer.repeatTimer)
+    }
+
     func testLogitechControlEventMatchesGenericCommandMappingWithRightCommandFlag() {
         let transformer = ButtonActionsTransformer(mappings: [
             .init(

--- a/LinearMouseUnitTests/EventTransformer/EventTransformerManagerTests.swift
+++ b/LinearMouseUnitTests/EventTransformer/EventTransformerManagerTests.swift
@@ -8,7 +8,8 @@ final class EventTransformerManagerTests: XCTestCase {
     override func tearDown() {
         super.tearDown()
         ConfigurationState.shared.configuration = .init()
-        SettingsState.shared.recording = false
+        SettingsState.shared.endButtonMappingRecording()
+        SettingsState.shared.endVirtualButtonRecordingPreparation()
         SettingsState.shared.recordedButtonMappingEvent = nil
         SettingsState.shared.recordedVirtualButtonEvent = nil
     }
@@ -208,6 +209,7 @@ final class EventTransformerManagerTests: XCTestCase {
         XCTAssertEqual(lateButtonActionsTransformer.mappings, [buttonMapping])
         XCTAssertEqual(lateButtonActionsTransformer.universalBackForward, .both)
         XCTAssertFalse(lateButtonActionsTransformer.ignoresLinearMouseSyntheticScrollEvents)
+        XCTAssertIdentical(earlyButtonActionsTransformer.runtimeState, lateButtonActionsTransformer.runtimeState)
     }
 
     func testScrollButtonMappingsUseScrollPipelineWithoutSmoothing() throws {
@@ -242,6 +244,7 @@ final class EventTransformerManagerTests: XCTestCase {
         XCTAssertEqual(buttonActionsTransformers.map(\.mappings), [[scrollMapping], [buttonMapping]])
         XCTAssertEqual(buttonActionsTransformers.map(\.universalBackForward), [.both, .both])
         XCTAssertEqual(buttonActionsTransformers.map(\.ignoresLinearMouseSyntheticScrollEvents), [true, false])
+        XCTAssertIdentical(buttonActionsTransformers[0].runtimeState, buttonActionsTransformers[1].runtimeState)
     }
 
     func testSmoothedScrollingDoesNotApplyScrollButtonMappingsToSyntheticEvents() throws {
@@ -288,7 +291,8 @@ final class EventTransformerManagerTests: XCTestCase {
                 )
             )
         ])
-        SettingsState.shared.recording = true
+        let recordingSessionID = UUID()
+        SettingsState.shared.beginButtonMappingRecording(sessionID: recordingSessionID)
 
         let event = try XCTUnwrap(CGEvent(
             scrollWheelEvent2Source: nil,
@@ -313,11 +317,56 @@ final class EventTransformerManagerTests: XCTestCase {
         let recordedExpectation = expectation(description: "Recorded transformed scroll mapping")
         DispatchQueue.main.async {
             let recordedEvent = SettingsState.shared.recordedButtonMappingEvent
+            XCTAssertEqual(recordedEvent?.recordingSessionID, recordingSessionID)
             XCTAssertNil(recordedEvent?.button)
             XCTAssertEqual(recordedEvent?.scroll, .down)
             XCTAssertEqual(recordedEvent?.modifierFlags, [.maskControl])
             recordedExpectation.fulfill()
         }
         wait(for: [recordedExpectation], timeout: 1)
+    }
+
+    func testEndingStaleButtonMappingRecordingSessionDoesNotStopCurrentSession() {
+        let staleSessionID = UUID()
+        let currentSessionID = UUID()
+
+        SettingsState.shared.beginButtonMappingRecording(sessionID: staleSessionID)
+        SettingsState.shared.beginButtonMappingRecording(sessionID: currentSessionID)
+        SettingsState.shared.endButtonMappingRecording(sessionID: staleSessionID)
+
+        XCTAssertTrue(SettingsState.shared.recording)
+        XCTAssertEqual(SettingsState.shared.buttonMappingRecordingSessionID, currentSessionID)
+
+        SettingsState.shared.endButtonMappingRecording(sessionID: currentSessionID)
+
+        XCTAssertFalse(SettingsState.shared.recording)
+        XCTAssertNil(SettingsState.shared.buttonMappingRecordingSessionID)
+    }
+
+    func testScrollButtonRecordingIgnoresStaleAsyncEventAfterSessionChanges() throws {
+        let staleSessionID = UUID()
+        let currentSessionID = UUID()
+        let transformer = ButtonMappingScrollRecordingTransformer()
+        let event = try XCTUnwrap(CGEvent(
+            scrollWheelEvent2Source: nil,
+            units: .line,
+            wheelCount: 2,
+            wheel1: 1,
+            wheel2: 0,
+            wheel3: 0
+        ))
+
+        SettingsState.shared.beginButtonMappingRecording(sessionID: staleSessionID)
+        XCTAssertNil(transformer.transform(event))
+        SettingsState.shared.endButtonMappingRecording(sessionID: staleSessionID)
+        SettingsState.shared.beginButtonMappingRecording(sessionID: currentSessionID)
+
+        let staleEventExpectation = expectation(description: "Stale scroll recording is ignored")
+        DispatchQueue.main.async {
+            XCTAssertNil(SettingsState.shared.recordedButtonMappingEvent)
+            XCTAssertEqual(SettingsState.shared.buttonMappingRecordingSessionID, currentSessionID)
+            staleEventExpectation.fulfill()
+        }
+        wait(for: [staleEventExpectation], timeout: 1)
     }
 }

--- a/LinearMouseUnitTests/EventTransformer/EventTransformerManagerTests.swift
+++ b/LinearMouseUnitTests/EventTransformer/EventTransformerManagerTests.swift
@@ -8,6 +8,9 @@ final class EventTransformerManagerTests: XCTestCase {
     override func tearDown() {
         super.tearDown()
         ConfigurationState.shared.configuration = .init()
+        SettingsState.shared.recording = false
+        SettingsState.shared.recordedButtonMappingEvent = nil
+        SettingsState.shared.recordedVirtualButtonEvent = nil
     }
 
     func testSyntheticSmoothedEventStillGetsModifierActions() throws {
@@ -84,7 +87,7 @@ final class EventTransformerManagerTests: XCTestCase {
         let view = ScrollWheelEventView(transformedEvent)
 
         XCTAssertEqual(view.deltaY, 3)
-        XCTAssertEqual(view.scrollPhase, nil)
+        XCTAssertNil(view.scrollPhase)
         XCTAssertEqual(view.momentumPhase, .none)
     }
 
@@ -157,5 +160,164 @@ final class EventTransformerManagerTests: XCTestCase {
             .first)
 
         XCTAssertEqual(buttonActionsTransformer.universalBackForward, .both)
+    }
+
+    func testSmoothedScrollingRoutesScrollButtonMappingsBeforeSmoothing() throws {
+        let scrollMapping = Scheme.Buttons.Mapping(scroll: .up, control: true, action: .arg0(.none))
+        let buttonMapping = Scheme.Buttons.Mapping(button: .mouse(4), action: .arg0(.none))
+        ConfigurationState.shared.configuration = .init(schemes: [
+            Scheme(
+                scrolling: .init(smoothed: .init(vertical: .init(enabled: true, preset: .smooth))),
+                buttons: .init(mappings: [scrollMapping, buttonMapping], universalBackForward: .both)
+            )
+        ])
+
+        let event = try XCTUnwrap(CGEvent(
+            scrollWheelEvent2Source: nil,
+            units: .line,
+            wheelCount: 2,
+            wheel1: 1,
+            wheel2: 0,
+            wheel3: 0
+        ))
+        event.flags = [.maskControl]
+
+        let transformer = EventTransformerManager.shared.get(
+            withCGEvent: event,
+            withSourcePid: nil,
+            withTargetPid: nil,
+            withMouseLocationPid: nil,
+            withDisplay: nil
+        )
+        let transformers = try XCTUnwrap(transformer as? [EventTransformer])
+        let smoothedIndex = try XCTUnwrap(transformers.firstIndex { $0 is SmoothedScrollingTransformer })
+        let buttonActionsTransformers = transformers.enumerated().compactMap { index, transformer in
+            (transformer as? ButtonActionsTransformer).map { (index, $0) }
+        }
+
+        let earlyButtonActionsTransformer = try XCTUnwrap(buttonActionsTransformers
+            .first { index, _ in index < smoothedIndex }?
+            .1)
+        let lateButtonActionsTransformer = try XCTUnwrap(buttonActionsTransformers
+            .first { index, _ in index > smoothedIndex }?
+            .1)
+
+        XCTAssertEqual(earlyButtonActionsTransformer.mappings, [scrollMapping])
+        XCTAssertEqual(earlyButtonActionsTransformer.universalBackForward, .both)
+        XCTAssertTrue(earlyButtonActionsTransformer.ignoresLinearMouseSyntheticScrollEvents)
+        XCTAssertEqual(lateButtonActionsTransformer.mappings, [buttonMapping])
+        XCTAssertEqual(lateButtonActionsTransformer.universalBackForward, .both)
+        XCTAssertFalse(lateButtonActionsTransformer.ignoresLinearMouseSyntheticScrollEvents)
+    }
+
+    func testScrollButtonMappingsUseScrollPipelineWithoutSmoothing() throws {
+        let scrollMapping = Scheme.Buttons.Mapping(scroll: .up, control: true, action: .arg0(.none))
+        let buttonMapping = Scheme.Buttons.Mapping(button: .mouse(4), action: .arg0(.none))
+        ConfigurationState.shared.configuration = .init(schemes: [
+            Scheme(
+                buttons: .init(mappings: [scrollMapping, buttonMapping], universalBackForward: .both)
+            )
+        ])
+
+        let event = try XCTUnwrap(CGEvent(
+            scrollWheelEvent2Source: nil,
+            units: .line,
+            wheelCount: 2,
+            wheel1: 1,
+            wheel2: 0,
+            wheel3: 0
+        ))
+        event.flags = [.maskControl]
+
+        let transformer = EventTransformerManager.shared.get(
+            withCGEvent: event,
+            withSourcePid: nil,
+            withTargetPid: nil,
+            withMouseLocationPid: nil,
+            withDisplay: nil
+        )
+        let buttonActionsTransformers = try XCTUnwrap(transformer as? [EventTransformer])
+            .compactMap { $0 as? ButtonActionsTransformer }
+
+        XCTAssertEqual(buttonActionsTransformers.map(\.mappings), [[scrollMapping], [buttonMapping]])
+        XCTAssertEqual(buttonActionsTransformers.map(\.universalBackForward), [.both, .both])
+        XCTAssertEqual(buttonActionsTransformers.map(\.ignoresLinearMouseSyntheticScrollEvents), [true, false])
+    }
+
+    func testSmoothedScrollingDoesNotApplyScrollButtonMappingsToSyntheticEvents() throws {
+        ConfigurationState.shared.configuration = .init(schemes: [
+            Scheme(
+                scrolling: .init(smoothed: .init(vertical: .init(enabled: true, preset: .smooth))),
+                buttons: .init(mappings: [
+                    .init(scroll: .up, control: true, action: .arg0(.none))
+                ])
+            )
+        ])
+
+        let event = try XCTUnwrap(CGEvent(
+            scrollWheelEvent2Source: nil,
+            units: .pixel,
+            wheelCount: 2,
+            wheel1: 0,
+            wheel2: 0,
+            wheel3: 0
+        ))
+        let view = ScrollWheelEventView(event)
+        view.deltaYPt = 12
+        view.deltaYFixedPt = 12
+        event.flags = [.maskControl]
+        event.isLinearMouseSyntheticEvent = true
+
+        let transformer = EventTransformerManager.shared.get(
+            withCGEvent: event,
+            withSourcePid: nil,
+            withTargetPid: nil,
+            withMouseLocationPid: nil,
+            withDisplay: nil
+        )
+
+        XCTAssertNotNil(transformer.transform(event))
+    }
+
+    func testScrollButtonRecordingUsesReversedDirectionBeforeSmoothing() throws {
+        ConfigurationState.shared.configuration = .init(schemes: [
+            Scheme(
+                scrolling: .init(
+                    reverse: .init(vertical: true),
+                    smoothed: .init(vertical: .init(enabled: true, preset: .smooth))
+                )
+            )
+        ])
+        SettingsState.shared.recording = true
+
+        let event = try XCTUnwrap(CGEvent(
+            scrollWheelEvent2Source: nil,
+            units: .line,
+            wheelCount: 2,
+            wheel1: 1,
+            wheel2: 0,
+            wheel3: 0
+        ))
+        event.flags = [.maskControl]
+
+        let transformer = EventTransformerManager.shared.get(
+            withCGEvent: event,
+            withSourcePid: nil,
+            withTargetPid: nil,
+            withMouseLocationPid: nil,
+            withDisplay: nil
+        )
+
+        XCTAssertNil(transformer.transform(event))
+
+        let recordedExpectation = expectation(description: "Recorded transformed scroll mapping")
+        DispatchQueue.main.async {
+            let recordedEvent = SettingsState.shared.recordedButtonMappingEvent
+            XCTAssertNil(recordedEvent?.button)
+            XCTAssertEqual(recordedEvent?.scroll, .down)
+            XCTAssertEqual(recordedEvent?.modifierFlags, [.maskControl])
+            recordedExpectation.fulfill()
+        }
+        wait(for: [recordedExpectation], timeout: 1)
     }
 }

--- a/LinearMouseUnitTests/EventTransformer/EventTransformerManagerTests.swift
+++ b/LinearMouseUnitTests/EventTransformer/EventTransformerManagerTests.swift
@@ -1,6 +1,7 @@
 // MIT License
 // Copyright (c) 2021-2026 LinearMouse
 
+import Combine
 @testable import LinearMouse
 import XCTest
 
@@ -9,9 +10,7 @@ final class EventTransformerManagerTests: XCTestCase {
         super.tearDown()
         ConfigurationState.shared.configuration = .init()
         SettingsState.shared.endButtonMappingRecording()
-        SettingsState.shared.endVirtualButtonRecordingPreparation()
         SettingsState.shared.recordedButtonMappingEvent = nil
-        SettingsState.shared.recordedVirtualButtonEvent = nil
     }
 
     func testSyntheticSmoothedEventStillGetsModifierActions() throws {
@@ -341,6 +340,90 @@ final class EventTransformerManagerTests: XCTestCase {
 
         XCTAssertFalse(SettingsState.shared.recording)
         XCTAssertNil(SettingsState.shared.buttonMappingRecordingSessionID)
+    }
+
+    func testVirtualButtonPreparationIsPartOfButtonMappingRecordingSession() {
+        let recordingSessionID = UUID()
+        let deviceID: Int32 = 42
+
+        SettingsState.shared.beginButtonMappingRecording(
+            sessionID: recordingSessionID,
+            pendingVirtualButtonDeviceIDs: [deviceID]
+        )
+
+        XCTAssertTrue(SettingsState.shared.recording)
+        XCTAssertEqual(SettingsState.shared.buttonMappingRecordingSessionID, recordingSessionID)
+        XCTAssertTrue(SettingsState.shared.isPreparingVirtualButtonRecording)
+
+        SettingsState.shared.finishVirtualButtonRecordingPreparation(
+            for: deviceID,
+            sessionID: recordingSessionID
+        )
+
+        XCTAssertTrue(SettingsState.shared.recording)
+        XCTAssertEqual(SettingsState.shared.buttonMappingRecordingSessionID, recordingSessionID)
+        XCTAssertFalse(SettingsState.shared.isPreparingVirtualButtonRecording)
+    }
+
+    func testFinishingCompletedVirtualButtonPreparationDoesNotRepublishSession() {
+        let recordingSessionID = UUID()
+        let deviceID: Int32 = 42
+        var publishedSessions = [SettingsState.ButtonMappingRecordingSession?]()
+
+        SettingsState.shared.beginButtonMappingRecording(
+            sessionID: recordingSessionID,
+            pendingVirtualButtonDeviceIDs: [deviceID]
+        )
+
+        let cancellable = SettingsState.shared
+            .$buttonMappingRecordingSession
+            .dropFirst()
+            .sink { session in
+                publishedSessions.append(session)
+            }
+
+        SettingsState.shared.finishVirtualButtonRecordingPreparation(
+            for: deviceID,
+            sessionID: recordingSessionID
+        )
+        SettingsState.shared.finishVirtualButtonRecordingPreparation(
+            for: deviceID,
+            sessionID: recordingSessionID
+        )
+
+        XCTAssertEqual(publishedSessions.count, 1)
+        XCTAssertEqual(publishedSessions.first??.pendingVirtualButtonDeviceIDs, [])
+
+        cancellable.cancel()
+    }
+
+    func testEndingPreviousRecordingSessionDuringNewSessionPublishDoesNotClearNewSession() {
+        let previousSessionID = UUID()
+        let currentSessionID = UUID()
+        var publishedSessionIDs = [UUID?]()
+
+        SettingsState.shared.beginButtonMappingRecording(sessionID: previousSessionID)
+
+        let cancellable = SettingsState.shared
+            .$buttonMappingRecordingSession
+            .dropFirst()
+            .sink { session in
+                publishedSessionIDs.append(session?.id)
+
+                guard session?.id == currentSessionID else {
+                    return
+                }
+
+                SettingsState.shared.endButtonMappingRecording(sessionID: previousSessionID)
+            }
+
+        SettingsState.shared.beginButtonMappingRecording(sessionID: currentSessionID)
+
+        XCTAssertEqual(SettingsState.shared.buttonMappingRecordingSessionID, currentSessionID)
+        XCTAssertEqual(SettingsState.shared.buttonMappingRecordingSession?.id, currentSessionID)
+        XCTAssertEqual(publishedSessionIDs, [currentSessionID])
+
+        cancellable.cancel()
     }
 
     func testScrollButtonRecordingIgnoresStaleAsyncEventAfterSessionChanges() throws {


### PR DESCRIPTION
## Summary
- Route scroll-triggered button mappings through the scroll pipeline before smooth scrolling consumes the original wheel event.
- Keep mouse and Logitech button mappings in the button pipeline so click debouncing, auto scroll, and gesture handling keep their existing order.
- Record scroll button mappings from the transformed scroll pipeline, so reverse scrolling is respected and smooth scrolling no longer blocks recording.

## Testing
- `swiftformat LinearMouse/State/SettingsState.swift LinearMouse/EventTransformer/ButtonActionsTransformer.swift LinearMouse/EventTransformer/EventTransformerManager.swift LinearMouse/UI/ButtonsSettings/ButtonMappingsSection/ButtonMappingButtonRecorder.swift LinearMouseUnitTests/EventTransformer/EventTransformerManagerTests.swift`
- `swiftlint --quiet LinearMouse/State/SettingsState.swift LinearMouse/EventTransformer/ButtonActionsTransformer.swift LinearMouse/EventTransformer/EventTransformerManager.swift LinearMouse/UI/ButtonsSettings/ButtonMappingsSection/ButtonMappingButtonRecorder.swift LinearMouseUnitTests/EventTransformer/EventTransformerManagerTests.swift`
- `git diff --check`
- `xcodebuild test -project LinearMouse.xcodeproj -scheme LinearMouse`