### PR TITLE
Refine smooth scroll direction reversal braking

### DIFF
--- a/LinearMouse/EventTransformer/SmoothedScrollingEngine.swift
+++ b/LinearMouse/EventTransformer/SmoothedScrollingEngine.swift
@@ -126,6 +126,19 @@ final class SmoothedScrollingEngine {
             return currentVelocity + (inputVelocity - currentVelocity) * brakingBlend
         }
 
+        func residualInputAfterCancellingMomentum(input: Double, currentVelocity: Double) -> Double {
+            let inputVelocity = desiredVelocity(for: input)
+            let inputMagnitude = abs(inputVelocity)
+            let currentMagnitude = abs(currentVelocity)
+
+            guard inputMagnitude > currentMagnitude else {
+                return 0
+            }
+
+            let residualFraction = ((inputMagnitude - currentMagnitude) / inputMagnitude).clamped(to: 0 ... 1)
+            return input * residualFraction
+        }
+
         func blendFactor(for dt: TimeInterval) -> Double {
             let scaled = presetProfile.response * 0.75 + response * 0.8
             return (scaled * dt * 60).clamped(to: 0.0 ... 1.0)
@@ -277,17 +290,41 @@ final class SmoothedScrollingEngine {
     }
 
     private func cancelOpposingMomentum(deltaX: inout Double, deltaY: inout Double) {
-        if opposesMomentum(input: deltaX, velocity: velocityX) {
-            desiredVelocityX = 0
-            velocityX = 0
-            deltaX = 0
+        cancelOpposingMomentum(
+            delta: &deltaX,
+            behavior: horizontalBehavior,
+            desiredVelocity: &desiredVelocityX,
+            velocity: &velocityX
+        )
+        cancelOpposingMomentum(
+            delta: &deltaY,
+            behavior: verticalBehavior,
+            desiredVelocity: &desiredVelocityY,
+            velocity: &velocityY
+        )
+    }
+
+    private func cancelOpposingMomentum(
+        delta: inout Double,
+        behavior: AxisBehavior,
+        desiredVelocity: inout Double,
+        velocity: inout Double
+    ) {
+        guard opposesMomentum(input: delta, velocity: velocity) else {
+            return
         }
 
-        if opposesMomentum(input: deltaY, velocity: velocityY) {
-            desiredVelocityY = 0
-            velocityY = 0
-            deltaY = 0
+        let residualInput: Double
+        switch behavior {
+        case .passthrough:
+            residualInput = delta
+        case let .smoothed(tuning):
+            residualInput = tuning.residualInputAfterCancellingMomentum(input: delta, currentVelocity: velocity)
         }
+
+        desiredVelocity = 0
+        velocity = 0
+        delta = residualInput
     }
 
     private func opposesMomentum(input: Double, velocity: Double) -> Bool {

--- a/LinearMouseUnitTests/EventTransformer/SmoothedScrollingEngineTests.swift
+++ b/LinearMouseUnitTests/EventTransformer/SmoothedScrollingEngineTests.swift
@@ -121,7 +121,7 @@ final class SmoothedScrollingEngineTests: XCTestCase {
         XCTAssertLessThan(abs(reengagedEmission.deltaY), abs(baseline.deltaY) * 2.6)
     }
 
-    func testMomentumReengagementInOppositeDirectionFirstCancelsCarryThenScrolls() throws {
+    func testWeakMomentumReengagementInOppositeDirectionFirstCancelsCarryThenScrolls() throws {
         let engine = SmoothedScrollingEngine(smoothed: .init(
             vertical: Scheme.Scrolling.Smoothed.Preset.easeInOut.defaultConfiguration
         ))
@@ -145,7 +145,7 @@ final class SmoothedScrollingEngineTests: XCTestCase {
         XCTAssertGreaterThan(baseline.deltaY, 0)
 
         let reengagementTimestamp = 25.0 / 120.0
-        engine.feed(deltaX: 0, deltaY: -36, timestamp: reengagementTimestamp)
+        engine.feed(deltaX: 0, deltaY: -1, timestamp: reengagementTimestamp)
         let cancellationEmission = try XCTUnwrap(engine.advance(to: reengagementTimestamp + 1.0 / 120.0))
 
         XCTAssertEqual(cancellationEmission.phase, .momentumEnded)
@@ -156,6 +156,46 @@ final class SmoothedScrollingEngineTests: XCTestCase {
 
         XCTAssertEqual(reengagedEmission.phase, .touchBegan)
         XCTAssertLessThan(reengagedEmission.deltaY, 0)
+    }
+
+    func testMomentumTailReverseInputCanStartImmediatelyWhenItOvercomesRemainingMomentum() throws {
+        let configuration = Scheme.Scrolling.Smoothed.Preset.easeInOut.defaultConfiguration
+        let engine = SmoothedScrollingEngine(smoothed: .init(vertical: configuration))
+        let freshEngine = SmoothedScrollingEngine(smoothed: .init(vertical: configuration))
+
+        var tailEmission: SmoothedScrollingEngine.Emission?
+        var tailTimestamp: TimeInterval?
+
+        for step in 0 ..< 6 {
+            let timestamp = Double(step) / 120
+            engine.feed(deltaX: 0, deltaY: 40, timestamp: timestamp)
+            _ = engine.advance(to: timestamp + 1.0 / 120)
+        }
+
+        for step in 6 ..< 240 {
+            let timestamp = Double(step + 1) / 120
+            if let emission = engine.advance(to: timestamp),
+               emission.phase == .momentumChanged,
+               abs(emission.deltaY) < 0.2 {
+                tailEmission = emission
+                tailTimestamp = timestamp
+                break
+            }
+        }
+
+        let baselineTail = try XCTUnwrap(tailEmission)
+        let reengagementTimestamp = try XCTUnwrap(tailTimestamp)
+        XCTAssertGreaterThan(baselineTail.deltaY, 0)
+
+        freshEngine.feed(deltaX: 0, deltaY: -36, timestamp: 0)
+        let freshReversePickup = try XCTUnwrap(freshEngine.advance(to: 1.0 / 120.0))
+
+        engine.feed(deltaX: 0, deltaY: -36, timestamp: reengagementTimestamp)
+        let reengagedEmission = try XCTUnwrap(engine.advance(to: reengagementTimestamp + 1.0 / 120.0))
+
+        XCTAssertEqual(reengagedEmission.phase, .touchBegan)
+        XCTAssertLessThan(reengagedEmission.deltaY, 0)
+        XCTAssertLessThan(abs(reengagedEmission.deltaY), abs(freshReversePickup.deltaY))
     }
 
     func testMomentumTailReengagementRecoversTowardFreshPickup() throws {


### PR DESCRIPTION
## Summary
- Preserve the residual opposite-direction input after it cancels remaining smooth-scroll momentum.
- Keep weak opposite-direction input as a pure brake when it is not strong enough to overcome the current momentum.
- Add coverage for both weak reversal braking and low-momentum reverse startup behavior.

Follow-up to #1225.

## Testing
- `swiftformat LinearMouse/EventTransformer/SmoothedScrollingEngine.swift LinearMouseUnitTests/EventTransformer/SmoothedScrollingEngineTests.swift`
- `swiftlint --quiet LinearMouse/EventTransformer/SmoothedScrollingEngine.swift LinearMouseUnitTests/EventTransformer/SmoothedScrollingEngineTests.swift`
- `git diff --check`
- `xcodebuild test -project LinearMouse.xcodeproj -scheme LinearMouse`