### PR TITLE
Increase pointer acceleration range

### DIFF
--- a/Documentation/Configuration.d.ts
+++ b/Documentation/Configuration.d.ts
@@ -406,7 +406,7 @@ declare namespace Scheme {
      * @title Pointer acceleration
      * @description A number to set acceleration, or "unset" to restore system default. If omitted, the previous/merged value applies.
      * @minimum 0
-     * @maximum 20
+     * @maximum 40
      */
     acceleration?: number | Unset;
 

--- a/Documentation/Configuration.json
+++ b/Documentation/Configuration.json
@@ -1132,7 +1132,7 @@
             }
           ],
           "description": "A number to set acceleration, or \"unset\" to restore system default. If omitted, the previous/merged value applies.",
-          "maximum": 20,
+          "maximum": 40,
           "minimum": 0,
           "title": "Pointer acceleration"
         },

--- a/LinearMouse/Model/Configuration/Scheme/Pointer.swift
+++ b/LinearMouse/Model/Configuration/Scheme/Pointer.swift
@@ -8,7 +8,7 @@ extension Scheme {
         typealias Value = Unsettable<Decimal>
         typealias RangeValue = Decimal
 
-        static var range: ClosedRange<RangeValue> = 0 ... 20
+        static var range: ClosedRange<RangeValue> = 0 ... 40
 
         static func clamp(_ value: Value?) -> Value? {
             guard let value else {

--- a/LinearMouse/UI/PointerSettings/PointerSettings.swift
+++ b/LinearMouse/UI/PointerSettings/PointerSettings.swift
@@ -35,11 +35,11 @@ struct PointerSettings: View {
                         HStack(alignment: .firstTextBaseline) {
                             Slider(
                                 value: $state.pointerAcceleration,
-                                in: 0.0 ... 20.0
+                                in: 0.0 ... 40.0
                             ) {
                                 labelWithDescription {
                                     Text("Pointer acceleration")
-                                    Text(verbatim: "(0–20)")
+                                    Text(verbatim: "(0–40)")
                                 }
                             }
                             TextField(
@@ -130,11 +130,11 @@ struct PointerSettings: View {
                         HStack(alignment: .firstTextBaseline) {
                             Slider(
                                 value: $state.pointerAcceleration,
-                                in: 0.0 ... 20.0
+                                in: 0.0 ... 40.0
                             ) {
                                 labelWithDescription {
                                     Text("Tracking speed")
-                                    Text(verbatim: "(0–20)")
+                                    Text(verbatim: "(0–40)")
                                 }
                             }
                             TextField(

--- a/Modules/PointerKit/Sources/PointerKit/PointerDevice.swift
+++ b/Modules/PointerKit/Sources/PointerKit/PointerDevice.swift
@@ -347,7 +347,7 @@ public extension PointerDevice {
     /**
      Indicates the pointer acceleration.
 
-     This value is in the range [0, 20] ∪ { -1 }. -1 means acceleration and sensitivity are disabled.
+     This value is in the range [0, 40] ∪ { -1 }. -1 means acceleration and sensitivity are disabled.
      */
     var pointerAcceleration: Double? {
         get {
@@ -359,7 +359,7 @@ public extension PointerDevice {
 
         set {
             setDynamicPropertyIOFixed(
-                newValue.map { $0 == -1 ? $0 : $0.clamp(0, 20) },
+                newValue.map { $0 == -1 ? $0 : $0.clamp(0, 40) },
                 forKey: pointerAccelerationType ?? kIOHIDMouseAccelerationTypeKey
             )
         }


### PR DESCRIPTION
## Summary
- Increase the configurable pointer acceleration range from 0-20 to 0-40.
- Update the pointer settings labels and generated configuration schema to match the expanded range.
- Keep Pointer speed unchanged.

## Testing
- npm run generate:json-schema
- swiftformat LinearMouse/Model/Configuration/Scheme/Pointer.swift LinearMouse/UI/PointerSettings/PointerSettings.swift Modules/PointerKit/Sources/PointerKit/PointerDevice.swift
- git diff --check
- xcodebuild test -project LinearMouse.xcodeproj -scheme LinearMouse -only-testing:LinearMouseUnitTests/ConfigurationTests

Related to #1196.