### PR TITLE
Add UI support for mouse and trackpad default settings

### DIFF
--- a/LinearMouse/Localizable.xcstrings
+++ b/LinearMouse/Localizable.xcstrings
@@ -5253,6 +5253,422 @@
         }
       }
     },
+    "All Mice" : {
+      "localizations" : {
+        "af" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Alle muise"
+          }
+        },
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "جميع الفأرات"
+          }
+        },
+        "bs" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Svi miševi"
+          }
+        },
+        "ca" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tots els ratolins"
+          }
+        },
+        "cs" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Všechny myši"
+          }
+        },
+        "da" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Alle mus"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Alle Mäuse"
+          }
+        },
+        "el" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Όλα τα ποντίκια"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Todos los ratones"
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kaikki hiiret"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Toutes les souris"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "כל העכברים"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Minden egér"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Semua Mouse"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tutti i mouse"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "すべてのマウス"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "모든 마우스"
+          }
+        },
+        "my" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "မောက်စ်အားလုံး"
+          }
+        },
+        "nb-NO" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Alle mus"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Alle muizen"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Wszystkie myszy"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Todos os ratos"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Todos os mouses"
+          }
+        },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Toate mouse-urile"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Все мыши"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Všetky myši"
+          }
+        },
+        "sr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Сви мишеви"
+          }
+        },
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Alla möss"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tüm Fareler"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Усі миші"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tất cả chuột"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "所有鼠标"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "所有滑鼠"
+          }
+        },
+        "zh-Hant-HK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "所有滑鼠"
+          }
+        }
+      }
+    },
+    "All Trackpads" : {
+      "localizations" : {
+        "af" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Alle stuurvlakke"
+          }
+        },
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "جميع لوحات التعقب"
+          }
+        },
+        "bs" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Svi dodirni paneli"
+          }
+        },
+        "ca" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tots els trackpads"
+          }
+        },
+        "cs" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Všechny trackpady"
+          }
+        },
+        "da" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Alle pegefelter"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Alle Trackpads"
+          }
+        },
+        "el" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Όλα τα trackpad"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Todos los trackpads"
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kaikki ohjauslevyt"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tous les trackpads"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "כל משטחי המגע"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Minden trackpad"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Semua Trackpad"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tutti i trackpad"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "すべてのトラックパッド"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "모든 트랙패드"
+          }
+        },
+        "my" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Trackpad အားလုံး"
+          }
+        },
+        "nb-NO" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Alle styreflater"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Alle trackpads"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Wszystkie gładziki"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Todos os trackpads"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Todos os trackpads"
+          }
+        },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Toate trackpadurile"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Все трекпады"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Všetky trackpady"
+          }
+        },
+        "sr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Сви трекпеди"
+          }
+        },
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Alla styrplattor"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tüm Trackpad’ler"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Усі трекпади"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tất cả bàn di chuột"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "所有触控板"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "所有觸控板"
+          }
+        },
+        "zh-Hant-HK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "所有觸控板"
+          }
+        }
+      }
+    },
     "Allow scroll bouncing" : {
       "localizations" : {
         "af" : {
@@ -6297,6 +6713,422 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "應用程式視窗"
+          }
+        }
+      }
+    },
+    "Applies to every mouse." : {
+      "localizations" : {
+        "af" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Van toepassing op elke muis."
+          }
+        },
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ينطبق على كل فأرة."
+          }
+        },
+        "bs" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Primjenjuje se na svaki miš."
+          }
+        },
+        "ca" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "S’aplica a tots els ratolins."
+          }
+        },
+        "cs" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Platí pro každou myš."
+          }
+        },
+        "da" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Gælder for alle mus."
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Gilt für jede Maus."
+          }
+        },
+        "el" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ισχύει για κάθε ποντίκι."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Se aplica a todos los ratones."
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Koskee kaikkia hiiriä."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "S’applique à chaque souris."
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "חל על כל עכבר."
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Minden egérre érvényes."
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Berlaku untuk setiap mouse."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Si applica a ogni mouse."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "すべてのマウスに適用されます。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "모든 마우스에 적용됩니다."
+          }
+        },
+        "my" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "မောက်စ်တိုင်းတွင် သက်ရောက်သည်။"
+          }
+        },
+        "nb-NO" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Gjelder for alle mus."
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Van toepassing op elke muis."
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dotyczy każdej myszy."
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aplica-se a todos os ratos."
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aplica-se a todos os mouses."
+          }
+        },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Se aplică fiecărui mouse."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Применяется ко всем мышам."
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Platí pre každú myš."
+          }
+        },
+        "sr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Примењује се на сваки миш."
+          }
+        },
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Gäller för varje mus."
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Her fare için geçerlidir."
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Застосовується до кожної миші."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Áp dụng cho mọi chuột."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "应用于每个鼠标。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "套用到每個滑鼠。"
+          }
+        },
+        "zh-Hant-HK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "套用到每個滑鼠。"
+          }
+        }
+      }
+    },
+    "Applies to every trackpad." : {
+      "localizations" : {
+        "af" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Van toepassing op elke stuurvlak."
+          }
+        },
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ينطبق على كل لوحة تعقب."
+          }
+        },
+        "bs" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Primjenjuje se na svaki dodirni panel."
+          }
+        },
+        "ca" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "S’aplica a tots els trackpads."
+          }
+        },
+        "cs" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Platí pro každý trackpad."
+          }
+        },
+        "da" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Gælder for alle pegefelter."
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Gilt für jedes Trackpad."
+          }
+        },
+        "el" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ισχύει για κάθε trackpad."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Se aplica a todos los trackpads."
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Koskee kaikkia ohjauslevyjä."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "S’applique à chaque trackpad."
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "חל על כל משטח מגע."
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Minden trackpadre érvényes."
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Berlaku untuk setiap trackpad."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Si applica a ogni trackpad."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "すべてのトラックパッドに適用されます。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "모든 트랙패드에 적용됩니다."
+          }
+        },
+        "my" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Trackpad တိုင်းတွင် သက်ရောက်သည်။"
+          }
+        },
+        "nb-NO" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Gjelder for alle styreflater."
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Van toepassing op elk trackpad."
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dotyczy każdego gładzika."
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aplica-se a todos os trackpads."
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aplica-se a todos os trackpads."
+          }
+        },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Se aplică fiecărui trackpad."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Применяется ко всем трекпадам."
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Platí pre každý trackpad."
+          }
+        },
+        "sr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Примењује се на сваки трекпед."
+          }
+        },
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Gäller för varje styrplatta."
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Her trackpad için geçerlidir."
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Застосовується до кожного трекпада."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Áp dụng cho mọi bàn di chuột."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "应用于每个触控板。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "套用到每個觸控板。"
+          }
+        },
+        "zh-Hant-HK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "套用到每個觸控板。"
           }
         }
       }

--- a/LinearMouse/Model/Configuration/Configuration.swift
+++ b/LinearMouse/Model/Configuration/Configuration.swift
@@ -152,6 +152,44 @@ extension Configuration {
     }
 
     func matchScheme(
+        withDeviceMatcher deviceMatcher: DeviceMatcher? = nil,
+        withApp app: String? = nil,
+        withParentApp parentApp: String? = nil,
+        withGroupApp groupApp: String? = nil,
+        withDisplay display: String? = nil,
+        withProcessName processName: String? = nil,
+        withProcessPath processPath: String? = nil
+    ) -> Scheme {
+        var mergedScheme = Scheme()
+
+        let `if` = Scheme.If(
+            device: deviceMatcher,
+            app: app,
+            parentApp: parentApp,
+            groupApp: groupApp,
+            processName: processName,
+            processPath: processPath,
+            display: display
+        )
+
+        mergedScheme.if = [`if`]
+
+        for scheme in schemes where scheme.isActive(
+            withDeviceMatcher: deviceMatcher,
+            withApp: app,
+            withParentApp: parentApp,
+            withGroupApp: groupApp,
+            withDisplay: display,
+            withProcessName: processName,
+            withProcessPath: processPath
+        ) {
+            scheme.merge(into: &mergedScheme)
+        }
+
+        return mergedScheme
+    }
+
+    func matchScheme(
         withDevice device: Device? = nil,
         withPid pid: pid_t? = nil,
         withDisplay display: String? = nil

--- a/LinearMouse/Model/Configuration/Configuration.swift
+++ b/LinearMouse/Model/Configuration/Configuration.swift
@@ -110,6 +110,20 @@ extension Configuration {
         try dump().write(to: url.resolvingSymlinksInPath(), options: .atomic)
     }
 
+    func matchScheme(in context: Scheme.MatchContext) -> Scheme {
+        // TODO: Backtrace the merge path
+        // TODO: Optimize the algorithm
+
+        var mergedScheme = Scheme()
+        mergedScheme.if = [Scheme.If(matchContext: context)]
+
+        for scheme in schemes where scheme.isActive(in: context) {
+            scheme.merge(into: &mergedScheme)
+        }
+
+        return mergedScheme
+    }
+
     func matchScheme(
         withDevice device: Device? = nil,
         withApp app: String? = nil,
@@ -119,36 +133,17 @@ extension Configuration {
         withProcessName processName: String? = nil,
         withProcessPath processPath: String? = nil
     ) -> Scheme {
-        // TODO: Backtrace the merge path
-        // TODO: Optimize the algorithm
-
-        var mergedScheme = Scheme()
-
-        let `if` = Scheme.If(
-            device: device.map { DeviceMatcher(of: $0) },
-            app: app,
-            parentApp: parentApp,
-            groupApp: groupApp,
-            processName: processName,
-            processPath: processPath,
-            display: display
+        matchScheme(
+            in: Scheme.MatchContext(
+                device: device,
+                app: app,
+                parentApp: parentApp,
+                groupApp: groupApp,
+                display: display,
+                processName: processName,
+                processPath: processPath
+            )
         )
-
-        mergedScheme.if = [`if`]
-
-        for scheme in schemes where scheme.isActive(
-            withDevice: device,
-            withApp: app,
-            withParentApp: parentApp,
-            withGroupApp: groupApp,
-            withDisplay: display,
-            withProcessName: processName,
-            withProcessPath: processPath
-        ) {
-            scheme.merge(into: &mergedScheme)
-        }
-
-        return mergedScheme
     }
 
     func matchScheme(
@@ -160,33 +155,17 @@ extension Configuration {
         withProcessName processName: String? = nil,
         withProcessPath processPath: String? = nil
     ) -> Scheme {
-        var mergedScheme = Scheme()
-
-        let `if` = Scheme.If(
-            device: deviceMatcher,
-            app: app,
-            parentApp: parentApp,
-            groupApp: groupApp,
-            processName: processName,
-            processPath: processPath,
-            display: display
+        matchScheme(
+            in: Scheme.MatchContext(
+                deviceMatcher: deviceMatcher,
+                app: app,
+                parentApp: parentApp,
+                groupApp: groupApp,
+                display: display,
+                processName: processName,
+                processPath: processPath
+            )
         )
-
-        mergedScheme.if = [`if`]
-
-        for scheme in schemes where scheme.isActive(
-            withDeviceMatcher: deviceMatcher,
-            withApp: app,
-            withParentApp: parentApp,
-            withGroupApp: groupApp,
-            withDisplay: display,
-            withProcessName: processName,
-            withProcessPath: processPath
-        ) {
-            scheme.merge(into: &mergedScheme)
-        }
-
-        return mergedScheme
     }
 
     func matchScheme(

--- a/LinearMouse/Model/Configuration/DeviceMatcher.swift
+++ b/LinearMouse/Model/Configuration/DeviceMatcher.swift
@@ -35,47 +35,29 @@ extension DeviceMatcher {
     }
 
     func match(with device: Device) -> Bool {
-        func matchValue<T: Equatable>(_ destination: T?, _ source: T) -> Bool {
-            destination == nil || source == destination
-        }
-
-        func matchValue<T: Equatable>(_ destination: T?, _ source: T?) -> Bool {
-            destination == nil || source == destination
-        }
-
-        guard matchValue(vendorID, device.vendorID),
-              matchValue(productID, device.productID),
-              matchValue(productName, device.productName),
-              matchValue(serialNumber, device.serialNumber)
-        else {
-            return false
-        }
-
-        if let category {
-            guard category.contains(where: { $0.deviceCategory == device.category }) else {
-                return false
-            }
-        }
-
-        return true
+        isSatisfied(by: DeviceMatcher(of: device))
     }
 
     func match(with matcher: DeviceMatcher) -> Bool {
+        isSatisfied(by: matcher)
+    }
+
+    func isSatisfied(by candidate: DeviceMatcher) -> Bool {
         func matchValue<T: Equatable>(_ destination: T?, _ source: T?) -> Bool {
             destination == nil || source == destination
         }
 
-        guard matchValue(vendorID, matcher.vendorID),
-              matchValue(productID, matcher.productID),
-              matchValue(productName, matcher.productName),
-              matchValue(serialNumber, matcher.serialNumber)
+        guard matchValue(vendorID, candidate.vendorID),
+              matchValue(productID, candidate.productID),
+              matchValue(productName, candidate.productName),
+              matchValue(serialNumber, candidate.serialNumber)
         else {
             return false
         }
 
         if let category {
-            guard let matcherCategory = matcher.category,
-                  category.contains(where: { matcherCategory.contains($0) })
+            guard let candidateCategory = candidate.category,
+                  category.contains(where: { candidateCategory.contains($0) })
             else {
                 return false
             }

--- a/LinearMouse/Model/Configuration/DeviceMatcher.swift
+++ b/LinearMouse/Model/Configuration/DeviceMatcher.swift
@@ -16,6 +16,14 @@ struct DeviceMatcher: Codable, Equatable, Hashable, Defaults.Serializable {
 }
 
 extension DeviceMatcher {
+    init(category: Category) {
+        vendorID = nil
+        productID = nil
+        productName = nil
+        serialNumber = nil
+        self.category = [category]
+    }
+
     init(of device: Device) {
         self.init(
             vendorID: device.vendorID,
@@ -50,6 +58,44 @@ extension DeviceMatcher {
         }
 
         return true
+    }
+
+    func match(with matcher: DeviceMatcher) -> Bool {
+        func matchValue<T: Equatable>(_ destination: T?, _ source: T?) -> Bool {
+            destination == nil || source == destination
+        }
+
+        guard matchValue(vendorID, matcher.vendorID),
+              matchValue(productID, matcher.productID),
+              matchValue(productName, matcher.productName),
+              matchValue(serialNumber, matcher.serialNumber)
+        else {
+            return false
+        }
+
+        if let category {
+            guard let matcherCategory = matcher.category,
+                  category.contains(where: { matcherCategory.contains($0) })
+            else {
+                return false
+            }
+        }
+
+        return true
+    }
+
+    var categoryOnlyValue: Category? {
+        guard vendorID == nil,
+              productID == nil,
+              productName == nil,
+              serialNumber == nil,
+              let category,
+              category.count == 1
+        else {
+            return nil
+        }
+
+        return category.first
     }
 }
 

--- a/LinearMouse/Model/Configuration/Scheme/If/If.swift
+++ b/LinearMouse/Model/Configuration/Scheme/If/If.swift
@@ -82,4 +82,66 @@ extension Scheme.If {
 
         return true
     }
+
+    func isSatisfied(
+        withDeviceMatcher targetDeviceMatcher: DeviceMatcher? = nil,
+        withApp targetApp: String? = nil,
+        withParentApp targetParentApp: String?,
+        withGroupApp targetGroupApp: String?,
+        withDisplay targetDisplay: String? = nil,
+        withProcessName targetProcessName: String? = nil,
+        withProcessPath targetProcessPath: String? = nil
+    ) -> Bool {
+        if let device {
+            guard let targetDeviceMatcher else {
+                return false
+            }
+
+            guard device.match(with: targetDeviceMatcher) else {
+                return false
+            }
+        }
+
+        if let app {
+            guard app == targetApp else {
+                return false
+            }
+        }
+
+        if let parentApp {
+            guard parentApp == targetParentApp else {
+                return false
+            }
+        }
+
+        if let groupApp {
+            guard groupApp == targetGroupApp else {
+                return false
+            }
+        }
+
+        if let processName {
+            guard processName == targetProcessName else {
+                return false
+            }
+        }
+
+        if let processPath {
+            guard processPath == targetProcessPath else {
+                return false
+            }
+        }
+
+        if let display {
+            guard let targetDisplay else {
+                return false
+            }
+
+            guard display == targetDisplay else {
+                return false
+            }
+        }
+
+        return true
+    }
 }

--- a/LinearMouse/Model/Configuration/Scheme/If/If.swift
+++ b/LinearMouse/Model/Configuration/Scheme/If/If.swift
@@ -21,57 +21,61 @@ extension Scheme {
 }
 
 extension Scheme.If {
-    func isSatisfied(
-        withDevice targetDevice: Device? = nil,
-        withApp targetApp: String? = nil,
-        withParentApp targetParentApp: String?,
-        withGroupApp targetGroupApp: String?,
-        withDisplay targetDisplay: String? = nil,
-        withProcessName targetProcessName: String? = nil,
-        withProcessPath targetProcessPath: String? = nil
-    ) -> Bool {
+    init(matchContext context: Scheme.MatchContext) {
+        self.init(
+            device: context.device,
+            app: context.app,
+            parentApp: context.parentApp,
+            groupApp: context.groupApp,
+            processName: context.processName,
+            processPath: context.processPath,
+            display: context.display
+        )
+    }
+
+    func isSatisfied(in context: Scheme.MatchContext) -> Bool {
         if let device {
-            guard let targetDevice else {
+            guard let targetDevice = context.device else {
                 return false
             }
 
-            guard device.match(with: targetDevice) else {
+            guard device.isSatisfied(by: targetDevice) else {
                 return false
             }
         }
 
         if let app {
-            guard app == targetApp else {
+            guard app == context.app else {
                 return false
             }
         }
 
         if let parentApp {
-            guard parentApp == targetParentApp else {
+            guard parentApp == context.parentApp else {
                 return false
             }
         }
 
         if let groupApp {
-            guard groupApp == targetGroupApp else {
+            guard groupApp == context.groupApp else {
                 return false
             }
         }
 
         if let processName {
-            guard processName == targetProcessName else {
+            guard processName == context.processName else {
                 return false
             }
         }
 
         if let processPath {
-            guard processPath == targetProcessPath else {
+            guard processPath == context.processPath else {
                 return false
             }
         }
 
         if let display {
-            guard let targetDisplay else {
+            guard let targetDisplay = context.display else {
                 return false
             }
 
@@ -84,6 +88,28 @@ extension Scheme.If {
     }
 
     func isSatisfied(
+        withDevice targetDevice: Device? = nil,
+        withApp targetApp: String? = nil,
+        withParentApp targetParentApp: String?,
+        withGroupApp targetGroupApp: String?,
+        withDisplay targetDisplay: String? = nil,
+        withProcessName targetProcessName: String? = nil,
+        withProcessPath targetProcessPath: String? = nil
+    ) -> Bool {
+        isSatisfied(
+            in: Scheme.MatchContext(
+                device: targetDevice,
+                app: targetApp,
+                parentApp: targetParentApp,
+                groupApp: targetGroupApp,
+                display: targetDisplay,
+                processName: targetProcessName,
+                processPath: targetProcessPath
+            )
+        )
+    }
+
+    func isSatisfied(
         withDeviceMatcher targetDeviceMatcher: DeviceMatcher? = nil,
         withApp targetApp: String? = nil,
         withParentApp targetParentApp: String?,
@@ -92,56 +118,16 @@ extension Scheme.If {
         withProcessName targetProcessName: String? = nil,
         withProcessPath targetProcessPath: String? = nil
     ) -> Bool {
-        if let device {
-            guard let targetDeviceMatcher else {
-                return false
-            }
-
-            guard device.match(with: targetDeviceMatcher) else {
-                return false
-            }
-        }
-
-        if let app {
-            guard app == targetApp else {
-                return false
-            }
-        }
-
-        if let parentApp {
-            guard parentApp == targetParentApp else {
-                return false
-            }
-        }
-
-        if let groupApp {
-            guard groupApp == targetGroupApp else {
-                return false
-            }
-        }
-
-        if let processName {
-            guard processName == targetProcessName else {
-                return false
-            }
-        }
-
-        if let processPath {
-            guard processPath == targetProcessPath else {
-                return false
-            }
-        }
-
-        if let display {
-            guard let targetDisplay else {
-                return false
-            }
-
-            guard display == targetDisplay else {
-                return false
-            }
-        }
-
-        return true
+        isSatisfied(
+            in: Scheme.MatchContext(
+                deviceMatcher: targetDeviceMatcher,
+                app: targetApp,
+                parentApp: targetParentApp,
+                groupApp: targetGroupApp,
+                display: targetDisplay,
+                processName: targetProcessName,
+                processPath: targetProcessPath
+            )
+        )
     }
 }

--- a/LinearMouse/Model/Configuration/Scheme/Scheme.swift
+++ b/LinearMouse/Model/Configuration/Scheme/Scheme.swift
@@ -61,6 +61,32 @@ extension Scheme {
         }
     }
 
+    func isActive(
+        withDeviceMatcher deviceMatcher: DeviceMatcher? = nil,
+        withApp app: String? = nil,
+        withParentApp parentApp: String? = nil,
+        withGroupApp groupApp: String? = nil,
+        withDisplay display: String? = nil,
+        withProcessName processName: String? = nil,
+        withProcessPath processPath: String? = nil
+    ) -> Bool {
+        guard let `if` else {
+            return true
+        }
+
+        return `if`.contains {
+            $0.isSatisfied(
+                withDeviceMatcher: deviceMatcher,
+                withApp: app,
+                withParentApp: parentApp,
+                withGroupApp: groupApp,
+                withDisplay: display,
+                withProcessName: processName,
+                withProcessPath: processPath
+            )
+        }
+    }
+
     /// A scheme is device-specific if and only if a) it has only one `if` and
     /// b) the `if` contains conditions that specifies both vendorID and productID.
     var isDeviceSpecific: Bool {
@@ -79,6 +105,19 @@ extension Scheme {
         }
 
         return true
+    }
+
+    var isDeviceCategorySpecific: Bool {
+        guard let conditions = `if` else {
+            return false
+        }
+
+        guard conditions.count == 1,
+              let condition = conditions.first else {
+            return false
+        }
+
+        return condition.device?.categoryOnlyValue != nil
     }
 
     var isDisplaySpecific: Bool {
@@ -126,6 +165,35 @@ extension [Scheme] {
         }
     }
 
+    func allDeviceMatcherSpecificSchemes(of matcher: DeviceMatcher) -> [EnumeratedSequence<[Scheme]>.Element] {
+        self.enumerated().filter { _, scheme in
+            guard scheme.isDeviceSpecific else {
+                return false
+            }
+            guard scheme.if?.count == 1, let `if` = scheme.if?.first else {
+                return false
+            }
+            guard `if`.device?.match(with: matcher) == true else {
+                return false
+            }
+            return true
+        }
+    }
+
+    func allDeviceCategorySpecificSchemes(
+        of category: DeviceMatcher.Category
+    ) -> [EnumeratedSequence<[Scheme]>.Element] {
+        self.enumerated().filter { _, scheme in
+            guard scheme.isDeviceCategorySpecific else {
+                return false
+            }
+            guard scheme.if?.first?.device?.categoryOnlyValue == category else {
+                return false
+            }
+            return true
+        }
+    }
+
     enum SchemeIndex {
         case at(Int)
         case insertAt(Int)
@@ -137,14 +205,67 @@ extension [Scheme] {
         ofProcessPath processPath: String?,
         ofDisplay display: String?
     ) -> SchemeIndex {
-        let allDeviceSpecificSchemes = allDeviceSpecficSchemes(of: device)
+        schemeIndex(
+            among: allDeviceSpecficSchemes(of: device),
+            emptyInsertionIndex: endIndex,
+            ofApp: app,
+            ofProcessPath: processPath,
+            ofDisplay: display
+        )
+    }
 
-        guard let first = allDeviceSpecificSchemes.first,
-              let last = allDeviceSpecificSchemes.last else {
-            return .insertAt(self.endIndex)
+    func schemeIndex(
+        ofDeviceMatcher matcher: DeviceMatcher,
+        ofApp app: String?,
+        ofProcessPath processPath: String?,
+        ofDisplay display: String?
+    ) -> SchemeIndex {
+        if let category = matcher.categoryOnlyValue {
+            return schemeIndex(
+                ofDeviceCategory: category,
+                ofApp: app,
+                ofProcessPath: processPath,
+                ofDisplay: display
+            )
         }
 
-        if let (index, _) = allDeviceSpecificSchemes
+        return schemeIndex(
+            among: allDeviceMatcherSpecificSchemes(of: matcher),
+            emptyInsertionIndex: endIndex,
+            ofApp: app,
+            ofProcessPath: processPath,
+            ofDisplay: display
+        )
+    }
+
+    func schemeIndex(
+        ofDeviceCategory category: DeviceMatcher.Category,
+        ofApp app: String?,
+        ofProcessPath processPath: String?,
+        ofDisplay display: String?
+    ) -> SchemeIndex {
+        schemeIndex(
+            among: allDeviceCategorySpecificSchemes(of: category),
+            emptyInsertionIndex: firstDeviceSpecificSchemeIndex(of: category) ?? endIndex,
+            ofApp: app,
+            ofProcessPath: processPath,
+            ofDisplay: display
+        )
+    }
+
+    private func schemeIndex(
+        among matchingSchemes: [EnumeratedSequence<[Scheme]>.Element],
+        emptyInsertionIndex: Int,
+        ofApp app: String?,
+        ofProcessPath processPath: String?,
+        ofDisplay display: String?
+    ) -> SchemeIndex {
+        guard let first = matchingSchemes.first,
+              let last = matchingSchemes.last else {
+            return .insertAt(emptyInsertionIndex)
+        }
+
+        if let (index, _) = matchingSchemes
             .first(where: { _, scheme in
                 scheme.if?.first?.app == app &&
                     scheme.if?.first?.processPath == processPath &&
@@ -162,26 +283,43 @@ extension [Scheme] {
         }
 
         if app != nil {
-            if let (index, _) = allDeviceSpecificSchemes
+            if let (index, _) = matchingSchemes
                 .first(where: { _, scheme in scheme.if?.first?.app == app }) {
                 return .insertAt(index)
             }
         }
 
         if processPath != nil {
-            if let (index, _) = allDeviceSpecificSchemes
+            if let (index, _) = matchingSchemes
                 .first(where: { _, scheme in scheme.if?.first?.processPath == processPath }) {
                 return .insertAt(index)
             }
         }
 
         if display != nil {
-            if let (index, _) = allDeviceSpecificSchemes
+            if let (index, _) = matchingSchemes
                 .first(where: { _, scheme in scheme.if?.first?.display == display }) {
                 return .insertAt(index)
             }
         }
 
         return .insertAt(last.offset + 1)
+    }
+
+    private func firstDeviceSpecificSchemeIndex(of category: DeviceMatcher.Category) -> Int? {
+        enumerated()
+            .first { _, scheme in
+                guard scheme.isDeviceSpecific,
+                      let matcher = scheme.if?.first?.device else {
+                    return false
+                }
+
+                if matcher.category?.contains(category) == true {
+                    return true
+                }
+
+                return scheme.matchedDevices.contains { $0.category == category.deviceCategory }
+            }?
+            .offset
     }
 }

--- a/LinearMouse/Model/Configuration/Scheme/Scheme.swift
+++ b/LinearMouse/Model/Configuration/Scheme/Scheme.swift
@@ -35,6 +35,66 @@ struct Scheme: Codable, Equatable {
 }
 
 extension Scheme {
+    struct MatchContext {
+        var device: DeviceMatcher?
+        var app: String?
+        var parentApp: String?
+        var groupApp: String?
+        var display: String?
+        var processName: String?
+        var processPath: String?
+
+        init(
+            deviceMatcher: DeviceMatcher? = nil,
+            app: String? = nil,
+            parentApp: String? = nil,
+            groupApp: String? = nil,
+            display: String? = nil,
+            processName: String? = nil,
+            processPath: String? = nil
+        ) {
+            device = deviceMatcher
+            self.app = app
+            self.parentApp = parentApp
+            self.groupApp = groupApp
+            self.display = display
+            self.processName = processName
+            self.processPath = processPath
+        }
+
+        init(
+            device: Device?,
+            app: String? = nil,
+            parentApp: String? = nil,
+            groupApp: String? = nil,
+            display: String? = nil,
+            processName: String? = nil,
+            processPath: String? = nil
+        ) {
+            self.init(
+                deviceMatcher: device.map { DeviceMatcher(of: $0) },
+                app: app,
+                parentApp: parentApp,
+                groupApp: groupApp,
+                display: display,
+                processName: processName,
+                processPath: processPath
+            )
+        }
+    }
+}
+
+extension Scheme {
+    func isActive(in context: MatchContext) -> Bool {
+        guard let `if` else {
+            return true
+        }
+
+        return `if`.contains {
+            $0.isSatisfied(in: context)
+        }
+    }
+
     func isActive(
         withDevice device: Device? = nil,
         withApp app: String? = nil,
@@ -44,21 +104,17 @@ extension Scheme {
         withProcessName processName: String? = nil,
         withProcessPath processPath: String? = nil
     ) -> Bool {
-        guard let `if` else {
-            return true
-        }
-
-        return `if`.contains {
-            $0.isSatisfied(
-                withDevice: device,
-                withApp: app,
-                withParentApp: parentApp,
-                withGroupApp: groupApp,
-                withDisplay: display,
-                withProcessName: processName,
-                withProcessPath: processPath
+        isActive(
+            in: MatchContext(
+                device: device,
+                app: app,
+                parentApp: parentApp,
+                groupApp: groupApp,
+                display: display,
+                processName: processName,
+                processPath: processPath
             )
-        }
+        )
     }
 
     func isActive(
@@ -70,21 +126,17 @@ extension Scheme {
         withProcessName processName: String? = nil,
         withProcessPath processPath: String? = nil
     ) -> Bool {
-        guard let `if` else {
-            return true
-        }
-
-        return `if`.contains {
-            $0.isSatisfied(
-                withDeviceMatcher: deviceMatcher,
-                withApp: app,
-                withParentApp: parentApp,
-                withGroupApp: groupApp,
-                withDisplay: display,
-                withProcessName: processName,
-                withProcessPath: processPath
+        isActive(
+            in: MatchContext(
+                deviceMatcher: deviceMatcher,
+                app: app,
+                parentApp: parentApp,
+                groupApp: groupApp,
+                display: display,
+                processName: processName,
+                processPath: processPath
             )
-        }
+        )
     }
 
     /// A scheme is device-specific if and only if a) it has only one `if` and
@@ -151,18 +203,7 @@ extension Scheme: CustomStringConvertible {
 
 extension [Scheme] {
     func allDeviceSpecficSchemes(of device: Device) -> [EnumeratedSequence<[Scheme]>.Element] {
-        self.enumerated().filter { _, scheme in
-            guard scheme.isDeviceSpecific else {
-                return false
-            }
-            guard scheme.if?.count == 1, let `if` = scheme.if?.first else {
-                return false
-            }
-            guard `if`.device?.match(with: device) == true else {
-                return false
-            }
-            return true
-        }
+        allDeviceMatcherSpecificSchemes(of: DeviceMatcher(of: device))
     }
 
     func allDeviceMatcherSpecificSchemes(of matcher: DeviceMatcher) -> [EnumeratedSequence<[Scheme]>.Element] {
@@ -173,7 +214,7 @@ extension [Scheme] {
             guard scheme.if?.count == 1, let `if` = scheme.if?.first else {
                 return false
             }
-            guard `if`.device?.match(with: matcher) == true else {
+            guard `if`.device?.isSatisfied(by: matcher) == true else {
                 return false
             }
             return true

--- a/LinearMouse/State/DeviceState.swift
+++ b/LinearMouse/State/DeviceState.swift
@@ -15,9 +15,16 @@ class DeviceState: ObservableObject {
     static let shared = DeviceState()
 
     private var subscriptions = Set<AnyCancellable>()
+    private var isUpdatingCurrentDeviceRef = false
+
+    @Published var currentDeviceMatcher: DeviceMatcher?
 
     @Published var currentDeviceRef: WeakRef<Device>? {
         didSet {
+            guard !isUpdatingCurrentDeviceRef else {
+                return
+            }
+
             guard !Defaults[.autoSwitchToActiveDevice] else {
                 return
             }
@@ -66,14 +73,26 @@ extension DeviceState {
         DeviceManager.shared
     }
 
+    private func setCurrentDeviceRef(_ deviceRef: WeakRef<Device>?) {
+        isUpdatingCurrentDeviceRef = true
+        currentDeviceRef = deviceRef
+        isUpdatingCurrentDeviceRef = false
+    }
+
+    private func exactMatcher(of deviceRef: WeakRef<Device>?) -> DeviceMatcher? {
+        deviceRef?.value.map { DeviceMatcher(of: $0) }
+    }
+
     private func updateCurrentDeviceRef(lastActiveDeviceRef: WeakRef<Device>?) {
         guard !Defaults[.autoSwitchToActiveDevice] else {
-            currentDeviceRef = lastActiveDeviceRef
+            setCurrentDeviceRef(lastActiveDeviceRef)
+            currentDeviceMatcher = exactMatcher(of: lastActiveDeviceRef)
             return
         }
 
         guard let userSelectedDevice = Defaults[.selectedDevice] else {
-            currentDeviceRef = lastActiveDeviceRef
+            setCurrentDeviceRef(lastActiveDeviceRef)
+            currentDeviceMatcher = exactMatcher(of: lastActiveDeviceRef)
             return
         }
 
@@ -81,7 +100,8 @@ extension DeviceState {
             .first { userSelectedDevice.match(with: $0) }
             .map { WeakRef($0) }
 
-        currentDeviceRef = matchedDeviceRef ?? lastActiveDeviceRef
+        setCurrentDeviceRef(matchedDeviceRef ?? lastActiveDeviceRef)
+        currentDeviceMatcher = userSelectedDevice
     }
 
     private func updateCurrentDevice() {

--- a/LinearMouse/State/SchemeState.swift
+++ b/LinearMouse/State/SchemeState.swift
@@ -29,6 +29,14 @@ class SchemeState: ObservableObject {
                 self?.objectWillChange.send()
             }
             .store(in: &subscriptions)
+
+        deviceState.$currentDeviceMatcher
+            .debounce(for: 0.1, scheduler: RunLoop.main)
+            .removeDuplicates()
+            .sink { [weak self] _ in
+                self?.objectWillChange.send()
+            }
+            .store(in: &subscriptions)
     }
 }
 
@@ -37,11 +45,40 @@ extension SchemeState {
         deviceState.currentDeviceRef?.value
     }
 
-    private func hasMatchingSchemes(for device: Device?, app: AppTarget?, display: String?) -> Bool {
-        guard let device else {
+    private var deviceMatcher: DeviceMatcher? {
+        deviceState.currentDeviceMatcher
+    }
+
+    private func deviceConditionMatches(
+        _ conditionDeviceMatcher: DeviceMatcher,
+        targetMatcher: DeviceMatcher?,
+        targetDevice: Device?
+    ) -> Bool {
+        if let targetCategory = targetMatcher?.categoryOnlyValue {
+            return conditionDeviceMatcher == DeviceMatcher(category: targetCategory)
+        }
+
+        if conditionDeviceMatcher.categoryOnlyValue != nil {
             return false
         }
 
+        if let targetDevice {
+            return conditionDeviceMatcher.match(with: targetDevice)
+        }
+
+        guard let targetMatcher else {
+            return false
+        }
+
+        return conditionDeviceMatcher.match(with: targetMatcher)
+    }
+
+    private func hasMatchingSchemes(
+        for matcher: DeviceMatcher?,
+        device: Device?,
+        app: AppTarget?,
+        display: String?
+    ) -> Bool {
         let (appId, processPath) = extractAppComponents(from: app)
 
         return schemes.contains { scheme in
@@ -51,7 +88,7 @@ extension SchemeState {
 
             return conditions.contains { condition in
                 guard let deviceMatcher = condition.device,
-                      deviceMatcher.match(with: device) else {
+                      deviceConditionMatches(deviceMatcher, targetMatcher: matcher, targetDevice: device) else {
                     return false
                 }
 
@@ -63,11 +100,12 @@ extension SchemeState {
         }
     }
 
-    private func deleteMatchingSchemes(for device: Device?, app: AppTarget?, display: String?) {
-        guard let device else {
-            return
-        }
-
+    private func deleteMatchingSchemes(
+        for matcher: DeviceMatcher?,
+        device: Device?,
+        app: AppTarget?,
+        display: String?
+    ) {
         let (appId, processPath) = extractAppComponents(from: app)
 
         schemes.removeAll { scheme in
@@ -77,7 +115,7 @@ extension SchemeState {
 
             return conditions.contains { condition in
                 guard let deviceMatcher = condition.device,
-                      deviceMatcher.match(with: device) else {
+                      deviceConditionMatches(deviceMatcher, targetMatcher: matcher, targetDevice: device) else {
                     return false
                 }
 
@@ -90,7 +128,7 @@ extension SchemeState {
     }
 
     var isSchemeValid: Bool {
-        guard device != nil else {
+        guard deviceMatcher != nil else {
             return false
         }
 
@@ -113,16 +151,28 @@ extension SchemeState {
         }
     }
 
+    var targetSpecificSchemes: [EnumeratedSequence<[Scheme]>.Element] {
+        guard let deviceMatcher else {
+            return []
+        }
+
+        if let category = deviceMatcher.categoryOnlyValue {
+            return schemes.allDeviceCategorySpecificSchemes(of: category)
+        }
+
+        return schemes.allDeviceMatcherSpecificSchemes(of: deviceMatcher)
+    }
+
     var scheme: Scheme {
         get {
-            guard let device else {
+            guard let deviceMatcher else {
                 return Scheme()
             }
 
             let (app, processPath) = extractAppComponents(from: currentApp)
 
             if case let .at(index) = schemes.schemeIndex(
-                ofDevice: device,
+                ofDeviceMatcher: deviceMatcher,
                 ofApp: app,
                 ofProcessPath: processPath,
                 ofDisplay: currentDisplay
@@ -130,7 +180,7 @@ extension SchemeState {
                 return schemes[index]
             }
 
-            var ifCondition = Scheme.If(device: .init(of: device))
+            var ifCondition = Scheme.If(device: deviceMatcher)
             ifCondition.app = app
             ifCondition.processPath = processPath
             ifCondition.display = currentDisplay
@@ -139,14 +189,14 @@ extension SchemeState {
         }
 
         set {
-            guard let device else {
+            guard let deviceMatcher else {
                 return
             }
 
             let (app, processPath) = extractAppComponents(from: currentApp)
 
             switch schemes.schemeIndex(
-                ofDevice: device,
+                ofDeviceMatcher: deviceMatcher,
                 ofApp: app,
                 ofProcessPath: processPath,
                 ofDisplay: currentDisplay
@@ -208,14 +258,14 @@ extension SchemeState {
     }
 
     var mergedScheme: Scheme {
-        guard let device else {
+        guard let deviceMatcher else {
             return Scheme()
         }
 
         let (app, processPath) = extractAppComponents(from: currentApp)
 
         return configurationState.configuration.matchScheme(
-            withDevice: device,
+            withDeviceMatcher: deviceMatcher,
             withApp: app,
             withDisplay: currentDisplay,
             withProcessPath: processPath
@@ -226,23 +276,31 @@ extension SchemeState {
         hasMatchingSchemes(forApp: currentApp, forDisplay: currentDisplay)
     }
 
+    func hasMatchingSchemes(for matcher: DeviceMatcher?, forApp app: AppTarget?, forDisplay display: String?) -> Bool {
+        hasMatchingSchemes(for: matcher, device: nil, app: app, display: display)
+    }
+
     func hasMatchingSchemes(for device: Device?, forApp app: AppTarget?, forDisplay display: String?) -> Bool {
-        hasMatchingSchemes(for: device, app: app, display: display)
+        hasMatchingSchemes(for: device.map { DeviceMatcher(of: $0) }, device: device, app: app, display: display)
     }
 
     func hasMatchingSchemes(forApp app: AppTarget?, forDisplay display: String?) -> Bool {
-        hasMatchingSchemes(for: device, app: app, display: display)
+        hasMatchingSchemes(for: deviceMatcher, device: nil, app: app, display: display)
     }
 
     func deleteMatchingSchemes() {
         deleteMatchingSchemes(forApp: currentApp, forDisplay: currentDisplay)
     }
 
+    func deleteMatchingSchemes(for matcher: DeviceMatcher?, forApp app: AppTarget?, forDisplay display: String?) {
+        deleteMatchingSchemes(for: matcher, device: nil, app: app, display: display)
+    }
+
     func deleteMatchingSchemes(for device: Device?, forApp app: AppTarget?, forDisplay display: String?) {
-        deleteMatchingSchemes(for: device, app: app, display: display)
+        deleteMatchingSchemes(for: device.map { DeviceMatcher(of: $0) }, device: device, app: app, display: display)
     }
 
     func deleteMatchingSchemes(forApp app: AppTarget?, forDisplay display: String?) {
-        deleteMatchingSchemes(for: device, app: app, display: display)
+        deleteMatchingSchemes(for: deviceMatcher, device: nil, app: app, display: display)
     }
 }

--- a/LinearMouse/UI/Header/AppIndicator/AppPickerSheet/AppPickerState.swift
+++ b/LinearMouse/UI/Header/AppIndicator/AppPickerSheet/AppPickerState.swift
@@ -9,7 +9,6 @@ class AppPickerState: ObservableObject {
     static let shared: AppPickerState = .init()
 
     private let schemeState: SchemeState = .shared
-    private let deviceState: DeviceState = .shared
 
     @Published var installedApps: [InstalledApp] = []
 
@@ -18,11 +17,7 @@ class AppPickerState: ObservableObject {
     }
 
     private var configuredAppSet: Set<String> {
-        guard let device = deviceState.currentDeviceRef?.value else {
-            return []
-        }
-
-        return Set(schemeState.schemes.allDeviceSpecficSchemes(of: device).reduce([String]()) { acc, element in
+        Set(schemeState.targetSpecificSchemes.reduce([String]()) { acc, element in
             guard let app = element.element.if?.first?.app else {
                 return acc
             }
@@ -31,11 +26,7 @@ class AppPickerState: ObservableObject {
     }
 
     private var configuredExecutableSet: Set<String> {
-        guard let device = deviceState.currentDeviceRef?.value else {
-            return []
-        }
-
-        return Set(schemeState.schemes.allDeviceSpecficSchemes(of: device).reduce([String]()) { acc, element in
+        Set(schemeState.targetSpecificSchemes.reduce([String]()) { acc, element in
             guard let processPath = element.element.if?.first?.processPath else {
                 return acc
             }

--- a/LinearMouse/UI/Header/DeviceIndicator/DeviceIndicatorState.swift
+++ b/LinearMouse/UI/Header/DeviceIndicator/DeviceIndicatorState.swift
@@ -20,6 +20,14 @@ class DeviceIndicatorState: ObservableObject {
             }
             .store(in: &subscriptions)
 
+        deviceState.$currentDeviceMatcher
+            .debounce(for: 0.1, scheduler: RunLoop.main)
+            .removeDuplicates()
+            .sink { [weak self] _ in
+                self?.refreshActiveDeviceName()
+            }
+            .store(in: &subscriptions)
+
         DeviceManager.shared
             .$receiverPairedDeviceIdentities
             .receive(on: RunLoop.main)
@@ -44,6 +52,11 @@ extension DeviceIndicatorState {
     }
 
     private func refreshActiveDeviceName() {
+        if let category = deviceState.currentDeviceMatcher?.categoryOnlyValue {
+            activeDeviceName = displayName(for: category)
+            return
+        }
+
         guard let device = deviceState.currentDeviceRef?.value else {
             activeDeviceName = nil
             return
@@ -55,5 +68,14 @@ extension DeviceIndicatorState {
         }
 
         activeDeviceName = DeviceManager.shared.displayName(for: device)
+    }
+
+    private func displayName(for category: DeviceMatcher.Category) -> String {
+        switch category {
+        case .mouse:
+            return NSLocalizedString("All Mice", comment: "")
+        case .trackpad:
+            return NSLocalizedString("All Trackpads", comment: "")
+        }
     }
 }

--- a/LinearMouse/UI/Header/DeviceIndicator/DevicePickerSheet/DevicePicker.swift
+++ b/LinearMouse/UI/Header/DeviceIndicator/DevicePickerSheet/DevicePicker.swift
@@ -3,24 +3,52 @@
 
 import SwiftUI
 
+enum DevicePickerSelection {
+    case category(DeviceMatcher.Category)
+    case device(WeakRef<Device>)
+
+    var deviceRef: WeakRef<Device>? {
+        guard case let .device(deviceRef) = self else {
+            return nil
+        }
+
+        return deviceRef
+    }
+
+    var deviceMatcher: DeviceMatcher? {
+        switch self {
+        case let .category(category):
+            return DeviceMatcher(category: category)
+        case let .device(deviceRef):
+            return deviceRef.value.map { DeviceMatcher(of: $0) }
+        }
+    }
+}
+
 struct DevicePicker: View {
     @ObservedObject var state = DevicePickerState.shared
 
-    @Binding var selectedDeviceRef: WeakRef<Device>?
+    @Binding var selection: DevicePickerSelection?
+    var onSelectCategory: (DeviceMatcher.Category) -> Void
     var onSelectDevice: (WeakRef<Device>) -> Void
 
     var body: some View {
         ScrollView {
             VStack(alignment: .leading, spacing: 20) {
                 DevicePickerSection(
-                    selectedDeviceRef: $selectedDeviceRef, title: "Mouse",
+                    selection: $selection,
+                    category: .mouse,
+                    title: "Mouse",
                     devices: state.devices.filter(\.isMouse),
+                    onSelectCategory: onSelectCategory,
                     onSelectDevice: onSelectDevice
                 )
                 DevicePickerSection(
-                    selectedDeviceRef: $selectedDeviceRef,
+                    selection: $selection,
+                    category: .trackpad,
                     title: "Trackpad",
                     devices: state.devices.filter(\.isTrackpad),
+                    onSelectCategory: onSelectCategory,
                     onSelectDevice: onSelectDevice
                 )
             }

--- a/LinearMouse/UI/Header/DeviceIndicator/DevicePickerSheet/DevicePickerSection.swift
+++ b/LinearMouse/UI/Header/DeviceIndicator/DevicePickerSheet/DevicePickerSection.swift
@@ -4,10 +4,12 @@
 import SwiftUI
 
 struct DevicePickerSection: View {
-    @Binding var selectedDeviceRef: WeakRef<Device>?
+    @Binding var selection: DevicePickerSelection?
 
+    var category: DeviceMatcher.Category
     var title: LocalizedStringKey
     var devices: [DeviceModel]
+    var onSelectCategory: (DeviceMatcher.Category) -> Void
     var onSelectDevice: (WeakRef<Device>) -> Void
 
     var body: some View {
@@ -17,12 +19,20 @@ struct DevicePickerSection: View {
                 .foregroundColor(.secondary)
 
             VStack(spacing: 8) {
+                DevicePickerCategoryItem(
+                    category: category,
+                    isSelected: isCategorySelected
+                ) {
+                    selection = .category(category)
+                    onSelectCategory(category)
+                }
+
                 ForEach(devices) { deviceModel in
                     DevicePickerSectionItem(
                         deviceModel: deviceModel,
                         isSelected: isSelected(deviceModel)
                     ) {
-                        selectedDeviceRef = deviceModel.deviceRef
+                        selection = .device(deviceModel.deviceRef)
                         onSelectDevice(deviceModel.deviceRef)
                     }
                 }
@@ -31,8 +41,17 @@ struct DevicePickerSection: View {
         .frame(maxWidth: .infinity, alignment: .leading)
     }
 
+    private var isCategorySelected: Bool {
+        guard case let .category(selectedCategory) = selection else {
+            return false
+        }
+
+        return selectedCategory == category
+    }
+
     private func isSelected(_ deviceModel: DeviceModel) -> Bool {
-        guard let selectedDevice = selectedDeviceRef?.value else {
+        guard case let .device(selectedDeviceRef) = selection,
+              let selectedDevice = selectedDeviceRef.value else {
             return false
         }
 

--- a/LinearMouse/UI/Header/DeviceIndicator/DevicePickerSheet/DevicePickerSectionItem.swift
+++ b/LinearMouse/UI/Header/DeviceIndicator/DevicePickerSheet/DevicePickerSectionItem.swift
@@ -80,6 +80,56 @@ struct DevicePickerSectionItem: View {
     }
 }
 
+struct DevicePickerCategoryItem: View {
+    var category: DeviceMatcher.Category
+    var isSelected: Bool
+    var action: () -> Void
+
+    var body: some View {
+        Button(action: action) {
+            HStack(spacing: 12) {
+                VStack(alignment: .leading, spacing: 3) {
+                    Text(category.devicePickerTitle)
+                        .font(.body)
+                    Text(category.devicePickerDescription)
+                        .font(.subheadline)
+                        .foregroundColor(.secondary)
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+
+                if isSelected, #available(macOS 11.0, *) {
+                    Image(systemName: "checkmark")
+                        .font(.system(size: 13, weight: .semibold))
+                        .foregroundColor(.accentColor)
+                        .accessibilityHidden(true)
+                }
+            }
+            .frame(maxWidth: .infinity, minHeight: 44, alignment: .leading)
+        }
+        .buttonStyle(DeviceButtonStyle(isSelected: isSelected))
+    }
+}
+
+private extension DeviceMatcher.Category {
+    var devicePickerTitle: LocalizedStringKey {
+        switch self {
+        case .mouse:
+            return "All Mice"
+        case .trackpad:
+            return "All Trackpads"
+        }
+    }
+
+    var devicePickerDescription: LocalizedStringKey {
+        switch self {
+        case .mouse:
+            return "Applies to every mouse."
+        case .trackpad:
+            return "Applies to every trackpad."
+        }
+    }
+}
+
 private struct BatteryLevelIndicator: View {
     let level: Int
     var compact = false

--- a/LinearMouse/UI/Header/DeviceIndicator/DevicePickerSheet/DevicePickerSheet.swift
+++ b/LinearMouse/UI/Header/DeviceIndicator/DevicePickerSheet/DevicePickerSheet.swift
@@ -7,26 +7,27 @@ import SwiftUI
 struct DevicePickerSheet: View {
     @Binding var isPresented: Bool
     @State private var autoSwitchToActiveDevice = Defaults[.autoSwitchToActiveDevice]
-    @State private var selectedDeviceRef: WeakRef<Device>?
+    @State private var selection: DevicePickerSelection?
     @State private var showDeleteAlert = false
 
     @ObservedObject private var schemeState: SchemeState = .shared
     @ObservedObject private var deviceState: DeviceState = .shared
+    @ObservedObject private var deviceManager: DeviceManager = .shared
 
-    private var selectedDevice: Device? {
-        selectedDeviceRef?.value
+    private var selectedDeviceMatcher: DeviceMatcher? {
+        selection?.deviceMatcher
     }
 
     private var shouldShowDeleteButton: Bool {
         schemeState.hasMatchingSchemes(
-            for: selectedDevice,
+            for: selectedDeviceMatcher,
             forApp: schemeState.currentApp,
             forDisplay: schemeState.currentDisplay
         )
     }
 
     private var canConfirm: Bool {
-        autoSwitchToActiveDevice || selectedDeviceRef?.value != nil
+        autoSwitchToActiveDevice || selectedDeviceMatcher != nil
     }
 
     private var autoSwitchBinding: Binding<Bool> {
@@ -35,7 +36,7 @@ struct DevicePickerSheet: View {
             set: { newValue in
                 autoSwitchToActiveDevice = newValue
                 if newValue {
-                    syncSelectionWithCurrentDevice()
+                    syncSelectionWithActiveDevice()
                 }
             }
         )
@@ -61,9 +62,11 @@ struct DevicePickerSheet: View {
             .padding(.horizontal, 18)
             .padding(.top, 18)
 
-            DevicePicker(selectedDeviceRef: $selectedDeviceRef) { deviceRef in
-                handleDeviceSelection(deviceRef)
-            }
+            DevicePicker(
+                selection: $selection,
+                onSelectCategory: handleCategorySelection,
+                onSelectDevice: handleDeviceSelection
+            )
             .frame(minHeight: 248, maxHeight: 320)
 
             HStack(spacing: 8) {
@@ -94,11 +97,17 @@ struct DevicePickerSheet: View {
         }
         .onAppear {
             autoSwitchToActiveDevice = Defaults[.autoSwitchToActiveDevice]
-            syncSelectionWithCurrentDevice()
-        }
-        .onReceive(deviceState.$currentDeviceRef.receive(on: RunLoop.main)) { currentDeviceRef in
             if autoSwitchToActiveDevice {
-                selectedDeviceRef = currentDeviceRef
+                syncSelectionWithActiveDevice()
+            } else if let selectedDevice = Defaults[.selectedDevice] {
+                selection = selection(for: selectedDevice)
+            } else {
+                syncSelectionWithCurrentDevice()
+            }
+        }
+        .onReceive(deviceManager.$lastActiveDeviceRef.receive(on: RunLoop.main)) { lastActiveDeviceRef in
+            if autoSwitchToActiveDevice {
+                selection = lastActiveDeviceRef.map { .device($0) }
             }
         }
         .alert(isPresented: $showDeleteAlert) {
@@ -117,27 +126,53 @@ struct DevicePickerSheet: View {
         showDeleteAlert = true
     }
 
+    private func handleCategorySelection(_ category: DeviceMatcher.Category) {
+        selection = .category(category)
+        autoSwitchToActiveDevice = false
+    }
+
     private func handleDeviceSelection(_ deviceRef: WeakRef<Device>) {
-        selectedDeviceRef = deviceRef
+        selection = .device(deviceRef)
 
         let isSelectingActiveDevice = deviceRef.value === DeviceManager.shared.lastActiveDeviceRef?.value
         if isSelectingActiveDevice {
             autoSwitchToActiveDevice = true
-            syncSelectionWithCurrentDevice()
+            syncSelectionWithActiveDevice()
         } else if autoSwitchToActiveDevice {
             autoSwitchToActiveDevice = false
         }
     }
 
+    private func syncSelectionWithActiveDevice() {
+        selection = deviceManager.lastActiveDeviceRef.map { .device($0) }
+    }
+
     private func syncSelectionWithCurrentDevice() {
-        selectedDeviceRef = deviceState.currentDeviceRef
+        selection = deviceState.currentDeviceRef.map { .device($0) }
+    }
+
+    private func selection(for matcher: DeviceMatcher) -> DevicePickerSelection? {
+        if let category = matcher.categoryOnlyValue {
+            return .category(category)
+        }
+
+        return DevicePickerState.shared
+            .devices
+            .first { deviceModel in
+                guard let device = deviceModel.deviceRef.value else {
+                    return false
+                }
+
+                return matcher.match(with: device)
+            }
+            .map { .device($0.deviceRef) }
     }
 
     private func onOK() {
         Defaults[.autoSwitchToActiveDevice] = autoSwitchToActiveDevice
 
         if !autoSwitchToActiveDevice {
-            deviceState.currentDeviceRef = selectedDeviceRef
+            Defaults[.selectedDevice] = selectedDeviceMatcher
         }
 
         isPresented = false
@@ -145,7 +180,7 @@ struct DevicePickerSheet: View {
 
     private func confirmDelete() {
         schemeState.deleteMatchingSchemes(
-            for: selectedDevice,
+            for: selectedDeviceMatcher,
             forApp: schemeState.currentApp,
             forDisplay: schemeState.currentDisplay
         )

--- a/LinearMouseUnitTests/Model/ConfigurationTests.swift
+++ b/LinearMouseUnitTests/Model/ConfigurationTests.swift
@@ -38,6 +38,44 @@ final class ConfigurationTests: XCTestCase {
         XCTAssertEqual(scheme.scrolling.reverse.horizontal, true)
     }
 
+    func testMatchSchemeWithDeviceCategoryDoesNotMergeDeviceSpecificSchemes() {
+        var categoryScheme = Scheme(if: [.init(device: DeviceMatcher(category: .mouse))])
+        categoryScheme.pointer.disableAcceleration = true
+
+        var specificMatcher = DeviceMatcher(category: .mouse)
+        specificMatcher.vendorID = 1
+        specificMatcher.productID = 2
+
+        var deviceSpecificScheme = Scheme(if: [.init(device: specificMatcher)])
+        deviceSpecificScheme.pointer.disableAcceleration = false
+
+        let configuration = Configuration(schemes: [categoryScheme, deviceSpecificScheme])
+        let matchedScheme = configuration.matchScheme(withDeviceMatcher: DeviceMatcher(category: .mouse))
+
+        XCTAssertEqual(matchedScheme.pointer.disableAcceleration, true)
+    }
+
+    func testDeviceCategorySchemeInsertsBeforeDeviceSpecificSchemes() {
+        var specificMatcher = DeviceMatcher(category: .mouse)
+        specificMatcher.vendorID = 1
+        specificMatcher.productID = 2
+
+        let schemes = [Scheme(if: [.init(device: specificMatcher)])]
+        let index = schemes.schemeIndex(
+            ofDeviceCategory: .mouse,
+            ofApp: nil,
+            ofProcessPath: nil,
+            ofDisplay: nil
+        )
+
+        guard case let .insertAt(insertIndex) = index else {
+            XCTFail("Expected insertion index")
+            return
+        }
+
+        XCTAssertEqual(insertIndex, 0)
+    }
+
     func testMergeAutoScroll() {
         var scheme = Scheme()
         scheme.buttons.autoScroll.enabled = true

--- a/LinearMouseUnitTests/Model/ConfigurationTests.swift
+++ b/LinearMouseUnitTests/Model/ConfigurationTests.swift
@@ -55,6 +55,25 @@ final class ConfigurationTests: XCTestCase {
         XCTAssertEqual(matchedScheme.pointer.disableAcceleration, true)
     }
 
+    func testMatchSchemeWithSpecificDeviceMatcherMergesDeviceCategorySchemes() {
+        var categoryScheme = Scheme(if: [.init(device: DeviceMatcher(category: .mouse))])
+        categoryScheme.pointer.disableAcceleration = true
+        categoryScheme.scrolling.reverse.vertical = true
+
+        var specificMatcher = DeviceMatcher(category: .mouse)
+        specificMatcher.vendorID = 1
+        specificMatcher.productID = 2
+
+        var deviceSpecificScheme = Scheme(if: [.init(device: specificMatcher)])
+        deviceSpecificScheme.pointer.disableAcceleration = false
+
+        let configuration = Configuration(schemes: [categoryScheme, deviceSpecificScheme])
+        let matchedScheme = configuration.matchScheme(withDeviceMatcher: specificMatcher)
+
+        XCTAssertEqual(matchedScheme.pointer.disableAcceleration, false)
+        XCTAssertEqual(matchedScheme.scrolling.reverse.vertical, true)
+    }
+
     func testDeviceCategorySchemeInsertsBeforeDeviceSpecificSchemes() {
         var specificMatcher = DeviceMatcher(category: .mouse)
         specificMatcher.vendorID = 1


### PR DESCRIPTION
## Summary
- Add All Mice and All Trackpads options to Device Picker so users can configure default settings for each device category from the UI.
- Keep category schemes before device-specific schemes so individual device settings can override mouse/trackpad defaults.
- Keep auto-switch selection highlighting synced with the active device.
- Add localizations for the new Device Picker strings.

## Testing
- jq empty LinearMouse/Localizable.xcstrings
- git diff --check
- xcodebuild test -project LinearMouse.xcodeproj -scheme LinearMouse -only-testing:LinearMouseUnitTests/ConfigurationTests -derivedDataPath /tmp/linearmouse-category-device-schemes-derived-data

Closes #1215.