### PR TITLE
Add read-only Logitech Bolt receiver monitoring

### DIFF
--- a/LinearMouse/Device/ReceiverMonitor.swift
+++ b/LinearMouse/Device/ReceiverMonitor.swift
@@ -315,6 +315,7 @@ private final class ReceiverContext {
 
             // Wait for connection events (event-driven, no periodic rescan)
             let connectionSnapshots = provider.waitForReceiverConnectionChange(
+                for: device.pointerDevice,
                 using: receiverChannel,
                 timeout: ReceiverMonitor.refreshInterval
             ) { [weak self] in
@@ -327,7 +328,7 @@ private final class ReceiverContext {
 
             guard !connectionSnapshots.isEmpty else {
                 // Timeout with no events — verify channel is still alive
-                if receiverChannel.readNotificationFlags() == nil {
+                if !provider.receiverChannelIsReachable(for: device.pointerDevice, using: receiverChannel) {
                     os_log(
                         "Receiver channel appears dead, will reopen: locationID=%{public}d device=%{public}@",
                         log: ReceiverMonitor.log,

--- a/LinearMouse/Device/VendorSpecific/Logitech/LogitechBoltReceiverSupport.swift
+++ b/LinearMouse/Device/VendorSpecific/Logitech/LogitechBoltReceiverSupport.swift
@@ -1,0 +1,367 @@
+// MIT License
+// Copyright (c) 2021-2026 LinearMouse
+
+import Foundation
+import os.log
+
+private struct BoltHIDPP10Report {
+    let bytes: [UInt8]
+}
+
+extension LogitechReceiverChannel {
+    func discoverBoltSlots() -> LogitechHIDPPDeviceMetadataProvider.ReceiverSlotDiscovery? {
+        guard readBoltUniqueID() != nil else {
+            os_log(
+                "Bolt receiver unique ID is unavailable: locationID=%{public}@",
+                log: LogitechHIDPPDeviceMetadataProvider.log,
+                type: .info,
+                locationID.map(String.init) ?? "(nil)"
+            )
+            return nil
+        }
+
+        let connectedDeviceCount = readBoltConnectionState().flatMap {
+            LogitechHIDPPDeviceMetadataProvider.parseConnectedDeviceCount($0.bytes)
+        }
+        let connectionSnapshots = discoverBoltConnectionSnapshots(expectedCount: connectedDeviceCount)
+        let pairedSlots = (UInt8(1) ... UInt8(6)).compactMap {
+            discoverBoltSlotInfo($0, connectionSnapshot: connectionSnapshots[$0])
+        }
+
+        return pairedSlots.isEmpty ? nil : .init(slots: pairedSlots, connectionSnapshots: connectionSnapshots)
+    }
+
+    func discoverBoltSlotInfo(
+        _ slot: UInt8,
+        connectionSnapshot: LogitechHIDPPDeviceMetadataProvider.ReceiverConnectionSnapshot? = nil
+    ) -> LogitechHIDPPDeviceMetadataProvider.ReceiverSlotInfo? {
+        let metadataProvider = LogitechHIDPPDeviceMetadataProvider()
+        let pairingResponse = boltReceiverInfoRequest(subregister: UInt8(0x50 + Int(slot)))
+        let nameResponse = boltReceiverInfoRequest(subregister: UInt8(0x60 + Int(slot)), parameters: [0x01])
+
+        guard pairingResponse != nil || nameResponse != nil else {
+            return nil
+        }
+
+        let routedTransport = LogitechHIDPPTransport(device: self, deviceIndex: slot)
+        let routedName = routedTransport.flatMap { transport in
+            metadataProvider.readFriendlyName(using: transport) ?? metadataProvider.readName(using: transport)
+        }
+        let batteryLevel = routedTransport.flatMap {
+            metadataProvider.readReceiverBatteryLevel(using: $0)
+        }
+        let kind = connectionSnapshot?.kind
+            ?? pairingResponse.flatMap { Self.parseBoltReceiverKind($0.bytes) }
+            ?? 0
+        let name = routedName ?? nameResponse.flatMap { Self.parseBoltReceiverName($0.bytes) }
+
+        return .init(
+            slot: slot,
+            kind: kind,
+            name: name,
+            productID: pairingResponse.flatMap { Self.parseBoltReceiverProductID($0.bytes) },
+            serialNumber: pairingResponse.flatMap { Self.parseBoltReceiverSerialNumber($0.bytes) },
+            batteryLevel: batteryLevel,
+            hasLiveMetadata: routedName != nil || batteryLevel != nil
+        )
+    }
+
+    func discoverBoltPointingDeviceDiscovery(
+        baseName: String
+    ) -> LogitechHIDPPDeviceMetadataProvider.ReceiverPointingDeviceDiscovery {
+        guard let locationID,
+              let discovery = discoverBoltSlots()
+        else {
+            return .init(identities: [], connectionSnapshots: [:], liveReachableSlots: [])
+        }
+
+        let liveReachableSlots = Set(discovery.slots.compactMap { slot in
+            slot.hasLiveMetadata ? slot.slot : nil
+        })
+
+        let identities = discovery.slots.compactMap { slot -> ReceiverLogicalDeviceIdentity? in
+            guard let kind = ReceiverLogicalDeviceKind(rawValue: slot.kind), kind.isPointingDevice else {
+                return nil
+            }
+
+            return ReceiverLogicalDeviceIdentity(
+                receiverLocationID: locationID,
+                slot: slot.slot,
+                kind: kind,
+                name: slot.name ?? baseName,
+                serialNumber: slot.serialNumber,
+                productID: slot.productID,
+                batteryLevel: slot.batteryLevel
+            )
+        }
+
+        return .init(
+            identities: identities,
+            connectionSnapshots: discovery.connectionSnapshots,
+            liveReachableSlots: liveReachableSlots
+        )
+    }
+
+    private func readBoltUniqueID() -> BoltHIDPP10Report? {
+        boltHIDPP10LongRequest(register: 0xFB, parameters: [])
+    }
+
+    private func readBoltConnectionState() -> BoltHIDPP10Report? {
+        boltHIDPP10ShortRequest(
+            subID: 0x81,
+            register: LogitechHIDPPDeviceMetadataProvider.Constants.receiverConnectionStateRegister,
+            parameters: [0, 0, 0]
+        )
+    }
+
+    private func triggerBoltConnectionNotifications() -> Bool {
+        boltHIDPP10ShortRequest(
+            subID: 0x80,
+            register: LogitechHIDPPDeviceMetadataProvider.Constants.receiverConnectionStateRegister,
+            parameters: [0x02, 0x00, 0x00]
+        ) != nil
+    }
+
+    private func discoverBoltConnectionSnapshots(
+        expectedCount: Int? = nil
+    ) -> [UInt8: LogitechHIDPPDeviceMetadataProvider.ReceiverConnectionSnapshot] {
+        guard triggerBoltConnectionNotifications() else {
+            return [:]
+        }
+
+        return collectBoltConnectionSnapshots(timeout: 0.5, expectedCount: expectedCount, until: nil)
+    }
+
+    func waitForBoltConnectionSnapshots(
+        timeout: TimeInterval,
+        until shouldContinue: (() -> Bool)? = nil
+    ) -> [UInt8: LogitechHIDPPDeviceMetadataProvider.ReceiverConnectionSnapshot] {
+        guard triggerBoltConnectionNotifications() else {
+            return [:]
+        }
+
+        guard let initialNotification = waitForBoltConnectionNotification(
+            timeout: timeout,
+            until: shouldContinue
+        ) else {
+            return [:]
+        }
+
+        var snapshots = [initialNotification.slot: initialNotification.snapshot]
+        let deadline = Date().addingTimeInterval(0.1)
+        while Date() < deadline, shouldContinue?() ?? true {
+            guard let notification = waitForBoltConnectionNotification(timeout: 0.02, until: shouldContinue) else {
+                continue
+            }
+
+            snapshots[notification.slot] = notification.snapshot
+        }
+
+        return snapshots
+    }
+
+    func isBoltReceiverReachable() -> Bool {
+        readBoltUniqueID() != nil
+    }
+
+    private func collectBoltConnectionSnapshots(
+        timeout: TimeInterval,
+        expectedCount: Int? = nil,
+        until shouldContinue: (() -> Bool)? = nil
+    ) -> [UInt8: LogitechHIDPPDeviceMetadataProvider.ReceiverConnectionSnapshot] {
+        var snapshots = [UInt8: LogitechHIDPPDeviceMetadataProvider.ReceiverConnectionSnapshot]()
+        let deadline = Date().addingTimeInterval(timeout)
+        while Date() < deadline, shouldContinue?() ?? true {
+            guard let report = waitForHIDPPNotification(
+                timeout: 0.05,
+                matching: { response in
+                    LogitechHIDPPDeviceMetadataProvider.parseReceiverConnectionNotification(response) != nil
+                },
+                until: shouldContinue
+            ) else {
+                if let expectedCount,
+                   snapshots.values.filter(\.isConnected).count >= expectedCount {
+                    break
+                }
+                continue
+            }
+
+            guard let notification = LogitechHIDPPDeviceMetadataProvider
+                .parseReceiverConnectionNotification(report) else {
+                continue
+            }
+
+            snapshots[notification.slot] = notification.snapshot
+            if let expectedCount,
+               snapshots.values.filter(\.isConnected).count >= expectedCount {
+                break
+            }
+        }
+
+        return snapshots
+    }
+
+    private func waitForBoltConnectionNotification(
+        timeout: TimeInterval,
+        until shouldContinue: (() -> Bool)?
+    ) -> (slot: UInt8, snapshot: LogitechHIDPPDeviceMetadataProvider.ReceiverConnectionSnapshot)? {
+        guard let report = waitForHIDPPNotification(
+            timeout: timeout,
+            matching: { response in
+                LogitechHIDPPDeviceMetadataProvider.parseReceiverConnectionNotification(response) != nil
+            },
+            until: shouldContinue
+        ) else {
+            return nil
+        }
+
+        return LogitechHIDPPDeviceMetadataProvider.parseReceiverConnectionNotification(report)
+    }
+
+    private func boltReceiverInfoRequest(
+        subregister: UInt8,
+        parameters: [UInt8] = []
+    ) -> BoltHIDPP10Report? {
+        boltHIDPP10LongRequest(
+            register: LogitechHIDPPDeviceMetadataProvider.Constants.receiverInfoRegister,
+            parameters: [subregister] + parameters,
+            firstParameter: subregister
+        )
+    }
+
+    private func boltHIDPP10ShortRequest(
+        subID: UInt8,
+        register: UInt8,
+        parameters: [UInt8]
+    ) -> BoltHIDPP10Report? {
+        var bytes = [UInt8](repeating: 0, count: LogitechHIDPPDeviceMetadataProvider.Constants.shortReportLength)
+        bytes[0] = LogitechHIDPPDeviceMetadataProvider.Constants.shortReportID
+        bytes[1] = LogitechHIDPPDeviceMetadataProvider.Constants.receiverIndex
+        bytes[2] = subID
+        bytes[3] = register
+        for (index, parameter) in parameters.prefix(3).enumerated() {
+            bytes[4 + index] = parameter
+        }
+
+        let response = performSynchronousOutputReportRequest(
+            Data(bytes),
+            timeout: LogitechHIDPPDeviceMetadataProvider.Constants.timeout
+        ) { report in
+            let reply = [UInt8](report)
+            guard reply.count >= LogitechHIDPPDeviceMetadataProvider.Constants.shortReportLength,
+                  [
+                      LogitechHIDPPDeviceMetadataProvider.Constants.shortReportID,
+                      LogitechHIDPPDeviceMetadataProvider.Constants.longReportID
+                  ].contains(reply[0]),
+                  reply[1] == LogitechHIDPPDeviceMetadataProvider.Constants.receiverIndex
+            else {
+                return false
+            }
+
+            if reply[2] == 0x8F {
+                return reply[3] == subID && reply[4] == register
+            }
+
+            return reply[2] == subID && reply[3] == register
+        }
+
+        guard let response else {
+            return nil
+        }
+
+        let responseBytes = Array(response)
+        return responseBytes[2] == 0x8F ? nil : .init(bytes: responseBytes)
+    }
+
+    private func boltHIDPP10LongRequest(
+        register: UInt8,
+        parameters: [UInt8],
+        firstParameter: UInt8? = nil
+    ) -> BoltHIDPP10Report? {
+        var bytes = [UInt8](repeating: 0, count: LogitechHIDPPDeviceMetadataProvider.Constants.shortReportLength)
+        bytes[0] = LogitechHIDPPDeviceMetadataProvider.Constants.shortReportID
+        bytes[1] = LogitechHIDPPDeviceMetadataProvider.Constants.receiverIndex
+        bytes[2] = 0x83
+        bytes[3] = register
+        for (index, parameter) in parameters.prefix(3).enumerated() {
+            bytes[4 + index] = parameter
+        }
+
+        let response = performSynchronousOutputReportRequest(
+            Data(bytes),
+            timeout: LogitechHIDPPDeviceMetadataProvider.Constants.timeout
+        ) { report in
+            let reply = [UInt8](report)
+            guard reply.count >= 5,
+                  [
+                      LogitechHIDPPDeviceMetadataProvider.Constants.shortReportID,
+                      LogitechHIDPPDeviceMetadataProvider.Constants.longReportID
+                  ].contains(reply[0]),
+                  reply[1] == LogitechHIDPPDeviceMetadataProvider.Constants.receiverIndex
+            else {
+                return false
+            }
+
+            if reply[2] == 0x8F {
+                return reply[3] == 0x83 && reply[4] == register
+            }
+
+            guard reply[2] == 0x83,
+                  reply[3] == register
+            else {
+                return false
+            }
+
+            if let firstParameter {
+                return reply.count > 4 && reply[4] == firstParameter
+            }
+
+            return true
+        }
+
+        guard let response else {
+            return nil
+        }
+
+        let responseBytes = Array(response)
+        return responseBytes[2] == 0x8F ? nil : .init(bytes: responseBytes)
+    }
+
+    static func parseBoltReceiverKind(_ response: [UInt8]) -> UInt8? {
+        guard response.count >= 6 else {
+            return nil
+        }
+
+        return response[5] & 0x0F
+    }
+
+    static func parseBoltReceiverProductID(_ response: [UInt8]) -> Int? {
+        guard response.count >= 8 else {
+            return nil
+        }
+
+        return Int(response[7]) << 8 | Int(response[6])
+    }
+
+    static func parseBoltReceiverSerialNumber(_ response: [UInt8]) -> String? {
+        guard response.count >= 12 else {
+            return nil
+        }
+
+        return response[8 ... 11].map { String(format: "%02X", $0) }.joined()
+    }
+
+    static func parseBoltReceiverName(_ response: [UInt8]) -> String? {
+        guard response.count >= 7 else {
+            return nil
+        }
+
+        let length = Int(response[6])
+        let bytes = Array(response.dropFirst(7).prefix(length))
+        guard !bytes.isEmpty else {
+            return nil
+        }
+
+        return String(bytes: bytes, encoding: .utf8)
+    }
+}

--- a/LinearMouse/Device/VendorSpecific/Logitech/LogitechHIDPPDeviceMetadataProvider.swift
+++ b/LinearMouse/Device/VendorSpecific/Logitech/LogitechHIDPPDeviceMetadataProvider.swift
@@ -43,6 +43,9 @@ struct LogitechHIDPPDeviceMetadataProvider: VendorSpecificDeviceMetadataProvider
             0xC52B, // Unifying receiver
             0xC532 // Unifying receiver
         ]
+        static let monitorableBoltReceiverProductIDs: Set<Int> = [
+            0xC548 // Bolt receiver
+        ]
         /// These are recognized as receiver dongles, but receiver monitoring is
         /// intentionally disabled until their protocol/transport path is implemented.
         static let knownReceiverProductIDsWithoutMonitoringSupport: Set<Int> = [
@@ -74,12 +77,11 @@ struct LogitechHIDPPDeviceMetadataProvider: VendorSpecificDeviceMetadataProvider
             0xC543,
             0xC545,
             0xC547,
-            0xC54D,
-            // Bolt receivers are a different receiver family.
-            0xC548
+            0xC54D
         ]
         static let knownReceiverProductIDs: Set<Int> = [
             monitorableReceiverProductIDs,
+            monitorableBoltReceiverProductIDs,
             knownReceiverProductIDsWithoutMonitoringSupport
         ].reduce(into: []) { result, productIDs in
             result.formUnion(productIDs)
@@ -222,15 +224,36 @@ struct LogitechHIDPPDeviceMetadataProvider: VendorSpecificDeviceMetadataProvider
         transports: [PointerDeviceTransportName.bluetoothLowEnergy, PointerDeviceTransportName.usb]
     )
 
-    static func supportsReceiverMonitoring(vendorID: Int?, productID: Int?, transport: String?) -> Bool {
+    enum ReceiverProtocolFamily {
+        case classic
+        case bolt
+    }
+
+    static func receiverProtocolFamily(vendorID: Int?, productID: Int?, transport: String?) -> ReceiverProtocolFamily? {
         guard vendorID == Constants.vendorID,
               transport == PointerDeviceTransportName.usb,
               let productID
         else {
-            return false
+            return nil
         }
 
-        return Constants.monitorableReceiverProductIDs.contains(productID)
+        if Constants.monitorableReceiverProductIDs.contains(productID) {
+            return .classic
+        }
+
+        if Constants.monitorableBoltReceiverProductIDs.contains(productID) {
+            return .bolt
+        }
+
+        return nil
+    }
+
+    static func supportsClassicReceiverMonitoring(vendorID: Int?, productID: Int?, transport: String?) -> Bool {
+        receiverProtocolFamily(vendorID: vendorID, productID: productID, transport: transport) == .classic
+    }
+
+    static func supportsReceiverMonitoring(vendorID: Int?, productID: Int?, transport: String?) -> Bool {
+        receiverProtocolFamily(vendorID: vendorID, productID: productID, transport: transport) != nil
     }
 
     static func isKnownReceiver(vendorID: Int?, productID: Int?) -> Bool {
@@ -356,7 +379,15 @@ struct LogitechHIDPPDeviceMetadataProvider: VendorSpecificDeviceMetadataProvider
         for device: VendorSpecificDeviceContext,
         using receiverChannel: LogitechReceiverChannel
     ) -> ReceiverPointingDeviceDiscovery {
-        receiverChannel.discoverPointingDeviceDiscovery(baseName: device.product ?? device.name)
+        if Self.receiverProtocolFamily(
+            vendorID: device.vendorID,
+            productID: device.productID,
+            transport: device.transport
+        ) == .bolt {
+            return receiverChannel.discoverBoltPointingDeviceDiscovery(baseName: device.product ?? device.name)
+        }
+
+        return receiverChannel.discoverPointingDeviceDiscovery(baseName: device.product ?? device.name)
     }
 
     func receiverSlotIdentity(
@@ -369,7 +400,18 @@ struct LogitechHIDPPDeviceMetadataProvider: VendorSpecificDeviceMetadataProvider
             return nil
         }
 
-        guard let slotInfo = receiverChannel.discoverSlotInfo(slot, connectionSnapshot: connectionSnapshot) else {
+        let slotInfo: ReceiverSlotInfo?
+        if Self.receiverProtocolFamily(
+            vendorID: device.vendorID,
+            productID: device.productID,
+            transport: device.transport
+        ) == .bolt {
+            slotInfo = receiverChannel.discoverBoltSlotInfo(slot, connectionSnapshot: connectionSnapshot)
+        } else {
+            slotInfo = receiverChannel.discoverSlotInfo(slot, connectionSnapshot: connectionSnapshot)
+        }
+
+        guard let slotInfo else {
             return nil
         }
 
@@ -413,17 +455,51 @@ struct LogitechHIDPPDeviceMetadataProvider: VendorSpecificDeviceMetadataProvider
             return [:]
         }
 
-        receiverChannel.enableWirelessNotifications()
-        return receiverChannel.waitForConnectionSnapshots(timeout: timeout, until: shouldContinue)
+        return waitForReceiverConnectionChange(
+            for: device,
+            using: receiverChannel,
+            timeout: timeout,
+            until: shouldContinue
+        )
     }
 
     func waitForReceiverConnectionChange(
+        for device: VendorSpecificDeviceContext,
         using receiverChannel: LogitechReceiverChannel,
         timeout: TimeInterval,
         until shouldContinue: @escaping () -> Bool
     ) -> [UInt8: ReceiverConnectionSnapshot] {
-        receiverChannel.enableWirelessNotifications()
-        return receiverChannel.waitForConnectionSnapshots(timeout: timeout, until: shouldContinue)
+        switch Self.receiverProtocolFamily(
+            vendorID: device.vendorID,
+            productID: device.productID,
+            transport: device.transport
+        ) {
+        case .classic:
+            receiverChannel.enableWirelessNotifications()
+            return receiverChannel.waitForConnectionSnapshots(timeout: timeout, until: shouldContinue)
+        case .bolt:
+            return receiverChannel.waitForBoltConnectionSnapshots(timeout: timeout, until: shouldContinue)
+        case nil:
+            return [:]
+        }
+    }
+
+    func receiverChannelIsReachable(
+        for device: VendorSpecificDeviceContext,
+        using receiverChannel: LogitechReceiverChannel
+    ) -> Bool {
+        switch Self.receiverProtocolFamily(
+            vendorID: device.vendorID,
+            productID: device.productID,
+            transport: device.transport
+        ) {
+        case .classic:
+            return receiverChannel.readNotificationFlags() != nil
+        case .bolt:
+            return receiverChannel.isBoltReceiverReachable()
+        case nil:
+            return false
+        }
     }
 
     private func metadata(using transport: LogitechHIDPPTransport) -> VendorSpecificDeviceMetadata? {
@@ -542,7 +618,7 @@ struct LogitechHIDPPDeviceMetadataProvider: VendorSpecificDeviceMetadataProvider
         }
     }
 
-    fileprivate func readFriendlyName(using transport: LogitechHIDPPTransport) -> String? {
+    func readFriendlyName(using transport: LogitechHIDPPTransport) -> String? {
         guard let featureIndex = transport.featureIndex(for: .deviceFriendlyName),
               let lengthResponse = transport.request(featureIndex: featureIndex, function: 0x00, parameters: []),
               let length = lengthResponse.payload.first,
@@ -559,7 +635,7 @@ struct LogitechHIDPPDeviceMetadataProvider: VendorSpecificDeviceMetadataProvider
         )
     }
 
-    fileprivate func readName(using transport: LogitechHIDPPTransport) -> String? {
+    func readName(using transport: LogitechHIDPPTransport) -> String? {
         guard let featureIndex = transport.featureIndex(for: .deviceName),
               let lengthResponse = transport.request(featureIndex: featureIndex, function: 0x00, parameters: []),
               let length = lengthResponse.payload.first,
@@ -649,7 +725,7 @@ struct LogitechHIDPPDeviceMetadataProvider: VendorSpecificDeviceMetadataProvider
         return nil
     }
 
-    fileprivate func readReceiverBatteryLevel(using transport: LogitechHIDPPTransport) -> Int? {
+    func readReceiverBatteryLevel(using transport: LogitechHIDPPTransport) -> Int? {
         readBatteryLevel(using: transport)
     }
 
@@ -1727,7 +1803,7 @@ final class LogitechReprogrammableControlsMonitor {
         case PointerDeviceTransportName.bluetoothLowEnergy:
             return true
         case PointerDeviceTransportName.usb:
-            return LogitechHIDPPDeviceMetadataProvider.supportsReceiverMonitoring(
+            return LogitechHIDPPDeviceMetadataProvider.supportsClassicReceiverMonitoring(
                 vendorID: vendorID,
                 productID: productID,
                 transport: transport

--- a/LinearMouseUnitTests/Device/VendorSpecificDeviceMetadataTests.swift
+++ b/LinearMouseUnitTests/Device/VendorSpecificDeviceMetadataTests.swift
@@ -82,6 +82,23 @@ final class VendorSpecificDeviceMetadataTests: XCTestCase {
         )
     }
 
+    func testLogitechReceiverMonitoringAllowsSupportedBoltReceiverProductIDs() {
+        XCTAssertTrue(
+            LogitechHIDPPDeviceMetadataProvider.supportsReceiverMonitoring(
+                vendorID: 0x046D,
+                productID: 0xC548,
+                transport: PointerDeviceTransportName.usb
+            )
+        )
+        XCTAssertFalse(
+            LogitechHIDPPDeviceMetadataProvider.supportsClassicReceiverMonitoring(
+                vendorID: 0x046D,
+                productID: 0xC548,
+                transport: PointerDeviceTransportName.usb
+            )
+        )
+    }
+
     func testLogitechReceiverMonitoringRejectsReceiversWithoutImplementedProtocolSupport() {
         XCTAssertFalse(
             LogitechHIDPPDeviceMetadataProvider.supportsReceiverMonitoring(
@@ -100,7 +117,7 @@ final class VendorSpecificDeviceMetadataTests: XCTestCase {
         XCTAssertFalse(
             LogitechHIDPPDeviceMetadataProvider.supportsReceiverMonitoring(
                 vendorID: 0x046D,
-                productID: 0xC548,
+                productID: 0xC541,
                 transport: PointerDeviceTransportName.usb
             )
         )
@@ -168,7 +185,7 @@ final class VendorSpecificDeviceMetadataTests: XCTestCase {
         XCTAssertEqual(device.outputReportRequestCount, 0)
     }
 
-    func testLogitechControlsMonitorUsesReceiverWhitelistForUsbDevices() {
+    func testLogitechControlsMonitorUsesReceiverAllowlistForUsbDevices() {
         XCTAssertTrue(
             LogitechReprogrammableControlsMonitor.supports(
                 vendorID: 0x046D,
@@ -180,6 +197,13 @@ final class VendorSpecificDeviceMetadataTests: XCTestCase {
             LogitechReprogrammableControlsMonitor.supports(
                 vendorID: 0x046D,
                 productID: 0xC539,
+                transport: PointerDeviceTransportName.usb
+            )
+        )
+        XCTAssertFalse(
+            LogitechReprogrammableControlsMonitor.supports(
+                vendorID: 0x046D,
+                productID: 0xC548,
                 transport: PointerDeviceTransportName.usb
             )
         )
@@ -204,6 +228,33 @@ final class VendorSpecificDeviceMetadataTests: XCTestCase {
                 transport: PointerDeviceTransportName.usb
             )
         )
+    }
+
+    func testBoltReceiverPairingInfoParserUsesBoltRegisterLayout() {
+        let response: [UInt8] = [
+            0x11, 0xFF, 0x83, 0xB5, 0x52, 0x02, 0x3E, 0xB0, 0xEF, 0x0F,
+            0x42, 0x5B, 0x02, 0x01, 0x80, 0x14, 0x01, 0x00, 0x00, 0x00
+        ]
+
+        XCTAssertEqual(LogitechReceiverChannel.parseBoltReceiverKind(response), 0x02)
+        XCTAssertEqual(LogitechReceiverChannel.parseBoltReceiverProductID(response), 0xB03E)
+        XCTAssertEqual(LogitechReceiverChannel.parseBoltReceiverSerialNumber(response), "EF0F425B")
+    }
+
+    func testBoltReceiverNameParserUsesAvailableNameFragment() {
+        let response: [UInt8] = [
+            0x11, 0xFF, 0x83, 0xB5, 0x62, 0x01, 0x0E, 0x4D, 0x58, 0x20,
+            0x45, 0x72, 0x67, 0x6F, 0x20, 0x53, 0x20, 0x50, 0x6C, 0x75
+        ]
+
+        XCTAssertEqual(LogitechReceiverChannel.parseBoltReceiverName(response), "MX Ergo S Plu")
+    }
+
+    func testBoltReceiverParsersRejectShortResponses() {
+        XCTAssertNil(LogitechReceiverChannel.parseBoltReceiverKind([0x11, 0xFF, 0x83]))
+        XCTAssertNil(LogitechReceiverChannel.parseBoltReceiverProductID([0x11, 0xFF, 0x83]))
+        XCTAssertNil(LogitechReceiverChannel.parseBoltReceiverSerialNumber([0x11, 0xFF, 0x83]))
+        XCTAssertNil(LogitechReceiverChannel.parseBoltReceiverName([0x11, 0xFF, 0x83]))
     }
 
     func testLogitechControlsMonitorNeedsMatchingDirectBluetoothLowEnergyConfiguration() {


### PR DESCRIPTION
## Summary

Adds minimal read-only monitoring support for Logitech Bolt receivers (`046D:C548`).

This allows LinearMouse to discover paired Bolt pointing devices and surface receiver-routed metadata such as name, product ID, serial number, battery level, and connection state where available.

This PR is intentionally scoped as a foundation for Bolt support. Additional Bolt features can be added later after this base receiver monitoring path is reviewed and approved.

## Details

- Adds Bolt receiver discovery using Bolt receiver information registers
- Publishes paired Bolt pointing devices through the existing `ReceiverLogicalDeviceIdentity` model
- Reuses existing routed HID++ metadata reads for friendly name/name and battery level when supported by the paired device
- Adds a Bolt-specific connection notification wait path
- Keeps receiver-routed Logitech reprogrammable controls disabled for Bolt

## Non-goals

This PR does not add Bolt support for:

- reprogrammable/special button monitoring
- DPI controls
- pairing or unpairing
- other mutating receiver/device configuration

## Testing

- `swiftformat --lint LinearMouse/Device/ReceiverMonitor.swift LinearMouse/Device/VendorSpecific/Logitech/LogitechHIDPPDeviceMetadataProvider.swift LinearMouse/Device/VendorSpecific/Logitech/LogitechBoltReceiverSupport.swift LinearMouseUnitTests/Device/VendorSpecificDeviceMetadataTests.swift`
- `swiftlint lint LinearMouse/Device/VendorSpecific/Logitech/LogitechBoltReceiverSupport.swift`
- `xcodebuild test -project LinearMouse.xcodeproj -scheme LinearMouse -only-testing:LinearMouseUnitTests/VendorSpecificDeviceMetadataTests`
- `git diff --check`

Hardware checked with a Logitech Bolt receiver (`046D:C548`) and a paired MX Ergo S Plus.