### PR TITLE
Fix Logitech gesture button click fallback

### DIFF
--- a/LinearMouse/Device/VendorSpecific/Logitech/LogitechHIDPPDeviceMetadataProvider.swift
+++ b/LinearMouse/Device/VendorSpecific/Logitech/LogitechHIDPPDeviceMetadataProvider.swift
@@ -2249,25 +2249,39 @@ final class LogitechReprogrammableControlsMonitor {
                             EventTransformerManager.shared.handleLogitechControlEvent(logitechContext)
                         } ?? .notHandled
 
-                        guard !handlingResult.suppressesSyntheticFallback else {
+                        let fallbackAction = state.syntheticFallbackAction(
+                            for: controlIdentity,
+                            isPressed: isPressed,
+                            handlingResult: handlingResult
+                        )
+
+                        guard fallbackAction != .suppress else {
                             continue
                         }
 
                         os_log(
-                            "Logitech control event was not handled internally; posting synthetic fallback: locationID=%{public}d slot=%{public}u device=%{public}@ cid=0x%{public}04X identityFallback=%{public}@",
+                            "Posting Logitech synthetic fallback: locationID=%{public}d slot=%{public}u device=%{public}@ cid=0x%{public}04X action=%{public}@ identityFallback=%{public}@",
                             log: Self.log,
                             type: .info,
                             locationID,
                             slot,
                             targetName,
                             controlID,
+                            String(describing: fallbackAction),
                             monitorTarget.allowsIdentityFallback ? "true" : "false"
                         )
 
-                        postSyntheticButton(
-                            button: reservedVirtualButtonNumber,
-                            down: isPressed
-                        )
+                        switch fallbackAction {
+                        case .suppress:
+                            break
+                        case .postCurrentEvent:
+                            postSyntheticButton(
+                                button: reservedVirtualButtonNumber,
+                                down: isPressed
+                            )
+                        case .postClick:
+                            postSyntheticClick(button: reservedVirtualButtonNumber)
+                        }
                     }
                 }
             }
@@ -2946,6 +2960,11 @@ final class LogitechReprogrammableControlsMonitor {
         SyntheticMouseButtonEventEmitter.post(button: button, down: down)
     }
 
+    private func postSyntheticClick(button: Int) {
+        postSyntheticButton(button: button, down: true)
+        postSyntheticButton(button: button, down: false)
+    }
+
     private func releaseButtonIfNeeded() {
         let buttonsToRelease = state.takePressedButtons()
 
@@ -3082,6 +3101,48 @@ final class LogitechReprogrammableControlsMonitor {
     }
 }
 
+enum LogitechSyntheticFallbackAction: Equatable {
+    case suppress
+    case postCurrentEvent
+    case postClick
+}
+
+struct LogitechSyntheticFallbackCoordinator {
+    private var deferredControls = Set<LogitechControlIdentity>()
+
+    mutating func action(
+        for controlIdentity: LogitechControlIdentity,
+        isPressed: Bool,
+        handlingResult: LogitechControlEventHandlingResult
+    ) -> LogitechSyntheticFallbackAction {
+        if isPressed {
+            switch handlingResult {
+            case .handledDeferringSyntheticFallback:
+                deferredControls.insert(controlIdentity)
+                return .suppress
+            case .handled:
+                deferredControls.remove(controlIdentity)
+                return .suppress
+            case .handledAllowingSyntheticFallback, .notHandled:
+                deferredControls.remove(controlIdentity)
+                return .postCurrentEvent
+            }
+        }
+
+        let wasDeferred = deferredControls.remove(controlIdentity) != nil
+
+        if handlingResult.suppressesSyntheticFallback {
+            return .suppress
+        }
+
+        return wasDeferred ? .postClick : .postCurrentEvent
+    }
+
+    mutating func reset() {
+        deferredControls.removeAll()
+    }
+}
+
 private final class LogitechReprogrammableControlsMonitorState {
     private typealias WorkerResources = (Thread?, HIDPPNotificationHandling?, ObservationToken?)
 
@@ -3095,6 +3156,7 @@ private final class LogitechReprogrammableControlsMonitorState {
     private var needsReconfiguration = false
     private var needsForcedReconfiguration = false
     private var pressedButtons = Set<Int>()
+    private var syntheticFallbackCoordinator = LogitechSyntheticFallbackCoordinator()
 
     var shouldContinueRunning: Bool {
         queue.sync { isEnabled } && !Thread.current.isCancelled
@@ -3245,9 +3307,26 @@ private final class LogitechReprogrammableControlsMonitorState {
         queue.sync { down ? pressedButtons.insert(button).inserted : pressedButtons.remove(button) != nil }
     }
 
+    func syntheticFallbackAction(
+        for controlIdentity: LogitechControlIdentity,
+        isPressed: Bool,
+        handlingResult: LogitechControlEventHandlingResult
+    ) -> LogitechSyntheticFallbackAction {
+        queue.sync {
+            syntheticFallbackCoordinator.action(
+                for: controlIdentity,
+                isPressed: isPressed,
+                handlingResult: handlingResult
+            )
+        }
+    }
+
     func takePressedButtons() -> Set<Int> {
         queue.sync {
-            defer { pressedButtons.removeAll() }
+            defer {
+                pressedButtons.removeAll()
+                syntheticFallbackCoordinator.reset()
+            }
             return pressedButtons
         }
     }

--- a/LinearMouse/EventTransformer/EventTransformer.swift
+++ b/LinearMouse/EventTransformer/EventTransformer.swift
@@ -13,9 +13,10 @@ enum LogitechControlEventHandlingResult {
     case notHandled
     case handled
     case handledAllowingSyntheticFallback
+    case handledDeferringSyntheticFallback
 
     var suppressesSyntheticFallback: Bool {
-        self == .handled
+        self == .handled || self == .handledDeferringSyntheticFallback
     }
 }
 

--- a/LinearMouse/EventTransformer/GestureButtonTransformer.swift
+++ b/LinearMouse/EventTransformer/GestureButtonTransformer.swift
@@ -298,7 +298,7 @@ extension GestureButtonTransformer: LogitechControlEventHandling {
                 }
 
                 state = .cooldown(until: until, released: true)
-                return .handledAllowingSyntheticFallback
+                return .handled
             }
             state = .idle
         }
@@ -309,7 +309,7 @@ extension GestureButtonTransformer: LogitechControlEventHandling {
             }
             state = .tracking(startTime: DispatchTime.now().uptimeNanoseconds, deltaX: 0, deltaY: 0)
             os_log("Started tracking gesture (Logitech control)", log: Self.log, type: .info)
-            return .handledAllowingSyntheticFallback
+            return .handledDeferringSyntheticFallback
         }
 
         switch state {

--- a/LinearMouseUnitTests/Device/VendorSpecificDeviceMetadataTests.swift
+++ b/LinearMouseUnitTests/Device/VendorSpecificDeviceMetadataTests.swift
@@ -473,6 +473,65 @@ final class VendorSpecificDeviceMetadataTests: XCTestCase {
         )
     }
 
+    func testLogitechSyntheticFallbackDefersGestureClickUntilRelease() {
+        var coordinator = LogitechSyntheticFallbackCoordinator()
+        let controlIdentity = LogitechControlIdentity(controlID: 0x00D0, productID: 0xB015, serialNumber: "ABC")
+
+        XCTAssertEqual(
+            coordinator.action(
+                for: controlIdentity,
+                isPressed: true,
+                handlingResult: .handledDeferringSyntheticFallback
+            ),
+            .suppress
+        )
+        XCTAssertEqual(
+            coordinator.action(for: controlIdentity, isPressed: false, handlingResult: .notHandled),
+            .postClick
+        )
+    }
+
+    func testLogitechSyntheticFallbackCancelsDeferredClickWhenGestureHandlesRelease() {
+        var coordinator = LogitechSyntheticFallbackCoordinator()
+        let controlIdentity = LogitechControlIdentity(controlID: 0x00D0, productID: 0xB015, serialNumber: "ABC")
+
+        _ = coordinator.action(
+            for: controlIdentity,
+            isPressed: true,
+            handlingResult: .handledDeferringSyntheticFallback
+        )
+
+        XCTAssertEqual(
+            coordinator.action(for: controlIdentity, isPressed: false, handlingResult: .handled),
+            .suppress
+        )
+    }
+
+    func testLogitechSyntheticFallbackSeparatesDeferredClicksByIdentity() {
+        var coordinator = LogitechSyntheticFallbackCoordinator()
+        let firstControl = LogitechControlIdentity(controlID: 0x00D0, productID: 0xB015, serialNumber: "ABC")
+        let secondControl = LogitechControlIdentity(controlID: 0x00D0, productID: 0xB015, serialNumber: "DEF")
+
+        _ = coordinator.action(
+            for: firstControl,
+            isPressed: true,
+            handlingResult: .handledDeferringSyntheticFallback
+        )
+
+        XCTAssertEqual(
+            coordinator.action(for: secondControl, isPressed: true, handlingResult: .notHandled),
+            .postCurrentEvent
+        )
+        XCTAssertEqual(
+            coordinator.action(for: secondControl, isPressed: false, handlingResult: .notHandled),
+            .postCurrentEvent
+        )
+        XCTAssertEqual(
+            coordinator.action(for: firstControl, isPressed: false, handlingResult: .notHandled),
+            .postClick
+        )
+    }
+
     func testLogitechControlIdentityProvidesFriendlyUserVisibleName() {
         XCTAssertEqual(
             LogitechControlIdentity(controlID: 0x00D0, productID: nil, serialNumber: nil)

--- a/LinearMouseUnitTests/EventTransformer/GestureButtonTransformerTests.swift
+++ b/LinearMouseUnitTests/EventTransformer/GestureButtonTransformerTests.swift
@@ -57,7 +57,7 @@ final class GestureButtonTransformerTests: XCTestCase {
 
         XCTAssertEqual(
             transformer.handleLogitechControlEvent(logitechContext(pressed: true)),
-            .handledAllowingSyntheticFallback
+            .handledDeferringSyntheticFallback
         )
         XCTAssertEqual(
             transformer.handleLogitechControlEvent(logitechContext(pressed: false)),
@@ -77,18 +77,18 @@ final class GestureButtonTransformerTests: XCTestCase {
         )
     }
 
-    func testLogitechControlGestureAllowsSyntheticFallbackForCleanupRelease() throws {
+    func testLogitechControlGestureSuppressesSyntheticFallbackForCleanupRelease() throws {
         let transformer = makeLogitechGestureTransformer()
 
         XCTAssertEqual(
             transformer.handleLogitechControlEvent(logitechContext(pressed: true)),
-            .handledAllowingSyntheticFallback
+            .handledDeferringSyntheticFallback
         )
 
         XCTAssertNil(try transformer.transform(makeMouseMovedEvent(deltaX: testGestureThreshold)))
         XCTAssertEqual(
             transformer.handleLogitechControlEvent(logitechContext(pressed: false)),
-            .handledAllowingSyntheticFallback
+            .handled
         )
     }
 
@@ -97,12 +97,12 @@ final class GestureButtonTransformerTests: XCTestCase {
 
         XCTAssertEqual(
             transformer.handleLogitechControlEvent(logitechContext(pressed: true)),
-            .handledAllowingSyntheticFallback
+            .handledDeferringSyntheticFallback
         )
         XCTAssertNil(try transformer.transform(makeMouseMovedEvent(deltaX: testGestureThreshold)))
         XCTAssertEqual(
             transformer.handleLogitechControlEvent(logitechContext(pressed: false)),
-            .handledAllowingSyntheticFallback
+            .handled
         )
         XCTAssertEqual(
             transformer.handleLogitechControlEvent(logitechContext(pressed: true)),


### PR DESCRIPTION
## Summary

Follow-up to #1211.

When a Logitech control is used as a gesture button, defer its synthetic click fallback until release. This keeps normal tap/click behavior when no gesture is triggered, but suppresses the fallback click once a gesture has handled the control.

## Testing

- `xcodebuild test -project LinearMouse.xcodeproj -scheme LinearMouse -only-testing:LinearMouseUnitTests/GestureButtonTransformerTests -only-testing:LinearMouseUnitTests/VendorSpecificDeviceMetadataTests`