### PR TITLE
Add Logitech high-resolution wheel support

### DIFF
--- a/Documentation/Configuration.d.ts
+++ b/Documentation/Configuration.d.ts
@@ -77,6 +77,12 @@ type Scheme = {
    * @description Customize the buttons behavior.
    */
   buttons?: Scheme.Buttons;
+
+  /**
+   * @title Logitech settings
+   * @description Customize supported Logitech HID++ device behavior.
+   */
+  logitech?: Scheme.Logitech;
 };
 
 declare namespace Scheme {
@@ -438,6 +444,14 @@ declare namespace Scheme {
      * @default false
      */
     redirectsToScroll?: boolean;
+  };
+
+  type Logitech = {
+    /**
+     * @title High resolution wheel
+     * @description Enable finer vertical wheel steps on supported Logitech HID++ mice.
+     */
+    highResolutionWheel?: boolean;
   };
 
   type Buttons = {

--- a/Documentation/Configuration.json
+++ b/Documentation/Configuration.json
@@ -97,6 +97,11 @@
           "description": "This value can be a single condition or an array. A scheme is activated if at least one of the conditions is met.",
           "title": "Scheme activation conditions"
         },
+        "logitech": {
+          "$ref": "#/definitions/Scheme.Logitech",
+          "description": "Customize supported Logitech HID++ device behavior.",
+          "title": "Logitech settings"
+        },
         "pointer": {
           "$ref": "#/definitions/Scheme.Pointer",
           "description": "Customize the pointer acceleration and speed.",
@@ -1118,6 +1123,17 @@
       "description": "Match trackpad devices.",
       "title": "Trackpad",
       "type": "string"
+    },
+    "Scheme.Logitech": {
+      "additionalProperties": false,
+      "properties": {
+        "highResolutionWheel": {
+          "description": "Enable finer vertical wheel steps on supported Logitech HID++ mice.",
+          "title": "High resolution wheel",
+          "type": "boolean"
+        }
+      },
+      "type": "object"
     },
     "Scheme.Pointer": {
       "additionalProperties": false,

--- a/LinearMouse/Device/Device+HighResolutionWheel.swift
+++ b/LinearMouse/Device/Device+HighResolutionWheel.swift
@@ -1,0 +1,142 @@
+// MIT License
+// Copyright (c) 2021-2026 LinearMouse
+
+import Foundation
+
+extension Device {
+    private static let highResolutionWheelQueue = DispatchQueue(
+        label: "app.linearmouse.high-resolution-wheel",
+        qos: .userInitiated
+    )
+
+    struct HighResolutionWheelInfo: Equatable {
+        let supportsHighResolutionWheel: Bool
+        let enabled: Bool?
+        let multiplier: Int?
+    }
+
+    func applyConfiguredHighResolutionWheel(_ enabled: Bool) {
+        Self.highResolutionWheelQueue.async {
+            _ = self.applyHighResolutionWheelSynchronously(enabled)
+        }
+    }
+
+    func refreshHighResolutionWheelInfo(completion: @escaping (HighResolutionWheelInfo) -> Void) {
+        Self.highResolutionWheelQueue.async {
+            let info = self.highResolutionWheelInfo
+
+            DispatchQueue.main.async {
+                completion(info)
+            }
+        }
+    }
+
+    private var unsupportedHighResolutionWheelInfo: HighResolutionWheelInfo {
+        HighResolutionWheelInfo(
+            supportsHighResolutionWheel: false,
+            enabled: nil,
+            multiplier: nil
+        )
+    }
+
+    private var highResolutionWheelInfo: HighResolutionWheelInfo {
+        guard !isRemoved, let controller = logitechHighResolutionWheelController else {
+            return unsupportedHighResolutionWheelInfo
+        }
+
+        let capabilities = controller.capabilities()
+        let enabled = controller.isHighResolutionWheelEnabled()
+        let multiplier = capabilities.map { Int($0.multiplier) }
+        updateHighResolutionWheelCache(enabled: enabled, multiplier: multiplier)
+
+        return HighResolutionWheelInfo(
+            supportsHighResolutionWheel: true,
+            enabled: enabled,
+            multiplier: multiplier
+        )
+    }
+
+    private func applyHighResolutionWheelSynchronously(_ enabled: Bool) -> Bool? {
+        guard !isRemoved,
+              let controller = logitechHighResolutionWheelController else {
+            return nil
+        }
+
+        let capabilities = controller.capabilities()
+        let currentEnabled = controller.isHighResolutionWheelEnabled()
+
+        highResolutionWheelLock.lock()
+        if initialHighResolutionWheelEnabled == nil {
+            initialHighResolutionWheelEnabled = currentEnabled
+        }
+        if cachedHighResolutionWheelEnabled == enabled {
+            cachedHighResolutionWheelMultiplier = enabled ? capabilities.map { Int($0.multiplier) } : nil
+            highResolutionWheelLock.unlock()
+            return enabled
+        }
+        highResolutionWheelLock.unlock()
+
+        guard let applied = controller.setHighResolutionWheelEnabled(enabled) else {
+            return nil
+        }
+
+        updateHighResolutionWheelCache(
+            enabled: applied,
+            multiplier: applied ? capabilities.map { Int($0.multiplier) } : nil
+        )
+
+        return applied
+    }
+
+    var highResolutionWheelNormalizationMultiplier: Int? {
+        highResolutionWheelLock.lock()
+        defer { highResolutionWheelLock.unlock() }
+
+        guard cachedHighResolutionWheelEnabled == true,
+              let multiplier = cachedHighResolutionWheelMultiplier,
+              multiplier > 1 else {
+            return nil
+        }
+
+        return multiplier
+    }
+
+    func restoreHighResolutionWheel() {
+        Self.highResolutionWheelQueue.sync {
+            self.restoreHighResolutionWheelSynchronously()
+        }
+    }
+
+    private func restoreHighResolutionWheelSynchronously() {
+        guard !isRemoved,
+              let controller = logitechHighResolutionWheelController else {
+            clearHighResolutionWheelCache()
+            return
+        }
+
+        highResolutionWheelLock.lock()
+        let initialEnabled = initialHighResolutionWheelEnabled
+        highResolutionWheelLock.unlock()
+
+        if let initialEnabled {
+            _ = controller.setHighResolutionWheelEnabled(initialEnabled)
+        }
+
+        clearHighResolutionWheelCache()
+    }
+
+    private func clearHighResolutionWheelCache() {
+        highResolutionWheelLock.lock()
+        cachedHighResolutionWheelEnabled = nil
+        cachedHighResolutionWheelMultiplier = nil
+        initialHighResolutionWheelEnabled = nil
+        highResolutionWheelLock.unlock()
+    }
+
+    private func updateHighResolutionWheelCache(enabled: Bool?, multiplier: Int?) {
+        highResolutionWheelLock.lock()
+        cachedHighResolutionWheelEnabled = enabled
+        cachedHighResolutionWheelMultiplier = enabled == true ? multiplier : nil
+        highResolutionWheelLock.unlock()
+    }
+}

--- a/LinearMouse/Device/Device.swift
+++ b/LinearMouse/Device/Device.swift
@@ -36,6 +36,7 @@ class Device {
     private var inputReportHandlers: [InputReportHandler] = []
     private var logitechReprogrammableControlsMonitor: LogitechReprogrammableControlsMonitor?
     lazy var logitechDPIController = LogitechHIDPPDeviceDPIController(device: device)
+    lazy var logitechHighResolutionWheelController = LogitechHIDPPHighResolutionWheelController(device: device)
     private var logitechControlsMonitorSubscriptions = Set<AnyCancellable>()
     private let device: PointerDevice
 
@@ -50,6 +51,10 @@ class Device {
     private let initialPointerResolution: Double
     let hardwareDPILock = NSLock()
     var cachedHardwareDPI: Int?
+    let highResolutionWheelLock = NSLock()
+    var cachedHighResolutionWheelEnabled: Bool?
+    var cachedHighResolutionWheelMultiplier: Int?
+    var initialHighResolutionWheelEnabled: Bool?
 
     var isRemoved: Bool {
         hardwareDPILock.lock()
@@ -139,6 +144,11 @@ class Device {
         removed = true
         cachedHardwareDPI = nil
         hardwareDPILock.unlock()
+        highResolutionWheelLock.lock()
+        cachedHighResolutionWheelEnabled = nil
+        cachedHighResolutionWheelMultiplier = nil
+        initialHighResolutionWheelEnabled = nil
+        highResolutionWheelLock.unlock()
 
         inputObservationToken = nil
         reportObservationToken = nil
@@ -355,6 +365,7 @@ extension Device {
 
     func restorePointerAccelerationAndPointerSpeed() {
         restoreHardwareDPI()
+        restoreHighResolutionWheel()
         restorePointerSpeed()
         restorePointerAcceleration()
     }

--- a/LinearMouse/Device/DeviceManager.swift
+++ b/LinearMouse/Device/DeviceManager.swift
@@ -102,6 +102,7 @@ class DeviceManager: ObservableObject {
                 DispatchQueue.main.async {
                     self.updatePointerSpeed()
                     self.updateHardwareDPI()
+                    self.updateHighResolutionWheel()
                 }
             }
             .store(in: &subscriptions)
@@ -151,6 +152,7 @@ class DeviceManager: ObservableObject {
 
         updatePointerSpeed(for: device)
         updateHardwareDPI(for: device)
+        updateHighResolutionWheel(for: device)
 
         if shouldMonitorReceiver(device) {
             receiverMonitor.startMonitoring(device: device)
@@ -348,6 +350,36 @@ class DeviceManager: ObservableObject {
         }
 
         device.applyConfiguredHardwareDPI(hardwareDPI)
+    }
+
+    func updateHighResolutionWheel() {
+        guard state == .running else {
+            return
+        }
+
+        for device in devices {
+            updateHighResolutionWheel(for: device)
+        }
+    }
+
+    func updateHighResolutionWheel(for device: Device) {
+        guard state == .running else {
+            return
+        }
+
+        let schemes = ConfigurationState.shared.configuration.schemes
+        guard case let .at(index) = schemes.schemeIndex(
+            ofDevice: device,
+            ofApp: nil,
+            ofProcessPath: nil,
+            ofDisplay: nil
+        ),
+            let highResolutionWheel = schemes[index].logitech.highResolutionWheel
+        else {
+            return
+        }
+
+        device.applyConfiguredHighResolutionWheel(highResolutionWheel)
     }
 
     func restorePointerSpeedToInitialValue() {

--- a/LinearMouse/Device/VendorSpecific/Logitech/LogitechHIDPPDeviceMetadataProvider.swift
+++ b/LinearMouse/Device/VendorSpecific/Logitech/LogitechHIDPPDeviceMetadataProvider.swift
@@ -97,6 +97,7 @@ struct LogitechHIDPPDeviceMetadataProvider: VendorSpecificDeviceMetadataProvider
         case unifiedBattery = 0x1004
         case reprogControlsV4 = 0x1B04
         case adcMeasurement = 0x1F20
+        case hiresWheel = 0x2121
         case adjustableDPI = 0x2201
     }
 

--- a/LinearMouse/Device/VendorSpecific/Logitech/LogitechHIDPPHighResolutionWheelController.swift
+++ b/LinearMouse/Device/VendorSpecific/Logitech/LogitechHIDPPHighResolutionWheelController.swift
@@ -1,0 +1,94 @@
+// MIT License
+// Copyright (c) 2021-2026 LinearMouse
+
+import Foundation
+import PointerKit
+
+struct LogitechHIDPPHighResolutionWheelController {
+    private enum Constants {
+        static let getCapabilitiesFunction: UInt8 = 0x00
+        static let getModeFunction: UInt8 = 0x01
+        static let setModeFunction: UInt8 = 0x02
+        static let highResolutionModeBit: UInt8 = 0x02
+    }
+
+    struct Capabilities: Equatable {
+        let multiplier: UInt8
+        let flags: UInt8
+    }
+
+    private let transport: LogitechHIDPPTransport
+    private let featureIndex: UInt8
+
+    init?(device: VendorSpecificDeviceContext) {
+        guard device.vendorID == LogitechHIDPPDeviceMetadataProvider.Constants.vendorID,
+              device.transport == PointerDeviceTransportName.bluetoothLowEnergy,
+              let transport = LogitechHIDPPTransport(device: device, deviceIndex: nil),
+              let featureIndex = transport.featureIndex(for: .hiresWheel)
+        else {
+            return nil
+        }
+
+        self.transport = transport
+        self.featureIndex = featureIndex
+    }
+
+    func capabilities() -> Capabilities? {
+        guard let response = transport.request(
+            featureIndex: featureIndex,
+            function: Constants.getCapabilitiesFunction,
+            parameters: []
+        ),
+            response.payload.count >= 2
+        else {
+            return nil
+        }
+
+        return Capabilities(multiplier: response.payload[0], flags: response.payload[1])
+    }
+
+    func isHighResolutionWheelEnabled() -> Bool? {
+        readMode().map { $0 & Constants.highResolutionModeBit != 0 }
+    }
+
+    func setHighResolutionWheelEnabled(_ enabled: Bool) -> Bool? {
+        guard var mode = readMode() else {
+            return nil
+        }
+
+        let currentlyEnabled = mode & Constants.highResolutionModeBit != 0
+        guard currentlyEnabled != enabled else {
+            return enabled
+        }
+
+        if enabled {
+            mode |= Constants.highResolutionModeBit
+        } else {
+            mode &= ~Constants.highResolutionModeBit
+        }
+
+        guard transport.request(
+            featureIndex: featureIndex,
+            function: Constants.setModeFunction,
+            parameters: [mode]
+        ) != nil else {
+            return nil
+        }
+
+        return enabled
+    }
+
+    private func readMode() -> UInt8? {
+        guard let response = transport.request(
+            featureIndex: featureIndex,
+            function: Constants.getModeFunction,
+            parameters: []
+        ),
+            let mode = response.payload.first
+        else {
+            return nil
+        }
+
+        return mode
+    }
+}

--- a/LinearMouse/EventTransformer/EventTransformerManager.swift
+++ b/LinearMouse/EventTransformer/EventTransformerManager.swift
@@ -282,7 +282,10 @@ class EventTransformerManager {
 
         if hasSmoothedScrolling {
             appendScrollRecordingAndButtonMappings()
-            eventTransformer.append(SmoothedScrollingTransformer(smoothed: smoothed))
+            eventTransformer.append(SmoothedScrollingTransformer(
+                smoothed: smoothed,
+                highResolutionWheelMultiplier: highResolutionWheelMultiplier
+            ))
         }
 
         if let distance = scheme.scrolling.distance.horizontal {
@@ -390,7 +393,7 @@ class EventTransformerManager {
         smoothed: Scheme.Scrolling.Smoothed?
     ) -> LogitechHighResolutionWheelNormalizer.AxisMode {
         if smoothed != nil {
-            return .smoothed
+            return .passthrough
         }
 
         switch distance {

--- a/LinearMouse/EventTransformer/EventTransformerManager.swift
+++ b/LinearMouse/EventTransformer/EventTransformerManager.swift
@@ -217,6 +217,9 @@ class EventTransformerManager {
         )
 
         var eventTransformer: [EventTransformer] = []
+        let highResolutionWheelMultiplier = { [weak device] in
+            device?.highResolutionWheelNormalizationMultiplier
+        }
 
         if let reverse = scheme.scrolling.$reverse {
             let vertical = reverse.vertical ?? false
@@ -237,6 +240,22 @@ class EventTransformerManager {
         let scrollButtonMappings = buttonMappings.filter { $0.scroll != nil }
         let otherButtonMappings = buttonMappings.filter { $0.scroll == nil }
         let buttonActionsRuntimeState = ButtonActionsTransformer.RuntimeState()
+        if device != nil {
+            let highResolutionWheelNormalizer = LogitechHighResolutionWheelNormalizer(
+                verticalMode: highResolutionWheelNormalizerMode(
+                    distance: scheme.scrolling.distance.vertical,
+                    smoothed: smoothed.vertical
+                ),
+                horizontalMode: highResolutionWheelNormalizerMode(
+                    distance: scheme.scrolling.distance.horizontal,
+                    smoothed: smoothed.horizontal
+                ),
+                multiplier: highResolutionWheelMultiplier
+            )
+            if highResolutionWheelNormalizer.normalizesAnyAxis {
+                eventTransformer.append(highResolutionWheelNormalizer)
+            }
+        }
 
         func appendScrollButtonMappings() {
             guard !scrollButtonMappings.isEmpty else {
@@ -268,13 +287,19 @@ class EventTransformerManager {
 
         if let distance = scheme.scrolling.distance.horizontal {
             if smoothed.horizontal == nil {
-                eventTransformer.append(LinearScrollingHorizontalTransformer(distance: distance))
+                eventTransformer.append(LinearScrollingHorizontalTransformer(
+                    distance: distance,
+                    highResolutionWheelMultiplier: highResolutionWheelMultiplier
+                ))
             }
         }
 
         if let distance = scheme.scrolling.distance.vertical {
             if smoothed.vertical == nil {
-                eventTransformer.append(LinearScrollingVerticalTransformer(distance: distance))
+                eventTransformer.append(LinearScrollingVerticalTransformer(
+                    distance: distance,
+                    highResolutionWheelMultiplier: highResolutionWheelMultiplier
+                ))
             }
         }
 
@@ -358,6 +383,22 @@ class EventTransformerManager {
         eventTransformerCache.setValue(eventTransformer, forKey: cacheKey)
 
         return eventTransformer
+    }
+
+    private func highResolutionWheelNormalizerMode(
+        distance: Scheme.Scrolling.Distance?,
+        smoothed: Scheme.Scrolling.Smoothed?
+    ) -> LogitechHighResolutionWheelNormalizer.AxisMode {
+        if smoothed != nil {
+            return .smoothed
+        }
+
+        switch distance {
+        case .some(.line), .some(.pixel):
+            return .passthrough
+        case .some(.auto), nil:
+            return .lowResolution
+        }
     }
 
     private func autoScrollTransformer(for autoScroll: Scheme.Buttons.AutoScroll?) -> AutoScrollTransformer? {

--- a/LinearMouse/EventTransformer/LinearScrollingHorizontalTransformer.swift
+++ b/LinearMouse/EventTransformer/LinearScrollingHorizontalTransformer.swift
@@ -84,13 +84,12 @@ class LinearScrollingHorizontalTransformer: EventTransformer {
 
     private func lowResolutionUnits(from view: ScrollWheelEventView) -> Int? {
         guard let multiplier = highResolutionWheelMultiplier(),
-              multiplier > 1,
-              view.deltaX != 0 else {
+              multiplier > 1 else {
             return Int(view.deltaXSignum)
         }
 
         return highResolutionWheelCounter.consume(
-            units: Int(view.deltaX),
+            units: LogitechHighResolutionWheelUnitReader.horizontalUnits(from: view, multiplier: multiplier),
             multiplier: multiplier,
             now: now()
         )
@@ -98,11 +97,11 @@ class LinearScrollingHorizontalTransformer: EventTransformer {
 
     private func highResolutionPixelUnits(from view: ScrollWheelEventView) -> Double {
         guard let multiplier = highResolutionWheelMultiplier(),
-              multiplier > 1,
-              view.deltaX != 0 else {
+              multiplier > 1 else {
             return Double(view.deltaXSignum)
         }
 
-        return Double(view.deltaX) / Double(multiplier)
+        return LogitechHighResolutionWheelUnitReader.horizontalUnits(from: view, multiplier: multiplier)
+            / Double(multiplier)
     }
 }

--- a/LinearMouse/EventTransformer/LinearScrollingHorizontalTransformer.swift
+++ b/LinearMouse/EventTransformer/LinearScrollingHorizontalTransformer.swift
@@ -89,7 +89,11 @@ class LinearScrollingHorizontalTransformer: EventTransformer {
         }
 
         return highResolutionWheelCounter.consume(
-            units: LogitechHighResolutionWheelUnitReader.horizontalUnits(from: view, multiplier: multiplier),
+            units: LogitechHighResolutionWheelUnitReader.horizontalUnitResolution(
+                from: view,
+                multiplier: multiplier
+            )
+            .rawUnits,
             multiplier: multiplier,
             now: now()
         )
@@ -101,7 +105,11 @@ class LinearScrollingHorizontalTransformer: EventTransformer {
             return Double(view.deltaXSignum)
         }
 
-        return LogitechHighResolutionWheelUnitReader.horizontalUnits(from: view, multiplier: multiplier)
-            / Double(multiplier)
+        return LogitechHighResolutionWheelUnitReader.horizontalUnitResolution(
+            from: view,
+            multiplier: multiplier
+        )
+        .rawUnits
+        / Double(multiplier)
     }
 }

--- a/LinearMouse/EventTransformer/LinearScrollingHorizontalTransformer.swift
+++ b/LinearMouse/EventTransformer/LinearScrollingHorizontalTransformer.swift
@@ -8,9 +8,18 @@ class LinearScrollingHorizontalTransformer: EventTransformer {
     private static let log = OSLog(subsystem: Bundle.main.bundleIdentifier!, category: "LinearScrollingHorizontal")
 
     private let distance: Scheme.Scrolling.Distance
+    private let highResolutionWheelMultiplier: () -> Int?
+    private let now: () -> TimeInterval
+    private var highResolutionWheelCounter = LogitechHighResolutionWheelScrollCounter()
 
-    init(distance: Scheme.Scrolling.Distance) {
+    init(
+        distance: Scheme.Scrolling.Distance,
+        highResolutionWheelMultiplier: @escaping () -> Int? = { nil },
+        now: @escaping () -> TimeInterval = { ProcessInfo.processInfo.systemUptime }
+    ) {
         self.distance = distance
+        self.highResolutionWheelMultiplier = highResolutionWheelMultiplier
+        self.now = now
     }
 
     func transform(_ event: CGEvent) -> CGEvent? {
@@ -37,21 +46,26 @@ class LinearScrollingHorizontalTransformer: EventTransformer {
         }
 
         let (continuous, oldValue) = (view.continuous, view.matrixValue)
-        let deltaXSignum = view.deltaXSignum
 
         switch distance {
         case .auto:
             return event
 
         case let .line(value):
+            guard let normalizedUnits = lowResolutionUnits(from: view) else {
+                return nil
+            }
+
             view.continuous = false
-            view.deltaX = deltaXSignum * Int64(value)
+            view.deltaX = Int64(normalizedUnits * value)
             view.deltaY = 0
 
         case let .pixel(value):
+            let pixelValue = highResolutionPixelUnits(from: view) * value.asTruncatedDouble
+
             view.continuous = true
-            view.deltaXPt = Double(deltaXSignum) * value.asTruncatedDouble
-            view.deltaXFixedPt = Double(deltaXSignum) * value.asTruncatedDouble
+            view.deltaXPt = pixelValue
+            view.deltaXFixedPt = pixelValue
             view.deltaYPt = 0
             view.deltaYFixedPt = 0
         }
@@ -66,5 +80,29 @@ class LinearScrollingHorizontalTransformer: EventTransformer {
         )
 
         return event
+    }
+
+    private func lowResolutionUnits(from view: ScrollWheelEventView) -> Int? {
+        guard let multiplier = highResolutionWheelMultiplier(),
+              multiplier > 1,
+              view.deltaX != 0 else {
+            return Int(view.deltaXSignum)
+        }
+
+        return highResolutionWheelCounter.consume(
+            units: Int(view.deltaX),
+            multiplier: multiplier,
+            now: now()
+        )
+    }
+
+    private func highResolutionPixelUnits(from view: ScrollWheelEventView) -> Double {
+        guard let multiplier = highResolutionWheelMultiplier(),
+              multiplier > 1,
+              view.deltaX != 0 else {
+            return Double(view.deltaXSignum)
+        }
+
+        return Double(view.deltaX) / Double(multiplier)
     }
 }

--- a/LinearMouse/EventTransformer/LinearScrollingVerticalTransformer.swift
+++ b/LinearMouse/EventTransformer/LinearScrollingVerticalTransformer.swift
@@ -88,7 +88,11 @@ class LinearScrollingVerticalTransformer: EventTransformer {
         }
 
         return highResolutionWheelCounter.consume(
-            units: LogitechHighResolutionWheelUnitReader.verticalUnits(from: view, multiplier: multiplier),
+            units: LogitechHighResolutionWheelUnitReader.verticalUnitResolution(
+                from: view,
+                multiplier: multiplier
+            )
+            .rawUnits,
             multiplier: multiplier,
             now: now()
         )
@@ -100,7 +104,11 @@ class LinearScrollingVerticalTransformer: EventTransformer {
             return Double(view.deltaYSignum)
         }
 
-        return LogitechHighResolutionWheelUnitReader.verticalUnits(from: view, multiplier: multiplier)
-            / Double(multiplier)
+        return LogitechHighResolutionWheelUnitReader.verticalUnitResolution(
+            from: view,
+            multiplier: multiplier
+        )
+        .rawUnits
+        / Double(multiplier)
     }
 }

--- a/LinearMouse/EventTransformer/LinearScrollingVerticalTransformer.swift
+++ b/LinearMouse/EventTransformer/LinearScrollingVerticalTransformer.swift
@@ -8,9 +8,18 @@ class LinearScrollingVerticalTransformer: EventTransformer {
     private static let log = OSLog(subsystem: Bundle.main.bundleIdentifier!, category: "LinearScrollingVertical")
 
     private let distance: Scheme.Scrolling.Distance
+    private let highResolutionWheelMultiplier: () -> Int?
+    private let now: () -> TimeInterval
+    private var highResolutionWheelCounter = LogitechHighResolutionWheelScrollCounter()
 
-    init(distance: Scheme.Scrolling.Distance) {
+    init(
+        distance: Scheme.Scrolling.Distance,
+        highResolutionWheelMultiplier: @escaping () -> Int? = { nil },
+        now: @escaping () -> TimeInterval = { ProcessInfo.processInfo.systemUptime }
+    ) {
         self.distance = distance
+        self.highResolutionWheelMultiplier = highResolutionWheelMultiplier
+        self.now = now
     }
 
     func transform(_ event: CGEvent) -> CGEvent? {
@@ -37,21 +46,25 @@ class LinearScrollingVerticalTransformer: EventTransformer {
         }
 
         let (continuous, oldValue) = (view.continuous, view.matrixValue)
-        let deltaYSignum = view.deltaYSignum
-
         switch distance {
         case .auto:
             return event
 
         case let .line(value):
+            guard let normalizedUnits = lowResolutionUnits(from: view) else {
+                return nil
+            }
+
             view.continuous = false
-            view.deltaY = deltaYSignum * Int64(value)
+            view.deltaY = Int64(normalizedUnits * value)
             view.deltaX = 0
 
         case let .pixel(value):
+            let pixelValue = highResolutionPixelUnits(from: view) * value.asTruncatedDouble
+
             view.continuous = true
-            view.deltaYPt = Double(deltaYSignum) * value.asTruncatedDouble
-            view.deltaYFixedPt = Double(deltaYSignum) * value.asTruncatedDouble
+            view.deltaYPt = pixelValue
+            view.deltaYFixedPt = pixelValue
             view.deltaXPt = 0
             view.deltaXFixedPt = 0
         }
@@ -66,5 +79,29 @@ class LinearScrollingVerticalTransformer: EventTransformer {
         )
 
         return event
+    }
+
+    private func lowResolutionUnits(from view: ScrollWheelEventView) -> Int? {
+        guard let multiplier = highResolutionWheelMultiplier(),
+              multiplier > 1,
+              view.deltaY != 0 else {
+            return Int(view.deltaYSignum)
+        }
+
+        return highResolutionWheelCounter.consume(
+            units: Int(view.deltaY),
+            multiplier: multiplier,
+            now: now()
+        )
+    }
+
+    private func highResolutionPixelUnits(from view: ScrollWheelEventView) -> Double {
+        guard let multiplier = highResolutionWheelMultiplier(),
+              multiplier > 1,
+              view.deltaY != 0 else {
+            return Double(view.deltaYSignum)
+        }
+
+        return Double(view.deltaY) / Double(multiplier)
     }
 }

--- a/LinearMouse/EventTransformer/LinearScrollingVerticalTransformer.swift
+++ b/LinearMouse/EventTransformer/LinearScrollingVerticalTransformer.swift
@@ -83,13 +83,12 @@ class LinearScrollingVerticalTransformer: EventTransformer {
 
     private func lowResolutionUnits(from view: ScrollWheelEventView) -> Int? {
         guard let multiplier = highResolutionWheelMultiplier(),
-              multiplier > 1,
-              view.deltaY != 0 else {
+              multiplier > 1 else {
             return Int(view.deltaYSignum)
         }
 
         return highResolutionWheelCounter.consume(
-            units: Int(view.deltaY),
+            units: LogitechHighResolutionWheelUnitReader.verticalUnits(from: view, multiplier: multiplier),
             multiplier: multiplier,
             now: now()
         )
@@ -97,11 +96,11 @@ class LinearScrollingVerticalTransformer: EventTransformer {
 
     private func highResolutionPixelUnits(from view: ScrollWheelEventView) -> Double {
         guard let multiplier = highResolutionWheelMultiplier(),
-              multiplier > 1,
-              view.deltaY != 0 else {
+              multiplier > 1 else {
             return Double(view.deltaYSignum)
         }
 
-        return Double(view.deltaY) / Double(multiplier)
+        return LogitechHighResolutionWheelUnitReader.verticalUnits(from: view, multiplier: multiplier)
+            / Double(multiplier)
     }
 }

--- a/LinearMouse/EventTransformer/LogitechHighResolutionWheelNormalizer.swift
+++ b/LinearMouse/EventTransformer/LogitechHighResolutionWheelNormalizer.swift
@@ -7,10 +7,7 @@ final class LogitechHighResolutionWheelNormalizer: EventTransformer {
     enum AxisMode {
         case passthrough
         case lowResolution
-        case smoothed
     }
-
-    private static let lineStepInPixels = 36.0
 
     private let verticalMode: AxisMode
     private let horizontalMode: AxisMode
@@ -52,7 +49,11 @@ final class LogitechHighResolutionWheelNormalizer: EventTransformer {
     }
 
     private func normalizeVertical(on view: ScrollWheelEventView, multiplier: Int) {
-        let units = signedVerticalUnits(from: view)
+        let unitResolution = LogitechHighResolutionWheelUnitReader.verticalUnitResolution(
+            from: view,
+            multiplier: multiplier
+        )
+        let units = unitResolution.units
         guard units != 0 else {
             return
         }
@@ -67,14 +68,15 @@ final class LogitechHighResolutionWheelNormalizer: EventTransformer {
                 return
             }
             setLowResolutionVertical(steps, on: view)
-
-        case .smoothed:
-            setContinuousVertical(Double(units) * Self.lineStepInPixels / Double(multiplier), on: view)
         }
     }
 
     private func normalizeHorizontal(on view: ScrollWheelEventView, multiplier: Int) {
-        let units = signedHorizontalUnits(from: view)
+        let unitResolution = LogitechHighResolutionWheelUnitReader.horizontalUnitResolution(
+            from: view,
+            multiplier: multiplier
+        )
+        let units = unitResolution.units
         guard units != 0 else {
             return
         }
@@ -89,26 +91,7 @@ final class LogitechHighResolutionWheelNormalizer: EventTransformer {
                 return
             }
             setLowResolutionHorizontal(steps, on: view)
-
-        case .smoothed:
-            setContinuousHorizontal(Double(units) * Self.lineStepInPixels / Double(multiplier), on: view)
         }
-    }
-
-    private func signedVerticalUnits(from view: ScrollWheelEventView) -> Int {
-        if view.deltaY != 0 {
-            return Int(view.deltaY)
-        }
-
-        return Int(view.deltaYSignum)
-    }
-
-    private func signedHorizontalUnits(from view: ScrollWheelEventView) -> Int {
-        if view.deltaX != 0 {
-            return Int(view.deltaX)
-        }
-
-        return Int(view.deltaXSignum)
     }
 
     private func setLowResolutionVertical(_ steps: Int, on view: ScrollWheelEventView) {
@@ -123,22 +106,6 @@ final class LogitechHighResolutionWheelNormalizer: EventTransformer {
         view.deltaXPt = Double(steps) * 10
         view.deltaXFixedPt = Double(steps)
         view.ioHidScrollX = Double(steps)
-    }
-
-    private func setContinuousVertical(_ pixels: Double, on view: ScrollWheelEventView) {
-        view.continuous = true
-        view.deltaY = Int64((pixels / Self.lineStepInPixels).rounded(.towardZero))
-        view.deltaYPt = pixels
-        view.deltaYFixedPt = pixels
-        view.ioHidScrollY = pixels
-    }
-
-    private func setContinuousHorizontal(_ pixels: Double, on view: ScrollWheelEventView) {
-        view.continuous = true
-        view.deltaX = Int64((pixels / Self.lineStepInPixels).rounded(.towardZero))
-        view.deltaXPt = pixels
-        view.deltaXFixedPt = pixels
-        view.ioHidScrollX = pixels
     }
 
     private func zeroVertical(on view: ScrollWheelEventView) {
@@ -166,16 +133,16 @@ final class LogitechHighResolutionWheelNormalizer: EventTransformer {
 struct LogitechHighResolutionWheelScrollCounter {
     private static let resetInterval: TimeInterval = 1
 
-    private var remainder = 0
+    private var remainder = 0.0
     private var direction = 0
     private var lastTime: TimeInterval?
 
-    mutating func consume(units: Int, multiplier: Int, now: TimeInterval) -> Int? {
+    mutating func consume(units: Double, multiplier: Int, now: TimeInterval) -> Int? {
         guard units != 0, multiplier > 1 else {
-            return units == 0 ? nil : units
+            return units == 0 ? nil : Int(units.rounded(.toNearestOrAwayFromZero))
         }
 
-        let currentDirection = units.signum()
+        let currentDirection = units > 0 ? 1 : -1
         if let lastTime, now - lastTime > Self.resetInterval {
             remainder = 0
         }
@@ -187,16 +154,184 @@ struct LogitechHighResolutionWheelScrollCounter {
         lastTime = now
         remainder += units
 
+        let multiplier = Double(multiplier)
         guard abs(remainder) * 2 >= multiplier else {
             return nil
         }
 
-        var steps = remainder / multiplier
-        if steps == 0 {
-            steps = currentDirection
-        }
-        remainder -= steps * multiplier
+        let steps = Int((remainder / multiplier).rounded(.toNearestOrAwayFromZero))
+        remainder -= Double(steps) * multiplier
 
         return steps
+    }
+}
+
+enum LogitechHighResolutionWheelUnitReader {
+    struct UnitResolution {
+        var rawUnits: Double
+        var acceleratedUnits: Double
+        var units: Double
+    }
+
+    static func verticalUnits(from view: ScrollWheelEventView, multiplier: Int) -> Double {
+        verticalUnitResolution(from: view, multiplier: multiplier).units
+    }
+
+    static func verticalUnitResolution(from view: ScrollWheelEventView, multiplier: Int) -> UnitResolution {
+        units(
+            integerDelta: view.deltaY,
+            pointDelta: view.deltaYPt,
+            fixedPointDelta: view.deltaYFixedPt,
+            ioHidDelta: view.ioHidScrollY,
+            signum: view.deltaYSignum,
+            multiplier: multiplier
+        )
+    }
+
+    static func horizontalUnits(from view: ScrollWheelEventView, multiplier: Int) -> Double {
+        horizontalUnitResolution(from: view, multiplier: multiplier).units
+    }
+
+    static func horizontalUnitResolution(from view: ScrollWheelEventView, multiplier: Int) -> UnitResolution {
+        units(
+            integerDelta: view.deltaX,
+            pointDelta: view.deltaXPt,
+            fixedPointDelta: view.deltaXFixedPt,
+            ioHidDelta: view.ioHidScrollX,
+            signum: view.deltaXSignum,
+            multiplier: multiplier
+        )
+    }
+
+    static func units(
+        integerDelta: Int64,
+        pointDelta: Double,
+        fixedPointDelta: Double,
+        ioHidDelta: Double,
+        signum: Int64,
+        multiplier: Int
+    ) -> UnitResolution {
+        let direction = eventDirection(
+            integerDelta: integerDelta,
+            pointDelta: pointDelta,
+            fixedPointDelta: fixedPointDelta,
+            signum: signum,
+            fallbackDelta: ioHidDelta
+        )
+        guard direction != 0 else {
+            return .init(rawUnits: 0, acceleratedUnits: 0, units: 0)
+        }
+
+        let rawUnitMagnitude = rawUnits(
+            ioHidDelta: ioHidDelta,
+            integerDelta: integerDelta,
+            pointDelta: pointDelta,
+            fixedPointDelta: fixedPointDelta,
+            signum: signum,
+            multiplier: multiplier
+        )
+        let accelerationMagnitude = accelerationMagnitude(
+            integerDelta: integerDelta,
+            pointDelta: pointDelta,
+            fixedPointDelta: fixedPointDelta,
+            usesIOHIDRawUnits: abs(ioHidDelta) >= 0.5
+        )
+
+        return .init(
+            rawUnits: direction * rawUnitMagnitude,
+            acceleratedUnits: direction * accelerationMagnitude,
+            units: direction * max(rawUnitMagnitude, accelerationMagnitude)
+        )
+    }
+
+    private static func rawUnits(
+        ioHidDelta: Double,
+        integerDelta: Int64,
+        pointDelta: Double,
+        fixedPointDelta: Double,
+        signum: Int64,
+        multiplier: Int
+    ) -> Double {
+        let ioHidUnits = abs(ioHidDelta)
+        if ioHidUnits >= 0.5 {
+            return ioHidUnits
+        }
+
+        return rawFallbackUnits(
+            integerDelta: integerDelta,
+            pointDelta: pointDelta,
+            fixedPointDelta: fixedPointDelta,
+            signum: signum,
+            multiplier: multiplier
+        )
+    }
+
+    private static func rawFallbackUnits(
+        integerDelta: Int64,
+        pointDelta: Double,
+        fixedPointDelta: Double,
+        signum: Int64,
+        multiplier: Int
+    ) -> Double {
+        let multiplier = Double(multiplier)
+
+        let fixedPointUnits = fixedPointDelta * multiplier
+        if abs(fixedPointUnits) >= 0.5 {
+            return abs(fixedPointUnits)
+        }
+
+        let pointUnits = pointDelta * multiplier / 10.0
+        if abs(pointUnits) >= 0.5 {
+            return abs(pointUnits)
+        }
+
+        if integerDelta != 0 {
+            return abs(Double(integerDelta))
+        }
+
+        return abs(Double(signum))
+    }
+
+    private static func accelerationMagnitude(
+        integerDelta: Int64,
+        pointDelta: Double,
+        fixedPointDelta: Double,
+        usesIOHIDRawUnits: Bool
+    ) -> Double {
+        guard usesIOHIDRawUnits else {
+            return 1
+        }
+
+        return max(
+            1,
+            abs(Double(integerDelta)),
+            abs(pointDelta) / 10.0,
+            abs(fixedPointDelta)
+        )
+    }
+
+    private static func eventDirection(
+        integerDelta: Int64,
+        pointDelta: Double,
+        fixedPointDelta: Double,
+        signum: Int64,
+        fallbackDelta: Double
+    ) -> Double {
+        if signum != 0 {
+            return Double(signum)
+        }
+        if fixedPointDelta != 0 {
+            return fixedPointDelta.sign == .minus ? -1 : 1
+        }
+        if pointDelta != 0 {
+            return pointDelta.sign == .minus ? -1 : 1
+        }
+        if integerDelta != 0 {
+            return Double(integerDelta.signum())
+        }
+        if fallbackDelta != 0 {
+            return fallbackDelta.sign == .minus ? -1 : 1
+        }
+        return 0
     }
 }

--- a/LinearMouse/EventTransformer/LogitechHighResolutionWheelNormalizer.swift
+++ b/LinearMouse/EventTransformer/LogitechHighResolutionWheelNormalizer.swift
@@ -1,0 +1,202 @@
+// MIT License
+// Copyright (c) 2021-2026 LinearMouse
+
+import Foundation
+
+final class LogitechHighResolutionWheelNormalizer: EventTransformer {
+    enum AxisMode {
+        case passthrough
+        case lowResolution
+        case smoothed
+    }
+
+    private static let lineStepInPixels = 36.0
+
+    private let verticalMode: AxisMode
+    private let horizontalMode: AxisMode
+    private let multiplier: () -> Int?
+    private let now: () -> TimeInterval
+
+    private var verticalCounter = LogitechHighResolutionWheelScrollCounter()
+    private var horizontalCounter = LogitechHighResolutionWheelScrollCounter()
+
+    init(
+        verticalMode: AxisMode,
+        horizontalMode: AxisMode,
+        multiplier: @escaping () -> Int?,
+        now: @escaping () -> TimeInterval = { ProcessInfo.processInfo.systemUptime }
+    ) {
+        self.verticalMode = verticalMode
+        self.horizontalMode = horizontalMode
+        self.multiplier = multiplier
+        self.now = now
+    }
+
+    var normalizesAnyAxis: Bool {
+        verticalMode != .passthrough || horizontalMode != .passthrough
+    }
+
+    func transform(_ event: CGEvent) -> CGEvent? {
+        guard event.type == .scrollWheel,
+              !event.isLinearMouseSyntheticEvent,
+              let multiplier = multiplier(),
+              multiplier > 1 else {
+            return event
+        }
+
+        let view = ScrollWheelEventView(event)
+        normalizeVertical(on: view, multiplier: multiplier)
+        normalizeHorizontal(on: view, multiplier: multiplier)
+
+        return hasScrollDelta(view) ? event : nil
+    }
+
+    private func normalizeVertical(on view: ScrollWheelEventView, multiplier: Int) {
+        let units = signedVerticalUnits(from: view)
+        guard units != 0 else {
+            return
+        }
+
+        switch verticalMode {
+        case .passthrough:
+            return
+
+        case .lowResolution:
+            guard let steps = verticalCounter.consume(units: units, multiplier: multiplier, now: now()) else {
+                zeroVertical(on: view)
+                return
+            }
+            setLowResolutionVertical(steps, on: view)
+
+        case .smoothed:
+            setContinuousVertical(Double(units) * Self.lineStepInPixels / Double(multiplier), on: view)
+        }
+    }
+
+    private func normalizeHorizontal(on view: ScrollWheelEventView, multiplier: Int) {
+        let units = signedHorizontalUnits(from: view)
+        guard units != 0 else {
+            return
+        }
+
+        switch horizontalMode {
+        case .passthrough:
+            return
+
+        case .lowResolution:
+            guard let steps = horizontalCounter.consume(units: units, multiplier: multiplier, now: now()) else {
+                zeroHorizontal(on: view)
+                return
+            }
+            setLowResolutionHorizontal(steps, on: view)
+
+        case .smoothed:
+            setContinuousHorizontal(Double(units) * Self.lineStepInPixels / Double(multiplier), on: view)
+        }
+    }
+
+    private func signedVerticalUnits(from view: ScrollWheelEventView) -> Int {
+        if view.deltaY != 0 {
+            return Int(view.deltaY)
+        }
+
+        return Int(view.deltaYSignum)
+    }
+
+    private func signedHorizontalUnits(from view: ScrollWheelEventView) -> Int {
+        if view.deltaX != 0 {
+            return Int(view.deltaX)
+        }
+
+        return Int(view.deltaXSignum)
+    }
+
+    private func setLowResolutionVertical(_ steps: Int, on view: ScrollWheelEventView) {
+        view.deltaY = Int64(steps)
+        view.deltaYPt = Double(steps) * 10
+        view.deltaYFixedPt = Double(steps)
+        view.ioHidScrollY = Double(steps)
+    }
+
+    private func setLowResolutionHorizontal(_ steps: Int, on view: ScrollWheelEventView) {
+        view.deltaX = Int64(steps)
+        view.deltaXPt = Double(steps) * 10
+        view.deltaXFixedPt = Double(steps)
+        view.ioHidScrollX = Double(steps)
+    }
+
+    private func setContinuousVertical(_ pixels: Double, on view: ScrollWheelEventView) {
+        view.continuous = true
+        view.deltaY = Int64((pixels / Self.lineStepInPixels).rounded(.towardZero))
+        view.deltaYPt = pixels
+        view.deltaYFixedPt = pixels
+        view.ioHidScrollY = pixels
+    }
+
+    private func setContinuousHorizontal(_ pixels: Double, on view: ScrollWheelEventView) {
+        view.continuous = true
+        view.deltaX = Int64((pixels / Self.lineStepInPixels).rounded(.towardZero))
+        view.deltaXPt = pixels
+        view.deltaXFixedPt = pixels
+        view.ioHidScrollX = pixels
+    }
+
+    private func zeroVertical(on view: ScrollWheelEventView) {
+        view.deltaY = 0
+        view.deltaYPt = 0
+        view.deltaYFixedPt = 0
+        view.ioHidScrollY = 0
+    }
+
+    private func zeroHorizontal(on view: ScrollWheelEventView) {
+        view.deltaX = 0
+        view.deltaXPt = 0
+        view.deltaXFixedPt = 0
+        view.ioHidScrollX = 0
+    }
+
+    private func hasScrollDelta(_ view: ScrollWheelEventView) -> Bool {
+        view.deltaX != 0 || view.deltaY != 0 ||
+            view.deltaXPt != 0 || view.deltaYPt != 0 ||
+            view.deltaXFixedPt != 0 || view.deltaYFixedPt != 0 ||
+            view.ioHidScrollX != 0 || view.ioHidScrollY != 0
+    }
+}
+
+struct LogitechHighResolutionWheelScrollCounter {
+    private static let resetInterval: TimeInterval = 1
+
+    private var remainder = 0
+    private var direction = 0
+    private var lastTime: TimeInterval?
+
+    mutating func consume(units: Int, multiplier: Int, now: TimeInterval) -> Int? {
+        guard units != 0, multiplier > 1 else {
+            return units == 0 ? nil : units
+        }
+
+        let currentDirection = units.signum()
+        if let lastTime, now - lastTime > Self.resetInterval {
+            remainder = 0
+        }
+        if direction != 0, currentDirection != direction {
+            remainder = 0
+        }
+
+        direction = currentDirection
+        lastTime = now
+        remainder += units
+
+        guard abs(remainder) * 2 >= multiplier else {
+            return nil
+        }
+
+        var steps = remainder / multiplier
+        if steps == 0 {
+            steps = currentDirection
+        }
+        remainder -= steps * multiplier
+
+        return steps
+    }
+}

--- a/LinearMouse/EventTransformer/SmoothedScrollingEngine.swift
+++ b/LinearMouse/EventTransformer/SmoothedScrollingEngine.swift
@@ -292,6 +292,7 @@ final class SmoothedScrollingEngine {
             sessionState = .touching
             touchHasBegun = false
             pendingMomentumBegin = false
+            lastTickTimestamp = timestamp
         } else if sessionState == .momentum, deltaX != 0 || deltaY != 0 {
             sessionState = .touching
             touchHasBegun = false
@@ -523,13 +524,22 @@ final class SmoothedScrollingEngine {
 }
 
 private struct WheelInputVelocityEstimator {
-    private static let resetInterval: TimeInterval = 1.0 / 25.0
-    private static let inputTimeConstant: TimeInterval = 1.0 / 20.0
-    private static let referenceInterval: TimeInterval = 1.0 / 45.0
+    // Estimate the distance represented by a short wheel gesture while capping
+    // the projection to the signed input that was actually received.
+    private static let inputGapResetInterval: TimeInterval = 1.0 / 25.0
+    private static let rateSmoothingTimeConstant: TimeInterval = 1.0 / 20.0
+    private static let projectedGestureInterval: TimeInterval = 1.0 / 15.0
+    private static let recentInputLimitInterval = inputGapResetInterval * 4
+
+    private struct InputSample {
+        var delta: Double
+        var timestamp: TimeInterval
+    }
 
     private var rateAdjustedInput = 0.0
     private var direction = 0
     private var lastTimestamp: TimeInterval?
+    private var recentInputs: [InputSample] = []
 
     mutating func add(_ delta: Double, timestamp: TimeInterval) {
         guard delta != 0 else {
@@ -540,10 +550,12 @@ private struct WheelInputVelocityEstimator {
         let currentDirection = delta > 0 ? 1 : -1
         if direction != 0, currentDirection != direction {
             rateAdjustedInput = 0
+            recentInputs.removeAll(keepingCapacity: true)
         }
 
         direction = currentDirection
-        rateAdjustedInput += delta * Self.referenceInterval / Self.inputTimeConstant
+        rateAdjustedInput += delta * Self.projectedGestureInterval / Self.rateSmoothingTimeConstant
+        recentInputs.append(.init(delta: delta, timestamp: timestamp))
     }
 
     mutating func projectedInput(for pendingInput: Double, at timestamp: TimeInterval) -> Double {
@@ -554,18 +566,37 @@ private struct WheelInputVelocityEstimator {
 
         advance(to: timestamp)
 
-        guard rateAdjustedInput != 0,
-              rateAdjustedInput.sign == pendingInput.sign,
-              abs(rateAdjustedInput) > abs(pendingInput) else {
-            return pendingInput
+        var projectedInput = pendingInput
+        if rateAdjustedInput != 0,
+           rateAdjustedInput.sign == pendingInput.sign,
+           abs(rateAdjustedInput) > abs(projectedInput) {
+            projectedInput = rateAdjustedInput
         }
-        return rateAdjustedInput
+
+        // The rate projection restores wheel input split across high-frequency ticks,
+        // but it must not exceed the real signed distance received recently.
+        let recentInput = recentInputs.reduce(0) { $0 + $1.delta }
+        guard recentInput != 0,
+              recentInput.sign == projectedInput.sign else {
+            return projectedInput
+        }
+
+        let projectedMagnitude = abs(projectedInput)
+        let inputMagnitude = abs(pendingInput)
+        let recentMagnitude = abs(recentInput)
+        if projectedMagnitude > recentMagnitude {
+            let cappedMagnitude = max(inputMagnitude, recentMagnitude)
+            projectedInput = projectedInput.sign == .minus ? -cappedMagnitude : cappedMagnitude
+        }
+
+        return projectedInput
     }
 
     mutating func reset() {
         rateAdjustedInput = 0
         direction = 0
         lastTimestamp = nil
+        recentInputs.removeAll(keepingCapacity: true)
     }
 
     private mutating func advance(to timestamp: TimeInterval) {
@@ -579,15 +610,17 @@ private struct WheelInputVelocityEstimator {
             self.lastTimestamp = timestamp
         }
 
-        guard dt <= Self.resetInterval else {
+        guard dt <= Self.inputGapResetInterval else {
             rateAdjustedInput = 0
             direction = 0
+            recentInputs.removeAll(keepingCapacity: true)
             return
         }
 
-        rateAdjustedInput *= exp(-dt / Self.inputTimeConstant)
+        rateAdjustedInput *= exp(-dt / Self.rateSmoothingTimeConstant)
         if abs(rateAdjustedInput) < 0.001 {
             rateAdjustedInput = 0
         }
+        recentInputs.removeAll { timestamp - $0.timestamp > Self.recentInputLimitInterval }
     }
 }

--- a/LinearMouse/EventTransformer/SmoothedScrollingEngine.swift
+++ b/LinearMouse/EventTransformer/SmoothedScrollingEngine.swift
@@ -19,6 +19,11 @@ final class SmoothedScrollingEngine {
         case vertical
     }
 
+    enum InputKind {
+        case wheel
+        case continuousGesture
+    }
+
     struct Emission {
         var deltaX: Double
         var deltaY: Double
@@ -183,6 +188,8 @@ final class SmoothedScrollingEngine {
     private var lastInputTimestamp: TimeInterval?
     private var pendingInputX = 0.0
     private var pendingInputY = 0.0
+    private var wheelInputVelocityEstimatorX = WheelInputVelocityEstimator()
+    private var wheelInputVelocityEstimatorY = WheelInputVelocityEstimator()
     private var desiredVelocityX = 0.0
     private var desiredVelocityY = 0.0
     private var velocityX = 0.0
@@ -240,10 +247,12 @@ final class SmoothedScrollingEngine {
         switch activeAxis {
         case .horizontal:
             pendingInputX = 0
+            wheelInputVelocityEstimatorX.reset()
             desiredVelocityX = 0
             velocityX = 0
         case .vertical:
             pendingInputY = 0
+            wheelInputVelocityEstimatorY.reset()
             desiredVelocityY = 0
             velocityY = 0
         }
@@ -261,7 +270,12 @@ final class SmoothedScrollingEngine {
         }
     }
 
-    func feed(deltaX rawDeltaX: Double, deltaY rawDeltaY: Double, timestamp: TimeInterval) {
+    func feed(
+        deltaX rawDeltaX: Double,
+        deltaY rawDeltaY: Double,
+        timestamp: TimeInterval,
+        inputKind: InputKind = .wheel
+    ) {
         var deltaX = rawDeltaX
         var deltaY = rawDeltaY
 
@@ -271,6 +285,7 @@ final class SmoothedScrollingEngine {
 
         pendingInputX += deltaX
         pendingInputY += deltaY
+        updateWheelInputVelocityEstimator(deltaX: deltaX, deltaY: deltaY, timestamp: timestamp, inputKind: inputKind)
         lastInputTimestamp = timestamp
 
         if sessionState == .idle, deltaX != 0 || deltaY != 0 {
@@ -331,6 +346,26 @@ final class SmoothedScrollingEngine {
         input != 0 && velocity != 0 && input.sign != velocity.sign
     }
 
+    private func updateWheelInputVelocityEstimator(
+        deltaX: Double,
+        deltaY: Double,
+        timestamp: TimeInterval,
+        inputKind: InputKind
+    ) {
+        switch inputKind {
+        case .wheel:
+            wheelInputVelocityEstimatorX.add(deltaX, timestamp: timestamp)
+            wheelInputVelocityEstimatorY.add(deltaY, timestamp: timestamp)
+        case .continuousGesture:
+            if deltaX != 0 {
+                wheelInputVelocityEstimatorX.reset()
+            }
+            if deltaY != 0 {
+                wheelInputVelocityEstimatorY.reset()
+            }
+        }
+    }
+
     func advance(to timestamp: TimeInterval) -> Emission? {
         let previousTick = lastTickTimestamp ?? timestamp
         let dt = (timestamp - previousTick).clamped(to: 1.0 / 240.0 ... 1.0 / 24.0)
@@ -339,10 +374,13 @@ final class SmoothedScrollingEngine {
         let hasPendingInput = pendingInputX != 0 || pendingInputY != 0
         let hasFreshInput = lastInputTimestamp.map { timestamp - $0 <= inputGrace } ?? false
         let shouldBlendMomentumReengagement = reengagedFromMomentum && hasPendingInput
+        let effectiveInputX = wheelInputVelocityEstimatorX.projectedInput(for: pendingInputX, at: timestamp)
+        let effectiveInputY = wheelInputVelocityEstimatorY.projectedInput(for: pendingInputY, at: timestamp)
 
         let emissionX = advanceAxis(
             behavior: horizontalBehavior,
             pendingInput: &pendingInputX,
+            effectiveInput: effectiveInputX,
             desiredVelocity: &desiredVelocityX,
             velocity: &velocityX,
             hasPendingInput: hasPendingInput,
@@ -353,6 +391,7 @@ final class SmoothedScrollingEngine {
         let emissionY = advanceAxis(
             behavior: verticalBehavior,
             pendingInput: &pendingInputY,
+            effectiveInput: effectiveInputY,
             desiredVelocity: &desiredVelocityY,
             velocity: &velocityY,
             hasPendingInput: hasPendingInput,
@@ -388,10 +427,14 @@ final class SmoothedScrollingEngine {
                 sessionState = .momentum
                 pendingMomentumBegin = true
                 touchHasBegun = false
+                wheelInputVelocityEstimatorX.reset()
+                wheelInputVelocityEstimatorY.reset()
                 return .init(deltaX: 0, deltaY: 0, phase: .touchEnded)
             }
 
             sessionState = .idle
+            wheelInputVelocityEstimatorX.reset()
+            wheelInputVelocityEstimatorY.reset()
             velocityX = 0
             velocityY = 0
             desiredVelocityX = 0
@@ -402,6 +445,8 @@ final class SmoothedScrollingEngine {
         case .momentum:
             guard hasMovement || shouldContinueMomentum else {
                 sessionState = .idle
+                wheelInputVelocityEstimatorX.reset()
+                wheelInputVelocityEstimatorY.reset()
                 velocityX = 0
                 velocityY = 0
                 desiredVelocityX = 0
@@ -423,6 +468,7 @@ final class SmoothedScrollingEngine {
     private func advanceAxis(
         behavior: AxisBehavior,
         pendingInput: inout Double,
+        effectiveInput: Double,
         desiredVelocity: inout Double,
         velocity: inout Double,
         hasPendingInput: Bool,
@@ -440,8 +486,8 @@ final class SmoothedScrollingEngine {
         case let .smoothed(tuning):
             if pendingInput != 0 {
                 desiredVelocity = reengagedFromMomentum
-                    ? tuning.reengagedDesiredVelocity(for: pendingInput, currentVelocity: velocity)
-                    : tuning.desiredVelocity(for: pendingInput)
+                    ? tuning.reengagedDesiredVelocity(for: effectiveInput, currentVelocity: velocity)
+                    : tuning.desiredVelocity(for: effectiveInput)
                 if reengagedFromMomentum {
                     let kick = tuning.reengagementKickFactor(
                         desiredVelocity: desiredVelocity,
@@ -473,5 +519,75 @@ final class SmoothedScrollingEngine {
         abs(pendingInput) >= axisActivityThreshold
             || abs(desiredVelocity) >= axisActivityThreshold
             || abs(velocity) >= axisActivityThreshold
+    }
+}
+
+private struct WheelInputVelocityEstimator {
+    private static let resetInterval: TimeInterval = 1.0 / 25.0
+    private static let inputTimeConstant: TimeInterval = 1.0 / 20.0
+    private static let referenceInterval: TimeInterval = 1.0 / 45.0
+
+    private var rateAdjustedInput = 0.0
+    private var direction = 0
+    private var lastTimestamp: TimeInterval?
+
+    mutating func add(_ delta: Double, timestamp: TimeInterval) {
+        guard delta != 0 else {
+            return
+        }
+
+        advance(to: timestamp)
+        let currentDirection = delta > 0 ? 1 : -1
+        if direction != 0, currentDirection != direction {
+            rateAdjustedInput = 0
+        }
+
+        direction = currentDirection
+        rateAdjustedInput += delta * Self.referenceInterval / Self.inputTimeConstant
+    }
+
+    mutating func projectedInput(for pendingInput: Double, at timestamp: TimeInterval) -> Double {
+        guard pendingInput != 0 else {
+            advance(to: timestamp)
+            return 0
+        }
+
+        advance(to: timestamp)
+
+        guard rateAdjustedInput != 0,
+              rateAdjustedInput.sign == pendingInput.sign,
+              abs(rateAdjustedInput) > abs(pendingInput) else {
+            return pendingInput
+        }
+        return rateAdjustedInput
+    }
+
+    mutating func reset() {
+        rateAdjustedInput = 0
+        direction = 0
+        lastTimestamp = nil
+    }
+
+    private mutating func advance(to timestamp: TimeInterval) {
+        guard let lastTimestamp else {
+            lastTimestamp = timestamp
+            return
+        }
+
+        let dt = max(timestamp - lastTimestamp, 0)
+        defer {
+            self.lastTimestamp = timestamp
+        }
+
+        guard dt <= Self.resetInterval else {
+            rateAdjustedInput = 0
+            direction = 0
+            return
+        }
+
+        rateAdjustedInput *= exp(-dt / Self.inputTimeConstant)
+        if abs(rateAdjustedInput) < 0.001 {
+            rateAdjustedInput = 0
+        }
     }
 }

--- a/LinearMouse/EventTransformer/SmoothedScrollingTransformer.swift
+++ b/LinearMouse/EventTransformer/SmoothedScrollingTransformer.swift
@@ -101,6 +101,7 @@ final class SmoothedScrollingTransformer: EventTransformer, Deactivatable {
         endSyntheticGestureScrollSeriesIfNeeded(phase: .cancelled)
         stopTimer()
         engine = SmoothedScrollingEngine(smoothed: smoothed)
+        delivery.resetPointDeltaRemainders()
         lastFlags = []
     }
 
@@ -172,6 +173,7 @@ final class SmoothedScrollingTransformer: EventTransformer, Deactivatable {
         if shouldResetAfterNativePhase {
             engine = SmoothedScrollingEngine(smoothed: smoothed)
             stopTimer()
+            delivery.resetPointDeltaRemainders()
         }
 
         return event
@@ -186,6 +188,7 @@ final class SmoothedScrollingTransformer: EventTransformer, Deactivatable {
         guard let emission = engine.advance(to: now()) else {
             if !engine.isRunning {
                 stopTimer()
+                delivery.resetPointDeltaRemainders()
             }
             return
         }
@@ -194,6 +197,7 @@ final class SmoothedScrollingTransformer: EventTransformer, Deactivatable {
 
         if !engine.isRunning {
             stopTimer()
+            delivery.resetPointDeltaRemainders()
         }
     }
 
@@ -327,9 +331,14 @@ private extension CGSGesturePhase {
     }
 }
 
-private struct SmoothedScrollEventDelivery {
+private final class SmoothedScrollEventDelivery {
     private static let inputLineStepInPoints = 36.0
     private static let outputLineStepInPoints = 12.0
+    private var pointDeltaAccumulator = SmoothedScrollPointDeltaAccumulator()
+
+    func resetPointDeltaRemainders() {
+        pointDeltaAccumulator.reset()
+    }
 
     func apply(
         phases: (scrollPhase: CGScrollPhase?, momentumPhase: CGMomentumScrollPhase),
@@ -407,35 +416,59 @@ private struct SmoothedScrollEventDelivery {
 
     func setHorizontal(_ value: Double, on view: ScrollWheelEventView) {
         view.deltaX = integerDelta(for: value)
-        view.deltaXPt = pointDelta(for: value)
+        view.deltaXPt = pointDeltaAccumulator.horizontalPointDelta(for: value)
         view.deltaXFixedPt = value
         view.ioHidScrollX = value
     }
 
     func setVertical(_ value: Double, on view: ScrollWheelEventView) {
         view.deltaY = integerDelta(for: value)
-        view.deltaYPt = pointDelta(for: value)
+        view.deltaYPt = pointDeltaAccumulator.verticalPointDelta(for: value)
         view.deltaYFixedPt = value
         view.ioHidScrollY = value
     }
 
     func zeroHorizontal(on view: ScrollWheelEventView) {
-        setHorizontal(0, on: view)
+        view.deltaX = 0
+        view.deltaXPt = 0
+        view.deltaXFixedPt = 0
+        view.ioHidScrollX = 0
     }
 
     func zeroVertical(on view: ScrollWheelEventView) {
-        setVertical(0, on: view)
+        view.deltaY = 0
+        view.deltaYPt = 0
+        view.deltaYFixedPt = 0
+        view.ioHidScrollY = 0
     }
 
     private func integerDelta(for value: Double) -> Int64 {
         Int64((value / Self.outputLineStepInPoints).rounded(.towardZero))
     }
+}
 
-    private func pointDelta(for value: Double) -> Double {
-        guard value != 0 else {
-            return 0
-        }
+struct SmoothedScrollPointDeltaAccumulator {
+    private var horizontalRemainder = 0.0
+    private var verticalRemainder = 0.0
 
-        return Double(Int64(value.rounded(.towardZero)))
+    mutating func reset() {
+        horizontalRemainder = 0
+        verticalRemainder = 0
+    }
+
+    mutating func horizontalPointDelta(for value: Double) -> Double {
+        pointDelta(for: value, remainder: &horizontalRemainder)
+    }
+
+    mutating func verticalPointDelta(for value: Double) -> Double {
+        pointDelta(for: value, remainder: &verticalRemainder)
+    }
+
+    private func pointDelta(for value: Double, remainder: inout Double) -> Double {
+        let combinedValue = value + remainder
+        let pointDelta = Double(Int64(combinedValue.rounded(.towardZero)))
+        remainder = combinedValue - pointDelta
+
+        return pointDelta
     }
 }

--- a/LinearMouse/EventTransformer/SmoothedScrollingTransformer.swift
+++ b/LinearMouse/EventTransformer/SmoothedScrollingTransformer.swift
@@ -375,11 +375,11 @@ private struct SmoothedScrollEventDelivery {
                 return view.deltaXFixedPt * Self.inputLineStepInPoints * 10
             }
         }
-        if view.deltaXPt != 0 {
-            return view.deltaXPt
-        }
         if view.deltaXFixedPt != 0 {
             return view.deltaXFixedPt
+        }
+        if view.deltaXPt != 0 {
+            return view.deltaXPt
         }
         return Double(view.deltaX) * Self.inputLineStepInPoints
     }
@@ -396,11 +396,11 @@ private struct SmoothedScrollEventDelivery {
                 return view.deltaYFixedPt * Self.inputLineStepInPoints * 10
             }
         }
-        if view.deltaYPt != 0 {
-            return view.deltaYPt
-        }
         if view.deltaYFixedPt != 0 {
             return view.deltaYFixedPt
+        }
+        if view.deltaYPt != 0 {
+            return view.deltaYPt
         }
         return Double(view.deltaY) * Self.inputLineStepInPoints
     }

--- a/LinearMouse/EventTransformer/SmoothedScrollingTransformer.swift
+++ b/LinearMouse/EventTransformer/SmoothedScrollingTransformer.swift
@@ -193,7 +193,12 @@ final class SmoothedScrollingTransformer: EventTransformer, Deactivatable {
             return delivery.deltaXInPixels(from: view)
         }
 
-        return LogitechHighResolutionWheelUnitReader.horizontalUnits(from: view, multiplier: multiplier)
+        let unitResolution = LogitechHighResolutionWheelUnitReader.horizontalUnitResolution(
+            from: view,
+            multiplier: multiplier
+        )
+        let smoothedUnits = Self.smoothedHighResolutionUnits(from: unitResolution)
+        return smoothedUnits
             * SmoothedScrollEventDelivery.inputLineStepInPoints
             / Double(multiplier)
     }
@@ -205,9 +210,28 @@ final class SmoothedScrollingTransformer: EventTransformer, Deactivatable {
             return delivery.deltaYInPixels(from: view)
         }
 
-        return LogitechHighResolutionWheelUnitReader.verticalUnits(from: view, multiplier: multiplier)
+        let unitResolution = LogitechHighResolutionWheelUnitReader.verticalUnitResolution(
+            from: view,
+            multiplier: multiplier
+        )
+        let smoothedUnits = Self.smoothedHighResolutionUnits(from: unitResolution)
+        return smoothedUnits
             * SmoothedScrollEventDelivery.inputLineStepInPoints
             / Double(multiplier)
+    }
+
+    static func smoothedHighResolutionUnits(
+        from unitResolution: LogitechHighResolutionWheelUnitReader.UnitResolution
+    ) -> Double {
+        let rawMagnitude = abs(unitResolution.rawUnits)
+        guard rawMagnitude > 1 else {
+            return unitResolution.rawUnits
+        }
+
+        let acceleratedMagnitude = abs(unitResolution.units)
+        let accelerationConfidence = 1 - 1 / rawMagnitude
+        let magnitude = rawMagnitude + (acceleratedMagnitude - rawMagnitude) * accelerationConfidence
+        return unitResolution.rawUnits.sign == .minus ? -magnitude : magnitude
     }
 
     private func stopTimer() {

--- a/LinearMouse/EventTransformer/SmoothedScrollingTransformer.swift
+++ b/LinearMouse/EventTransformer/SmoothedScrollingTransformer.swift
@@ -11,6 +11,7 @@ final class SmoothedScrollingTransformer: EventTransformer, Deactivatable {
     )
     private static let timerInterval: TimeInterval = 1.0 / 120.0
     private let smoothed: Scheme.Scrolling.Bidirectional<Scheme.Scrolling.Smoothed>
+    private let highResolutionWheelMultiplier: () -> Int?
     private let now: () -> TimeInterval
     private let eventSink: (CGEvent) -> Void
     private let delivery = SmoothedScrollEventDelivery()
@@ -19,13 +20,16 @@ final class SmoothedScrollingTransformer: EventTransformer, Deactivatable {
     private var timer: EventThreadTimer?
     private var lastFlags: CGEventFlags = []
     private var syntheticGestureScrollSeriesActive = false
+    private var syntheticMomentumScrollActive = false
 
     init(
         smoothed: Scheme.Scrolling.Bidirectional<Scheme.Scrolling.Smoothed>,
+        highResolutionWheelMultiplier: @escaping () -> Int? = { nil },
         now: @escaping () -> TimeInterval = { ProcessInfo.processInfo.systemUptime },
         eventSink: @escaping (CGEvent) -> Void = { $0.post(tap: .cgSessionEventTap) }
     ) {
         self.smoothed = smoothed
+        self.highResolutionWheelMultiplier = highResolutionWheelMultiplier
         self.now = now
         self.eventSink = eventSink
         engine = SmoothedScrollingEngine(smoothed: smoothed)
@@ -42,8 +46,8 @@ final class SmoothedScrollingTransformer: EventTransformer, Deactivatable {
             return event
         }
 
-        let deltaX = delivery.deltaXInPixels(from: view)
-        let deltaY = delivery.deltaYInPixels(from: view)
+        let deltaX = deltaXInPixels(from: view)
+        let deltaY = deltaYInPixels(from: view)
         let hasNativePhase = view.scrollPhase != nil
         let hasNativeMomentum = view.momentumPhase != .none
 
@@ -77,7 +81,8 @@ final class SmoothedScrollingTransformer: EventTransformer, Deactivatable {
             engine.feed(
                 deltaX: handlesX ? deltaX : 0,
                 deltaY: handlesY ? deltaY : 0,
-                timestamp: now()
+                timestamp: now(),
+                inputKind: .wheel
             )
             startTimerIfNeeded()
         }
@@ -103,6 +108,7 @@ final class SmoothedScrollingTransformer: EventTransformer, Deactivatable {
         engine = SmoothedScrollingEngine(smoothed: smoothed)
         delivery.resetPointDeltaRemainders()
         lastFlags = []
+        syntheticMomentumScrollActive = false
     }
 
     private func startTimerIfNeeded() {
@@ -142,7 +148,8 @@ final class SmoothedScrollingTransformer: EventTransformer, Deactivatable {
             engine.feed(
                 deltaX: handlesX ? deltaX : 0,
                 deltaY: handlesY ? deltaY : 0,
-                timestamp: now()
+                timestamp: now(),
+                inputKind: .continuousGesture
             )
         }
 
@@ -177,6 +184,30 @@ final class SmoothedScrollingTransformer: EventTransformer, Deactivatable {
         }
 
         return event
+    }
+
+    private func deltaXInPixels(from view: ScrollWheelEventView) -> Double {
+        guard let multiplier = highResolutionWheelMultiplier(),
+              multiplier > 1,
+              !view.continuous else {
+            return delivery.deltaXInPixels(from: view)
+        }
+
+        return LogitechHighResolutionWheelUnitReader.horizontalUnits(from: view, multiplier: multiplier)
+            * SmoothedScrollEventDelivery.inputLineStepInPoints
+            / Double(multiplier)
+    }
+
+    private func deltaYInPixels(from view: ScrollWheelEventView) -> Double {
+        guard let multiplier = highResolutionWheelMultiplier(),
+              multiplier > 1,
+              !view.continuous else {
+            return delivery.deltaYInPixels(from: view)
+        }
+
+        return LogitechHighResolutionWheelUnitReader.verticalUnits(from: view, multiplier: multiplier)
+            * SmoothedScrollEventDelivery.inputLineStepInPoints
+            / Double(multiplier)
     }
 
     private func stopTimer() {
@@ -217,32 +248,86 @@ final class SmoothedScrollingTransformer: EventTransformer, Deactivatable {
 
         let view = ScrollWheelEventView(event)
         view.continuous = true
-        delivery.setHorizontal(emission.deltaX, on: view)
-        delivery.setVertical(emission.deltaY, on: view)
-        let phases = delivery.phasesFor(emission.phase, appliesPhases: allowsBouncingForConfiguredAxes())
+        let accumulatesSubpixelDelta = emission.phase.accumulatesSyntheticSubpixelDelta
+        delivery.setSyntheticHorizontal(
+            emission.deltaX,
+            on: view,
+            accumulatesSubpixelDelta: accumulatesSubpixelDelta
+        )
+        delivery.setSyntheticVertical(
+            emission.deltaY,
+            on: view,
+            accumulatesSubpixelDelta: accumulatesSubpixelDelta
+        )
+
+        guard let phase = syntheticPhase(for: emission.phase, hasDelta: delivery.hasDelta(on: view)) else {
+            return
+        }
+
+        let phases = delivery.phasesFor(phase, appliesPhases: allowsBouncingForConfiguredAxes())
         delivery.apply(phases: phases, to: view)
-        guard view.scrollPhase != nil || view.momentumPhase != .none || emission.deltaX != 0 || emission.deltaY != 0
+        guard view.scrollPhase != nil || view.momentumPhase != .none || delivery.hasDelta(on: view)
         else {
             return
         }
         event.isLinearMouseSyntheticEvent = true
         event.flags = lastFlags
+        let postedDeltaX = view.deltaXFixedPt
+        let postedDeltaY = view.deltaYFixedPt
         postGestureScrollCompanionsIfNeeded(
             scrollPhase: phases.scrollPhase,
-            deltaX: emission.deltaX,
-            deltaY: emission.deltaY
+            deltaX: postedDeltaX,
+            deltaY: postedDeltaY
         )
         eventSink(event)
+        updateSyntheticMomentumState(afterPosting: phase)
 
         os_log(
             "post smoothed scroll deltaX=%{public}.3f deltaY=%{public}.3f phase=%{public}@ momentum=%{public}@",
             log: Self.log,
             type: .info,
-            emission.deltaX,
-            emission.deltaY,
+            postedDeltaX,
+            postedDeltaY,
             String(describing: view.scrollPhase),
             String(describing: view.momentumPhase)
         )
+    }
+
+    private func syntheticPhase(
+        for phase: SmoothedScrollingEngine.Phase,
+        hasDelta: Bool
+    ) -> SmoothedScrollingEngine.Phase? {
+        switch phase {
+        case .touchBegan:
+            return hasDelta ? .touchBegan : nil
+        case .touchChanged:
+            guard hasDelta else {
+                return nil
+            }
+            return syntheticGestureScrollSeriesActive ? .touchChanged : .touchBegan
+        case .touchEnded:
+            return syntheticGestureScrollSeriesActive ? .touchEnded : nil
+        case .momentumBegan:
+            return hasDelta ? .momentumBegan : nil
+        case .momentumChanged:
+            guard hasDelta else {
+                return nil
+            }
+            return syntheticMomentumScrollActive ? .momentumChanged : .momentumBegan
+        case .momentumEnded:
+            return syntheticMomentumScrollActive ? .momentumEnded : nil
+        }
+    }
+
+    private func updateSyntheticMomentumState(afterPosting phase: SmoothedScrollingEngine.Phase) {
+        switch phase {
+        case .momentumBegan:
+            syntheticMomentumScrollActive = true
+        case .momentumEnded:
+            syntheticMomentumScrollActive = false
+        case .touchBegan, .touchChanged, .touchEnded, .momentumChanged:
+            break
+        }
     }
 
     private func postGestureScrollCompanionsIfNeeded(
@@ -331,8 +416,19 @@ private extension CGSGesturePhase {
     }
 }
 
+private extension SmoothedScrollingEngine.Phase {
+    var accumulatesSyntheticSubpixelDelta: Bool {
+        switch self {
+        case .touchBegan, .touchChanged, .touchEnded:
+            return true
+        case .momentumBegan, .momentumChanged, .momentumEnded:
+            return false
+        }
+    }
+}
+
 private final class SmoothedScrollEventDelivery {
-    private static let inputLineStepInPoints = 36.0
+    static let inputLineStepInPoints = 36.0
     private static let outputLineStepInPoints = 12.0
     private var pointDeltaAccumulator = SmoothedScrollPointDeltaAccumulator()
 
@@ -428,6 +524,34 @@ private final class SmoothedScrollEventDelivery {
         view.ioHidScrollY = value
     }
 
+    func setSyntheticHorizontal(
+        _ value: Double,
+        on view: ScrollWheelEventView,
+        accumulatesSubpixelDelta: Bool
+    ) {
+        setSyntheticHorizontalOutput(
+            pointDeltaAccumulator.horizontalPointDelta(
+                for: value,
+                accumulates: accumulatesSubpixelDelta
+            ),
+            on: view
+        )
+    }
+
+    func setSyntheticVertical(
+        _ value: Double,
+        on view: ScrollWheelEventView,
+        accumulatesSubpixelDelta: Bool
+    ) {
+        setSyntheticVerticalOutput(
+            pointDeltaAccumulator.verticalPointDelta(
+                for: value,
+                accumulates: accumulatesSubpixelDelta
+            ),
+            on: view
+        )
+    }
+
     func zeroHorizontal(on view: ScrollWheelEventView) {
         view.deltaX = 0
         view.deltaXPt = 0
@@ -440,6 +564,27 @@ private final class SmoothedScrollEventDelivery {
         view.deltaYPt = 0
         view.deltaYFixedPt = 0
         view.ioHidScrollY = 0
+    }
+
+    func hasDelta(on view: ScrollWheelEventView) -> Bool {
+        view.deltaX != 0 || view.deltaY != 0 ||
+            view.deltaXPt != 0 || view.deltaYPt != 0 ||
+            view.deltaXFixedPt != 0 || view.deltaYFixedPt != 0 ||
+            view.ioHidScrollX != 0 || view.ioHidScrollY != 0
+    }
+
+    private func setSyntheticHorizontalOutput(_ value: Double, on view: ScrollWheelEventView) {
+        view.deltaX = integerDelta(for: value)
+        view.deltaXPt = value
+        view.deltaXFixedPt = value
+        view.ioHidScrollX = value
+    }
+
+    private func setSyntheticVerticalOutput(_ value: Double, on view: ScrollWheelEventView) {
+        view.deltaY = integerDelta(for: value)
+        view.deltaYPt = value
+        view.deltaYFixedPt = value
+        view.ioHidScrollY = value
     }
 
     private func integerDelta(for value: Double) -> Int64 {
@@ -456,19 +601,28 @@ struct SmoothedScrollPointDeltaAccumulator {
         verticalRemainder = 0
     }
 
-    mutating func horizontalPointDelta(for value: Double) -> Double {
-        pointDelta(for: value, remainder: &horizontalRemainder)
+    mutating func horizontalPointDelta(for value: Double, accumulates: Bool = true) -> Double {
+        pointDelta(for: value, remainder: &horizontalRemainder, accumulates: accumulates)
     }
 
-    mutating func verticalPointDelta(for value: Double) -> Double {
-        pointDelta(for: value, remainder: &verticalRemainder)
+    mutating func verticalPointDelta(for value: Double, accumulates: Bool = true) -> Double {
+        pointDelta(for: value, remainder: &verticalRemainder, accumulates: accumulates)
     }
 
-    private func pointDelta(for value: Double, remainder: inout Double) -> Double {
+    private func pointDelta(for value: Double, remainder: inout Double, accumulates: Bool) -> Double {
+        guard accumulates else {
+            remainder = 0
+            return truncatedPointDelta(for: value)
+        }
+
         let combinedValue = value + remainder
-        let pointDelta = Double(Int64(combinedValue.rounded(.towardZero)))
+        let pointDelta = truncatedPointDelta(for: combinedValue)
         remainder = combinedValue - pointDelta
 
         return pointDelta
+    }
+
+    private func truncatedPointDelta(for value: Double) -> Double {
+        Double(Int64(value.rounded(.towardZero)))
     }
 }

--- a/LinearMouse/Localizable.xcstrings
+++ b/LinearMouse/Localizable.xcstrings
@@ -27110,6 +27110,214 @@
         }
       }
     },
+    "High resolution wheel" : {
+      "localizations" : {
+        "af" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hoëresolusie-wiel"
+          }
+        },
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "عجلة عالية الدقة"
+          }
+        },
+        "bs" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Točkić visoke rezolucije"
+          }
+        },
+        "ca" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Roda d’alta resolució"
+          }
+        },
+        "cs" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kolečko s vysokým rozlišením"
+          }
+        },
+        "da" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Højopløsningshjul"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hochauflösendes Mausrad"
+          }
+        },
+        "el" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Τροχός υψηλής ανάλυσης"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Rueda de alta resolución"
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Korkean tarkkuuden rulla"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Molette haute résolution"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "גלגלת ברזולוציה גבוהה"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nagy felbontású görgő"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Roda resolusi tinggi"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Rotellina ad alta risoluzione"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "高解像度ホイール"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "고해상도 휠"
+          }
+        },
+        "my" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ကြည်လင်ပြတ်သားမှုမြင့် Wheel"
+          }
+        },
+        "nb-NO" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Høyoppløselig hjul"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Wiel met hoge resolutie"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kółko o wysokiej rozdzielczości"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Roda de alta resolução"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Roda de alta resolução"
+          }
+        },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Rotiță de înaltă rezoluție"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Колесо высокого разрешения"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Koliesko s vysokým rozlíšením"
+          }
+        },
+        "sr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Точкић високе резолуције"
+          }
+        },
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Högupplöst hjul"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Yüksek çözünürlüklü tekerlek"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Коліщатко високої роздільної здатності"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bánh xe độ phân giải cao"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "高分辨率滚轮"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "高解析度滾輪"
+          }
+        },
+        "zh-Hant-HK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "高解像度滾輪"
+          }
+        }
+      }
+    },
     "Hold keys while pressed" : {
       "localizations" : {
         "af" : {
@@ -59614,6 +59822,214 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "檢查更新間隔"
+          }
+        }
+      }
+    },
+    "Use finer vertical wheel steps on supported Logitech mice." : {
+      "localizations" : {
+        "af" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Gebruik fyner vertikale wielstappe op ondersteunde Logitech-muise."
+          }
+        },
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "استخدم خطوات عجلة عمودية أدق على فئران Logitech المدعومة."
+          }
+        },
+        "bs" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Koristite finije vertikalne korake točkića na podržanim Logitech miševima."
+          }
+        },
+        "ca" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Utilitza passos verticals de roda més fins en ratolins Logitech compatibles."
+          }
+        },
+        "cs" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Používejte jemnější svislé kroky kolečka u podporovaných myší Logitech."
+          }
+        },
+        "da" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Brug finere lodrette hjultrin på understøttede Logitech-mus."
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Verwende feinere vertikale Mausradschritte bei unterstützten Logitech-Mäusen."
+          }
+        },
+        "el" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Χρησιμοποιήστε λεπτότερα κατακόρυφα βήματα τροχού σε υποστηριζόμενα ποντίκια Logitech."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Usa pasos verticales de rueda más precisos en ratones Logitech compatibles."
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Käytä hienojakoisempia pystysuuntaisia rullausaskelia tuetuissa Logitech-hiirissä."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Utilisez des pas verticaux de molette plus fins sur les souris Logitech compatibles."
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "השתמשו בצעדי גלגלת אנכיים עדינים יותר בעכברי Logitech נתמכים."
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Használjon finomabb függőleges görgőlépéseket a támogatott Logitech egereken."
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Gunakan langkah roda vertikal yang lebih halus pada mouse Logitech yang didukung."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Usa passaggi verticali più fini della rotellina sui mouse Logitech supportati."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "対応するLogitechマウスで、より細かい垂直ホイールステップを使用します。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "지원되는 Logitech 마우스에서 더 세밀한 세로 휠 단계를 사용합니다."
+          }
+        },
+        "my" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ထောက်ပံ့ထားသော Logitech mouse များတွင် ပိုအသေးစိတ်သော ဒေါင်လိုက် wheel အဆင့်များကို အသုံးပြုပါ။"
+          }
+        },
+        "nb-NO" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bruk finere vertikale hjultrinn på støttede Logitech-mus."
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Gebruik fijnere verticale wielstappen op ondersteunde Logitech-muizen."
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Używaj dokładniejszych pionowych kroków kółka w obsługiwanych myszach Logitech."
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Use passos verticais mais finos da roda em ratos Logitech suportados."
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Use etapas verticais mais precisas da roda em mouses Logitech compatíveis."
+          }
+        },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Folosește pași verticali mai fini ai rotiței pe mouse-urile Logitech acceptate."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Используйте более точные вертикальные шаги колеса на поддерживаемых мышах Logitech."
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Používajte jemnejšie zvislé kroky kolieska na podporovaných myšiach Logitech."
+          }
+        },
+        "sr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Користите финије вертикалне кораке точкића на подржаним Logitech мишевима."
+          }
+        },
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Använd finare vertikala hjulsteg på Logitech-möss som stöds."
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Desteklenen Logitech farelerde daha ince dikey tekerlek adımları kullanın."
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Використовуйте точніші вертикальні кроки коліщатка на підтримуваних мишах Logitech."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sử dụng các bước bánh xe dọc mịn hơn trên chuột Logitech được hỗ trợ."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "在支持的罗技鼠标上使用更细腻的垂直滚轮步进。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "在支援的羅技滑鼠上使用更細緻的垂直滾輪步進。"
+          }
+        },
+        "zh-Hant-HK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "在支援的羅技滑鼠上使用更細緻的垂直滾輪步進。"
           }
         }
       }

--- a/LinearMouse/Model/Configuration/Scheme/Logitech.swift
+++ b/LinearMouse/Model/Configuration/Scheme/Logitech.swift
@@ -1,0 +1,26 @@
+// MIT License
+// Copyright (c) 2021-2026 LinearMouse
+
+import Foundation
+
+extension Scheme {
+    struct Logitech: Codable, Equatable, ImplicitInitable {
+        var highResolutionWheel: Bool?
+    }
+}
+
+extension Scheme.Logitech {
+    func merge(into logitech: inout Self) {
+        if let highResolutionWheel {
+            logitech.highResolutionWheel = highResolutionWheel
+        }
+    }
+
+    func merge(into logitech: inout Self?) {
+        if logitech == nil {
+            logitech = Self()
+        }
+
+        merge(into: &logitech!)
+    }
+}

--- a/LinearMouse/Model/Configuration/Scheme/Scheme.swift
+++ b/LinearMouse/Model/Configuration/Scheme/Scheme.swift
@@ -21,16 +21,20 @@ struct Scheme: Codable, Equatable {
 
     @ImplicitOptional var buttons: Buttons
 
+    @ImplicitOptional var logitech: Logitech
+
     init(
         if: [If]? = nil,
         scrolling: Scrolling? = nil,
         pointer: Pointer? = nil,
-        buttons: Buttons? = nil
+        buttons: Buttons? = nil,
+        logitech: Logitech? = nil
     ) {
         self.if = `if`
         $scrolling = scrolling
         $pointer = pointer
         $buttons = buttons
+        $logitech = logitech
     }
 }
 
@@ -188,6 +192,7 @@ extension Scheme {
         $scrolling?.merge(into: &scheme.scrolling)
         $pointer?.merge(into: &scheme.pointer)
         $buttons?.merge(into: &scheme.buttons)
+        $logitech?.merge(into: &scheme.logitech)
     }
 }
 

--- a/LinearMouse/UI/ScrollingSettings/LogitechHighResolutionWheelSection.swift
+++ b/LinearMouse/UI/ScrollingSettings/LogitechHighResolutionWheelSection.swift
@@ -1,0 +1,22 @@
+// MIT License
+// Copyright (c) 2021-2026 LinearMouse
+
+import SwiftUI
+
+extension ScrollingSettings {
+    struct LogitechHighResolutionWheelSection: View {
+        @ObservedObject private var state = ScrollingSettingsState.shared
+
+        var body: some View {
+            Section {
+                Toggle(isOn: $state.highResolutionWheel) {
+                    withDescription {
+                        Text("High resolution wheel")
+                        Text("Use finer vertical wheel steps on supported Logitech mice.")
+                    }
+                }
+            }
+            .modifier(SectionViewModifier())
+        }
+    }
+}

--- a/LinearMouse/UI/ScrollingSettings/ScrollingSettings.swift
+++ b/LinearMouse/UI/ScrollingSettings/ScrollingSettings.swift
@@ -4,6 +4,8 @@
 import SwiftUI
 
 struct ScrollingSettings: View {
+    @ObservedObject private var state = ScrollingSettingsState.shared
+
     var body: some View {
         DetailView {
             VStack(alignment: .leading) {
@@ -12,12 +14,19 @@ struct ScrollingSettings: View {
                 Form {
                     ReverseScrollingSection()
 
+                    if state.showsHighResolutionWheelControl {
+                        LogitechHighResolutionWheelSection()
+                    }
+
                     ScrollingModeSection()
 
                     ModifierKeysSection()
                 }
                 .modifier(FormViewModifier())
             }
+        }
+        .onAppear {
+            state.refreshHighResolutionWheelInfo()
         }
     }
 }

--- a/LinearMouse/UI/ScrollingSettings/ScrollingSettingsState.swift
+++ b/LinearMouse/UI/ScrollingSettings/ScrollingSettingsState.swift
@@ -10,7 +10,23 @@ class ScrollingSettingsState: ObservableObject {
     static let shared: ScrollingSettingsState = .init()
 
     @PublishedObject private var schemeState = SchemeState.shared
+    private let deviceState = DeviceState.shared
+    private var subscriptions = Set<AnyCancellable>()
     private var smoothedCache = Scheme.Scrolling.Bidirectional<Scheme.Scrolling.Smoothed>()
+
+    @Published private(set) var highResolutionWheelInfo: Device.HighResolutionWheelInfo?
+    @Published private(set) var highResolutionWheelInfoRefreshing = false
+
+    private init() {
+        deviceState.$currentDeviceRef
+            .debounce(for: 0.1, scheduler: RunLoop.main)
+            .removeDuplicates()
+            .sink { [weak self] _ in
+                self?.resetHighResolutionWheelInfo()
+                self?.refreshHighResolutionWheelInfo()
+            }
+            .store(in: &subscriptions)
+    }
 
     var scheme: Scheme {
         get { schemeState.scheme }
@@ -22,12 +38,70 @@ class ScrollingSettingsState: ObservableObject {
     }
 
     @Published var direction: Scheme.Scrolling.BidirectionalDirection = .vertical
+
+    private var currentDevice: Device? {
+        deviceState.currentDeviceRef?.value
+    }
 }
 
 extension ScrollingSettingsState {
     var reverseScrolling: Bool {
         get { mergedScheme.scrolling.reverse[direction] ?? false }
         set { scheme.scrolling.reverse[direction] = newValue }
+    }
+
+    var showsHighResolutionWheelControl: Bool {
+        highResolutionWheelInfo?.supportsHighResolutionWheel == true
+    }
+
+    var highResolutionWheel: Bool {
+        get {
+            schemeState.deviceScheme.logitech.highResolutionWheel
+                ?? highResolutionWheelInfo?.enabled
+                ?? false
+        }
+        set {
+            var deviceScheme = schemeState.deviceScheme
+            deviceScheme.logitech.highResolutionWheel = newValue
+            schemeState.deviceScheme = deviceScheme
+
+            if let currentDevice {
+                DeviceManager.shared.updateHighResolutionWheel(for: currentDevice)
+            }
+        }
+    }
+
+    func refreshHighResolutionWheelInfo() {
+        guard !highResolutionWheelInfoRefreshing else {
+            return
+        }
+
+        guard let device = currentDevice else {
+            resetHighResolutionWheelInfo()
+            return
+        }
+
+        highResolutionWheelInfoRefreshing = true
+        device.refreshHighResolutionWheelInfo { [weak self] info in
+            guard let self else {
+                return
+            }
+
+            guard self.currentDevice === device else {
+                self.highResolutionWheelInfoRefreshing = false
+                self.resetHighResolutionWheelInfo()
+                self.refreshHighResolutionWheelInfo()
+                return
+            }
+
+            self.highResolutionWheelInfo = info
+            self.highResolutionWheelInfoRefreshing = false
+        }
+    }
+
+    private func resetHighResolutionWheelInfo() {
+        highResolutionWheelInfo = nil
+        highResolutionWheelInfoRefreshing = false
     }
 
     enum ScrollingMode: String, Identifiable, CaseIterable {

--- a/LinearMouseUnitTests/Device/VendorSpecific/LogitechHIDPPHighResolutionWheelControllerTests.swift
+++ b/LinearMouseUnitTests/Device/VendorSpecific/LogitechHIDPPHighResolutionWheelControllerTests.swift
@@ -1,0 +1,130 @@
+// MIT License
+// Copyright (c) 2021-2026 LinearMouse
+
+import Foundation
+@testable import LinearMouse
+import PointerKit
+import XCTest
+
+final class LogitechHIDPPHighResolutionWheelControllerTests: XCTestCase {
+    func testReadsAndWritesHighResolutionWheelMode() {
+        let device = MockVendorSpecificDeviceContext(
+            vendorID: 0x046D,
+            productID: 0xB015,
+            transport: PointerDeviceTransportName.bluetoothLowEnergy,
+            maxInputReportSize: 20,
+            maxOutputReportSize: 20
+        )
+        device.responseProvider = { report in
+            let bytes = [UInt8](report)
+            guard bytes.count >= 4 else {
+                return nil
+            }
+
+            switch (bytes[2], bytes[3]) {
+            case (0x00, 0x08):
+                guard bytes[4] == 0x21, bytes[5] == 0x21 else {
+                    return nil
+                }
+                return Self.hidppLongReply(featureIndex: 0x00, address: 0x08, payload: [0x1E])
+            case (0x1E, 0x08):
+                return Self.hidppLongReply(featureIndex: 0x1E, address: 0x08, payload: [0x08, 0x0C])
+            case (0x1E, 0x18):
+                return Self.hidppLongReply(featureIndex: 0x1E, address: 0x18, payload: [0x04, 0x00])
+            case (0x1E, 0x28):
+                return Self.hidppLongReply(featureIndex: 0x1E, address: 0x28, payload: [])
+            default:
+                return nil
+            }
+        }
+
+        let controller = LogitechHIDPPHighResolutionWheelController(device: device)
+
+        XCTAssertEqual(controller?.capabilities(), .init(multiplier: 8, flags: 0x0C))
+        XCTAssertEqual(controller?.isHighResolutionWheelEnabled(), false)
+        XCTAssertEqual(controller?.setHighResolutionWheelEnabled(true), true)
+        XCTAssertEqual(
+            device.sentReports.last.map { Array($0.prefix(5)) },
+            Optional([0x11, 0xFF, 0x1E, 0x28, 0x06] as [UInt8])
+        )
+    }
+
+    func testSkipsWritingWhenHighResolutionWheelModeAlreadyMatches() {
+        let device = MockVendorSpecificDeviceContext(
+            vendorID: 0x046D,
+            productID: 0xB015,
+            transport: PointerDeviceTransportName.bluetoothLowEnergy,
+            maxInputReportSize: 20,
+            maxOutputReportSize: 20
+        )
+        device.responseProvider = { report in
+            let bytes = [UInt8](report)
+            guard bytes.count >= 4 else {
+                return nil
+            }
+
+            switch (bytes[2], bytes[3]) {
+            case (0x00, 0x08):
+                return Self.hidppLongReply(featureIndex: 0x00, address: 0x08, payload: [0x1E])
+            case (0x1E, 0x18):
+                return Self.hidppLongReply(featureIndex: 0x1E, address: 0x18, payload: [0x06, 0x00])
+            default:
+                return nil
+            }
+        }
+
+        let controller = LogitechHIDPPHighResolutionWheelController(device: device)
+
+        XCTAssertEqual(controller?.setHighResolutionWheelEnabled(true), true)
+        XCTAssertEqual(device.outputReportRequestCount, 2)
+        XCTAssertEqual(
+            device.sentReports.last.map { Array($0.prefix(4)) },
+            Optional([0x11, 0xFF, 0x1E, 0x18] as [UInt8])
+        )
+    }
+
+    func testRejectsDeviceWithoutHiresWheelFeature() {
+        let device = MockVendorSpecificDeviceContext(
+            vendorID: 0x046D,
+            productID: 0xB015,
+            transport: PointerDeviceTransportName.bluetoothLowEnergy,
+            maxInputReportSize: 20,
+            maxOutputReportSize: 20
+        )
+        device.responseProvider = { report in
+            let bytes = [UInt8](report)
+            guard bytes.count >= 6, bytes[2] == 0x00, bytes[3] == 0x08 else {
+                return nil
+            }
+
+            return Self.hidppLongReply(featureIndex: 0x00, address: 0x08, payload: [0x00])
+        }
+
+        XCTAssertNil(LogitechHIDPPHighResolutionWheelController(device: device))
+    }
+
+    func testOnlySupportsBluetoothLowEnergyDevicesForNow() {
+        let device = MockVendorSpecificDeviceContext(
+            vendorID: 0x046D,
+            productID: 0xB015,
+            transport: PointerDeviceTransportName.usb,
+            maxInputReportSize: 20,
+            maxOutputReportSize: 20
+        )
+
+        XCTAssertNil(LogitechHIDPPHighResolutionWheelController(device: device))
+        XCTAssertEqual(device.outputReportRequestCount, 0)
+    }
+
+    private static func hidppLongReply(featureIndex: UInt8, address: UInt8, payload: [UInt8]) -> Data {
+        var bytes = [UInt8](repeating: 0, count: 20)
+        bytes[0] = 0x11
+        bytes[1] = 0xFF
+        bytes[2] = featureIndex
+        bytes[3] = address
+        for (index, byte) in payload.enumerated() where index + 4 < bytes.count {
+            bytes[index + 4] = byte
+        }
+        return Data(bytes)
+    }
+}

--- a/LinearMouseUnitTests/EventTransformer/LinearScrollingTransformerTests.swift
+++ b/LinearMouseUnitTests/EventTransformer/LinearScrollingTransformerTests.swift
@@ -95,6 +95,22 @@ final class LinearScrollingTransformerTests: XCTestCase {
         XCTAssertEqual(view.deltaYFixedPt, 62.60723876953125, accuracy: 0.001)
     }
 
+    func testHighResolutionWheelLinearDistanceShouldUseRawUnitsWhenAccelerationIsPresent() {
+        let resolution = LogitechHighResolutionWheelUnitReader.units(
+            integerDelta: 14,
+            pointDelta: 140,
+            fixedPointDelta: 13.943,
+            ioHidDelta: -1,
+            signum: 1,
+            multiplier: 8
+        )
+        let pixelDistance = abs(resolution.rawUnits) * 36 / 8
+
+        XCTAssertEqual(resolution.rawUnits, 1, accuracy: 0.001)
+        XCTAssertEqual(resolution.units, 14, accuracy: 0.001)
+        XCTAssertEqual(pixelDistance, 4.5, accuracy: 0.001)
+    }
+
     private func makeVerticalHighResolutionScrollEvent(
         multiplier: Int = 8,
         units: Double = 1

--- a/LinearMouseUnitTests/EventTransformer/LinearScrollingTransformerTests.swift
+++ b/LinearMouseUnitTests/EventTransformer/LinearScrollingTransformerTests.swift
@@ -49,10 +49,10 @@ final class LinearScrollingTransformerTests: XCTestCase {
         )
 
         for _ in 0 ..< 3 {
-            XCTAssertNil(try transformer.transform(makeVerticalScrollEvent()))
+            XCTAssertNil(try transformer.transform(makeVerticalHighResolutionScrollEvent()))
         }
 
-        let transformedEvent = try XCTUnwrap(try transformer.transform(makeVerticalScrollEvent()))
+        let transformedEvent = try XCTUnwrap(try transformer.transform(makeVerticalHighResolutionScrollEvent()))
         let view = ScrollWheelEventView(transformedEvent)
 
         XCTAssertFalse(view.continuous)
@@ -67,7 +67,7 @@ final class LinearScrollingTransformerTests: XCTestCase {
             now: { 0 }
         )
 
-        let transformedEvent = try XCTUnwrap(try transformer.transform(makeVerticalScrollEvent()))
+        let transformedEvent = try XCTUnwrap(try transformer.transform(makeVerticalHighResolutionScrollEvent()))
         let view = ScrollWheelEventView(transformedEvent)
 
         XCTAssertTrue(view.continuous)
@@ -77,14 +77,39 @@ final class LinearScrollingTransformerTests: XCTestCase {
         XCTAssertEqual(view.deltaYFixedPt, 4.5, accuracy: 0.001)
     }
 
-    private func makeVerticalScrollEvent() throws -> CGEvent {
-        try XCTUnwrap(CGEvent(
+    func testHighResolutionWheelPixelScrollingUsesFixedPointUnitsWhenIntegerDeltaIsCoalesced() throws {
+        let transformer = LinearScrollingVerticalTransformer(
+            distance: .pixel(36),
+            highResolutionWheelMultiplier: { 10 },
+            now: { 0 }
+        )
+
+        let transformedEvent = try XCTUnwrap(try transformer.transform(
+            makeVerticalHighResolutionScrollEvent(multiplier: 10, units: 17.390899658203125)
+        ))
+        let view = ScrollWheelEventView(transformedEvent)
+
+        XCTAssertTrue(view.continuous)
+        XCTAssertEqual(view.deltaXFixedPt, 0)
+        XCTAssertEqual(view.deltaYPt, 62, accuracy: 0.001)
+        XCTAssertEqual(view.deltaYFixedPt, 62.60723876953125, accuracy: 0.001)
+    }
+
+    private func makeVerticalHighResolutionScrollEvent(
+        multiplier: Int = 8,
+        units: Double = 1
+    ) throws -> CGEvent {
+        let event = try XCTUnwrap(CGEvent(
             scrollWheelEvent2Source: nil,
             units: .line,
             wheelCount: 2,
-            wheel1: 1,
+            wheel1: Int32(units.sign == .minus ? -1 : 1),
             wheel2: 0,
             wheel3: 0
         ))
+        let view = ScrollWheelEventView(event)
+        view.deltaYFixedPt = units / Double(multiplier)
+        view.deltaYPt = units * 10 / Double(multiplier)
+        return event
     }
 }

--- a/LinearMouseUnitTests/EventTransformer/LinearScrollingTransformerTests.swift
+++ b/LinearMouseUnitTests/EventTransformer/LinearScrollingTransformerTests.swift
@@ -40,4 +40,51 @@ final class LinearScrollingTransformerTests: XCTestCase {
         XCTAssertEqual(view.deltaXFixedPt, 0)
         XCTAssertEqual(view.deltaYFixedPt, 36)
     }
+
+    func testHighResolutionWheelLineScrollingUsesMultiplier() throws {
+        let transformer = LinearScrollingVerticalTransformer(
+            distance: .line(3),
+            highResolutionWheelMultiplier: { 8 },
+            now: { 0 }
+        )
+
+        for _ in 0 ..< 3 {
+            XCTAssertNil(try transformer.transform(makeVerticalScrollEvent()))
+        }
+
+        let transformedEvent = try XCTUnwrap(try transformer.transform(makeVerticalScrollEvent()))
+        let view = ScrollWheelEventView(transformedEvent)
+
+        XCTAssertFalse(view.continuous)
+        XCTAssertEqual(view.deltaX, 0)
+        XCTAssertEqual(view.deltaY, 3)
+    }
+
+    func testHighResolutionWheelPixelScrollingUsesMultiplier() throws {
+        let transformer = LinearScrollingVerticalTransformer(
+            distance: .pixel(36),
+            highResolutionWheelMultiplier: { 8 },
+            now: { 0 }
+        )
+
+        let transformedEvent = try XCTUnwrap(try transformer.transform(makeVerticalScrollEvent()))
+        let view = ScrollWheelEventView(transformedEvent)
+
+        XCTAssertTrue(view.continuous)
+        XCTAssertEqual(view.deltaXFixedPt, 0)
+        XCTAssertGreaterThan(view.deltaYPt, 0)
+        XCTAssertLessThan(view.deltaYPt, 36)
+        XCTAssertEqual(view.deltaYFixedPt, 4.5, accuracy: 0.001)
+    }
+
+    private func makeVerticalScrollEvent() throws -> CGEvent {
+        try XCTUnwrap(CGEvent(
+            scrollWheelEvent2Source: nil,
+            units: .line,
+            wheelCount: 2,
+            wheel1: 1,
+            wheel2: 0,
+            wheel3: 0
+        ))
+    }
 }

--- a/LinearMouseUnitTests/EventTransformer/LogitechHighResolutionWheelNormalizerTests.swift
+++ b/LinearMouseUnitTests/EventTransformer/LogitechHighResolutionWheelNormalizerTests.swift
@@ -1,0 +1,61 @@
+// MIT License
+// Copyright (c) 2021-2026 LinearMouse
+
+@testable import LinearMouse
+import XCTest
+
+final class LogitechHighResolutionWheelNormalizerTests: XCTestCase {
+    func testLowResolutionModeAccumulatesHighResolutionWheelUnits() throws {
+        let transformer = LogitechHighResolutionWheelNormalizer(
+            verticalMode: .lowResolution,
+            horizontalMode: .passthrough,
+            multiplier: { 8 },
+            now: { 0 }
+        )
+
+        for _ in 0 ..< 3 {
+            XCTAssertNil(try transformer.transform(makeVerticalScrollEvent()))
+        }
+
+        let transformedEvent = try XCTUnwrap(try transformer.transform(makeVerticalScrollEvent()))
+        let view = ScrollWheelEventView(transformedEvent)
+
+        XCTAssertFalse(view.continuous)
+        XCTAssertEqual(view.deltaY, 1)
+        XCTAssertEqual(view.deltaYPt, 10)
+        XCTAssertEqual(view.deltaYFixedPt, 1)
+
+        for _ in 0 ..< 4 {
+            XCTAssertNil(try transformer.transform(makeVerticalScrollEvent()))
+        }
+    }
+
+    func testSmoothedModeScalesHighResolutionWheelUnitsToFractionalPixels() throws {
+        let transformer = LogitechHighResolutionWheelNormalizer(
+            verticalMode: .smoothed,
+            horizontalMode: .passthrough,
+            multiplier: { 8 },
+            now: { 0 }
+        )
+
+        let transformedEvent = try XCTUnwrap(try transformer.transform(makeVerticalScrollEvent()))
+        let view = ScrollWheelEventView(transformedEvent)
+
+        XCTAssertTrue(view.continuous)
+        XCTAssertEqual(view.deltaY, 0)
+        XCTAssertGreaterThan(view.deltaYPt, 0)
+        XCTAssertLessThan(view.deltaYPt, 36)
+        XCTAssertEqual(view.deltaYFixedPt, 4.5, accuracy: 0.001)
+    }
+
+    private func makeVerticalScrollEvent() throws -> CGEvent {
+        try XCTUnwrap(CGEvent(
+            scrollWheelEvent2Source: nil,
+            units: .line,
+            wheelCount: 2,
+            wheel1: 1,
+            wheel2: 0,
+            wheel3: 0
+        ))
+    }
+}

--- a/LinearMouseUnitTests/EventTransformer/LogitechHighResolutionWheelNormalizerTests.swift
+++ b/LinearMouseUnitTests/EventTransformer/LogitechHighResolutionWheelNormalizerTests.swift
@@ -14,10 +14,10 @@ final class LogitechHighResolutionWheelNormalizerTests: XCTestCase {
         )
 
         for _ in 0 ..< 3 {
-            XCTAssertNil(try transformer.transform(makeVerticalScrollEvent()))
+            XCTAssertNil(try transformer.transform(makeVerticalHighResolutionScrollEvent()))
         }
 
-        let transformedEvent = try XCTUnwrap(try transformer.transform(makeVerticalScrollEvent()))
+        let transformedEvent = try XCTUnwrap(try transformer.transform(makeVerticalHighResolutionScrollEvent()))
         let view = ScrollWheelEventView(transformedEvent)
 
         XCTAssertFalse(view.continuous)
@@ -26,36 +26,254 @@ final class LogitechHighResolutionWheelNormalizerTests: XCTestCase {
         XCTAssertEqual(view.deltaYFixedPt, 1)
 
         for _ in 0 ..< 4 {
-            XCTAssertNil(try transformer.transform(makeVerticalScrollEvent()))
+            XCTAssertNil(try transformer.transform(makeVerticalHighResolutionScrollEvent()))
         }
     }
 
-    func testSmoothedModeScalesHighResolutionWheelUnitsToFractionalPixels() throws {
+    func testLowResolutionModeUsesFixedPointUnitsWhenIntegerDeltaIsCoalesced() throws {
         let transformer = LogitechHighResolutionWheelNormalizer(
-            verticalMode: .smoothed,
+            verticalMode: .lowResolution,
             horizontalMode: .passthrough,
-            multiplier: { 8 },
+            multiplier: { 10 },
             now: { 0 }
         )
 
-        let transformedEvent = try XCTUnwrap(try transformer.transform(makeVerticalScrollEvent()))
+        let transformedEvent = try XCTUnwrap(try transformer.transform(
+            makeVerticalHighResolutionScrollEvent(multiplier: 10, units: 17.390899658203125)
+        ))
         let view = ScrollWheelEventView(transformedEvent)
 
-        XCTAssertTrue(view.continuous)
-        XCTAssertEqual(view.deltaY, 0)
-        XCTAssertGreaterThan(view.deltaYPt, 0)
-        XCTAssertLessThan(view.deltaYPt, 36)
-        XCTAssertEqual(view.deltaYFixedPt, 4.5, accuracy: 0.001)
+        XCTAssertFalse(view.continuous)
+        XCTAssertEqual(view.deltaY, 2)
+        XCTAssertEqual(view.deltaYPt, 20)
+        XCTAssertEqual(view.deltaYFixedPt, 2)
     }
 
-    private func makeVerticalScrollEvent() throws -> CGEvent {
-        try XCTUnwrap(CGEvent(
+    func testUnitReaderUsesAccelerationMagnitudeWhenIOHIDOnlyReportsRawTicks() {
+        let resolution = LogitechHighResolutionWheelUnitReader.units(
+            integerDelta: -6,
+            pointDelta: -69,
+            fixedPointDelta: -6.84417724609375,
+            ioHidDelta: 1,
+            signum: -1,
+            multiplier: 8
+        )
+
+        XCTAssertEqual(resolution.rawUnits, -1, accuracy: 0.001)
+        XCTAssertEqual(resolution.acceleratedUnits, -6.9, accuracy: 0.001)
+        XCTAssertEqual(resolution.units, -6.9, accuracy: 0.001)
+        XCTAssertEqual(
+            normalizedPixels(for: resolution, multiplier: 8),
+            -31.05,
+            accuracy: 0.001
+        )
+    }
+
+    func testUnitReaderUsesCoalescedEventDistanceWhenIOHIDDeltaIsSmaller() {
+        let resolution = LogitechHighResolutionWheelUnitReader.units(
+            integerDelta: -20,
+            pointDelta: -204,
+            fixedPointDelta: -20.31182861328125,
+            ioHidDelta: 4,
+            signum: -1,
+            multiplier: 8
+        )
+
+        XCTAssertEqual(resolution.rawUnits, -4, accuracy: 0.001)
+        XCTAssertEqual(resolution.acceleratedUnits, -20.4, accuracy: 0.001)
+        XCTAssertEqual(resolution.units, -20.4, accuracy: 0.001)
+        XCTAssertEqual(
+            normalizedPixels(for: resolution, multiplier: 8),
+            -91.8,
+            accuracy: 0.001
+        )
+    }
+
+    func testUnitReaderKeepsSlowRawIOHIDTickDistance() {
+        let resolutions = (0 ..< 8).map { _ in
+            LogitechHighResolutionWheelUnitReader.units(
+                integerDelta: -1,
+                pointDelta: -1,
+                fixedPointDelta: -0.100006103515625,
+                ioHidDelta: 1,
+                signum: -1,
+                multiplier: 8
+            )
+        }
+        let units = resolutions.map(\.units)
+        let pixels = resolutions
+            .map { normalizedPixels(for: $0, multiplier: 8) }
+            .reduce(0, +)
+
+        XCTAssertEqual(units.reduce(0, +), -8, accuracy: 0.001)
+        XCTAssertEqual(pixels, -36, accuracy: 0.001)
+    }
+
+    func testUnitReaderPreservesAcceleratedTraceDistance() {
+        let fixedPointDeltas = [
+            -0.100006103515625,
+            -0.23114013671875,
+            -1.065032958984375,
+            -3.109100341796875,
+            -4.987274169921875,
+            -6.0433502197265625,
+            -6.7981109619140625,
+            -7.48211669921875
+        ]
+        let integerDeltas: [Int64] = [-1, -1, -1, -3, -4, -6, -6, -7]
+        let pointDeltas = [-1.0, -3, -11, -32, -50, -61, -68, -75]
+
+        let resolutions = zip(zip(integerDeltas, pointDeltas), fixedPointDeltas).map { fields, fixedPointDelta in
+            let (integerDelta, pointDelta) = fields
+            return LogitechHighResolutionWheelUnitReader.units(
+                integerDelta: integerDelta,
+                pointDelta: pointDelta,
+                fixedPointDelta: fixedPointDelta,
+                ioHidDelta: 1,
+                signum: -1,
+                multiplier: 8
+            )
+        }
+        let units = resolutions.map(\.units)
+        let acceleration = resolutions.map(\.acceleratedUnits)
+        let pixels = resolutions
+            .map { normalizedPixels(for: $0, multiplier: 8) }
+            .reduce(0, +)
+
+        XCTAssertEqual(units.reduce(0, +), -31.7, accuracy: 0.001)
+        XCTAssertEqual(acceleration.reduce(0, +), -31.7, accuracy: 0.001)
+        XCTAssertEqual(pixels, -142.65, accuracy: 0.001)
+    }
+
+    func testLoggedHighResolutionBurstStaysBetweenRawTicksAndUnscaledCGDistance() {
+        let fields: [(integer: Int64, fixedPoint: Double, point: Double, ioHid: Double)] = [
+            (1, 0.100006103515625, 1.0, -1.0),
+            (1, 1.477264404296875, 15.0, -2.0),
+            (5, 5.49005126953125, 55.0, -1.0),
+            (6, 6.677581787109375, 67.0, -1.0),
+            (8, 8.458969116210938, 85.0, -2.0),
+            (9, 9.419586181640625, 95.0, -2.0),
+            (9, 9.694992065429688, 97.0, -1.0),
+            (10, 10.2265625, 103.0, -2.0),
+            (11, 11.68096923828125, 117.0, -3.0),
+            (12, 12.189132690429688, 122.0, -3.0),
+            (12, 12.497634887695312, 125.0, -2.0),
+            (12, 12.498245239257812, 125.0, -1.0),
+            (13, 13.219070434570312, 133.0, -4.0),
+            (13, 13.581680297851562, 136.0, -3.0),
+            (14, 14.665756225585938, 147.0, -4.0),
+            (15, 15.661636352539062, 157.0, -5.0),
+            (16, 16.38055419921875, 164.0, -5.0),
+            (18, 18.169158935546875, 182.0, -8.0),
+            (19, 19.004440307617188, 191.0, -4.0),
+            (19, 19.965545654296875, 200.0, -4.0),
+            (19, 19.955291748046875, 200.0, -4.0),
+            (20, 20.31182861328125, 204.0, -4.0),
+            (19, 19.957611083984375, 200.0, -3.0),
+            (19, 19.001113891601562, 191.0, -2.0),
+            (17, 17.540130615234375, 176.0, -1.0),
+            (15, 15.389617919921875, 154.0, -2.0),
+            (14, 14.305068969726562, 144.0, -1.0),
+            (12, 12.974929809570312, 130.0, -1.0),
+            (11, 11.932373046875, 120.0, -1.0)
+        ]
+
+        let normalizedPixels = normalizedPixelSum(for: fields, multiplier: 8)
+        let rawIOHIDPixels = rawIOHIDPixelSum(for: fields, multiplier: 8)
+        let unscaledCGPixels = unscaledCGPixelSum(for: fields)
+
+        XCTAssertEqual(normalizedPixels, 1732.5, accuracy: 0.001)
+        XCTAssertEqual(rawIOHIDPixels, 346.5, accuracy: 0.001)
+        XCTAssertEqual(unscaledCGPixels, 13_842.0, accuracy: 0.001)
+        XCTAssertGreaterThan(normalizedPixels, rawIOHIDPixels * 4.0)
+        XCTAssertLessThan(normalizedPixels, unscaledCGPixels * 0.20)
+    }
+
+    func testLoggedSlowAndFastHighResolutionInputsKeepDistinctDistances() {
+        let slowFields: [(integer: Int64, fixedPoint: Double, point: Double, ioHid: Double)] = [
+            (1, 0.100006103515625, 1.0, -1.0),
+            (1, 0.100006103515625, 1.0, -1.0),
+            (1, 0.100006103515625, 1.0, -1.0),
+            (1, 0.100006103515625, 1.0, -1.0),
+            (1, 0.100006103515625, 1.0, -1.0)
+        ]
+        let fastFields: [(integer: Int64, fixedPoint: Double, point: Double, ioHid: Double)] = [
+            (1, 0.100006103515625, 1.0, -1.0),
+            (1, 0.100006103515625, 1.0, -1.0),
+            (1, 0.7082061767578125, 8.0, -1.0),
+            (1, 1.968719482421875, 20.0, -1.0),
+            (3, 3.72259521484375, 38.0, -1.0),
+            (5, 5.421630859375, 55.0, -1.0),
+            (6, 6.1365203857421875, 62.0, -1.0),
+            (6, 6.84417724609375, 69.0, -1.0)
+        ]
+
+        let slowPixels = normalizedPixelSum(for: slowFields, multiplier: 8)
+        let fastPixels = normalizedPixelSum(for: fastFields, multiplier: 8)
+
+        XCTAssertEqual(slowPixels, 22.5, accuracy: 0.001)
+        XCTAssertEqual(fastPixels, 123.3, accuracy: 0.001)
+        XCTAssertGreaterThan(fastPixels, slowPixels * 5.0)
+    }
+
+    private func normalizedPixels(
+        for resolution: LogitechHighResolutionWheelUnitReader.UnitResolution,
+        multiplier: Int
+    ) -> Double {
+        resolution.units * 36 / Double(multiplier)
+    }
+
+    private func normalizedPixelSum(
+        for fields: [(integer: Int64, fixedPoint: Double, point: Double, ioHid: Double)],
+        multiplier: Int
+    ) -> Double {
+        fields
+            .map { field in
+                let resolution = LogitechHighResolutionWheelUnitReader.units(
+                    integerDelta: field.integer,
+                    pointDelta: field.point,
+                    fixedPointDelta: field.fixedPoint,
+                    ioHidDelta: field.ioHid,
+                    signum: field.integer.signum(),
+                    multiplier: multiplier
+                )
+                return abs(normalizedPixels(for: resolution, multiplier: multiplier))
+            }
+            .reduce(0, +)
+    }
+
+    private func rawIOHIDPixelSum(
+        for fields: [(integer: Int64, fixedPoint: Double, point: Double, ioHid: Double)],
+        multiplier: Int
+    ) -> Double {
+        fields
+            .map { abs($0.ioHid) * 36 / Double(multiplier) }
+            .reduce(0, +)
+    }
+
+    private func unscaledCGPixelSum(
+        for fields: [(integer: Int64, fixedPoint: Double, point: Double, ioHid: Double)]
+    ) -> Double {
+        fields
+            .map { max(abs(Double($0.integer)), abs($0.point) / 10, abs($0.fixedPoint)) * 36 }
+            .reduce(0, +)
+    }
+
+    private func makeVerticalHighResolutionScrollEvent(
+        multiplier: Int = 8,
+        units: Double = 1
+    ) throws -> CGEvent {
+        let event = try XCTUnwrap(CGEvent(
             scrollWheelEvent2Source: nil,
             units: .line,
             wheelCount: 2,
-            wheel1: 1,
+            wheel1: Int32(units.sign == .minus ? -1 : 1),
             wheel2: 0,
             wheel3: 0
         ))
+        let view = ScrollWheelEventView(event)
+        view.deltaYFixedPt = units / Double(multiplier)
+        view.deltaYPt = units * 10 / Double(multiplier)
+        return event
     }
 }

--- a/LinearMouseUnitTests/EventTransformer/SmoothedScrollingEngineTests.swift
+++ b/LinearMouseUnitTests/EventTransformer/SmoothedScrollingEngineTests.swift
@@ -29,7 +29,7 @@ final class SmoothedScrollingEngineTests: XCTestCase {
             }
         }
 
-        for step in 6 ..< 240 {
+        for step in 6 ..< 480 {
             let timestamp = Double(step + 1) / 120
             if let emission = engine.advance(to: timestamp) {
                 emissions.append(emission)
@@ -89,6 +89,87 @@ final class SmoothedScrollingEngineTests: XCTestCase {
         XCTAssertNotNil(easeInEmission)
         XCTAssertNotNil(easeOutEmission)
         XCTAssertLessThan(abs(easeInEmission?.deltaY ?? 0), abs(easeOutEmission?.deltaY ?? 0))
+    }
+
+    func testDenseSplitInputMatchesAggregatedInputAtSameOutputTick() throws {
+        let configuration = Scheme.Scrolling.Smoothed.Preset.easeInOut.defaultConfiguration
+        let aggregatedEngine = SmoothedScrollingEngine(smoothed: .init(vertical: configuration))
+        let splitEngine = SmoothedScrollingEngine(smoothed: .init(vertical: configuration))
+
+        aggregatedEngine.feed(deltaX: 0, deltaY: 36, timestamp: 0)
+
+        for step in 0 ..< 8 {
+            let timestamp = Double(step) / 960.0
+            splitEngine.feed(deltaX: 0, deltaY: 4.5, timestamp: timestamp)
+        }
+
+        let aggregatedEmission = try XCTUnwrap(aggregatedEngine.advance(to: 1.0 / 120.0))
+        let splitEmission = try XCTUnwrap(splitEngine.advance(to: 1.0 / 120.0))
+
+        XCTAssertEqual(abs(splitEmission.deltaY), abs(aggregatedEmission.deltaY), accuracy: 0.001)
+    }
+
+    func testLargeCoalescedInputIsNotCappedToSingleDetentSpeed() {
+        let singleDetentPeak = touchPeakDeltaY(for: [TimedScrollInput(timestamp: 0, deltaY: 36)])
+        let coalescedPeak = touchPeakDeltaY(for: [TimedScrollInput(timestamp: 0, deltaY: 144)])
+
+        XCTAssertGreaterThan(coalescedPeak, singleDetentPeak * 3.0)
+    }
+
+    func testSameRawTickDistanceHasHigherPeakWhenItArrivesDensely() {
+        let slowPeak = touchPeakDeltaY(for: splitDetentInputs(count: 4, detentInterval: 0.16))
+        let fastPeak = touchPeakDeltaY(for: splitDetentInputs(count: 4, detentInterval: 1.0 / 55.0))
+
+        XCTAssertGreaterThan(fastPeak, slowPeak * 2.0)
+    }
+
+    func testSingleDetentTimingChangesPeakWithoutGlobalScaling() {
+        let aggregatedPeak = touchPeakDeltaY(for: [TimedScrollInput(timestamp: 0, deltaY: 36)])
+        let slowSplitPeak = touchPeakDeltaY(for: splitDetentInputs(count: 1, detentInterval: 0.16))
+        let fastSplitPeak = touchPeakDeltaY(for: splitDetentInputs(count: 1, detentInterval: 1.0 / 55.0))
+
+        XCTAssertLessThan(slowSplitPeak, aggregatedPeak)
+        XCTAssertGreaterThan(fastSplitPeak, slowSplitPeak * 2.0)
+        XCTAssertLessThan(fastSplitPeak, aggregatedPeak * 1.05)
+    }
+
+    func testHighResolutionTraceUsesAcceleratedDistanceWithoutSkippingMultiplier() {
+        let rawPeak = touchPeakDeltaY(for: highResolutionTraceInputs(mode: .raw))
+        let normalizedPeak = touchPeakDeltaY(for: highResolutionTraceInputs(mode: .normalized))
+        let unscaledPeak = touchPeakDeltaY(for: highResolutionTraceInputs(mode: .unscaledAccelerated))
+
+        XCTAssertGreaterThan(normalizedPeak, rawPeak * 2.0)
+        XCTAssertLessThan(normalizedPeak, unscaledPeak * 0.60)
+    }
+
+    func testLoggedFastHighResolutionTicksUseAcceleratedDistanceWithoutSkippingMultiplier() {
+        let slowPeak = touchPeakDeltaY(for: splitDetentInputs(count: 1, detentInterval: 0.16))
+        let loggedNormalizedPeak = touchPeakDeltaY(for: loggedFastHighResolutionTickInputs(mode: .normalized))
+        let acceleratedPeak = touchPeakDeltaY(for: loggedFastHighResolutionTickInputs(mode: .unscaledAccelerated))
+
+        XCTAssertGreaterThan(loggedNormalizedPeak, slowPeak * 2.5)
+        XCTAssertLessThan(loggedNormalizedPeak, acceleratedPeak * 0.60)
+    }
+
+    func testPausedHighResolutionFastBurstEmitsMovementAfterTinyScroll() throws {
+        let fastStart = 0.18
+        let tinyPeak = touchPeakDeltaY(for: [TimedScrollInput(timestamp: 0, deltaY: -4.5)])
+        let fastBurstInputs = loggedFastHighResolutionTickInputs(mode: .normalized)
+            .map { TimedScrollInput(timestamp: $0.timestamp + fastStart, deltaY: $0.deltaY) }
+        let emissions = timedEmissions(
+            for: [TimedScrollInput(timestamp: 0, deltaY: -4.5)] + fastBurstInputs,
+            configuration: Scheme.Scrolling.Smoothed.Preset.easeInOut.defaultConfiguration
+        )
+
+        let burstTouchEmissions = emissions.filter {
+            $0.timestamp >= fastStart
+                && ($0.emission.phase == .touchBegan || $0.emission.phase == .touchChanged)
+        }
+        let firstBurstEmission = try XCTUnwrap(burstTouchEmissions.first)
+        let burstPeak = burstTouchEmissions.map { abs($0.emission.deltaY) }.max() ?? 0
+
+        XCTAssertGreaterThan(abs(firstBurstEmission.emission.deltaY), 0.01)
+        XCTAssertGreaterThan(burstPeak, tinyPeak * 4.0)
     }
 
     func testMomentumReengagementBlendsAdditionalInputWithoutSharpJump() throws {
@@ -267,5 +348,144 @@ final class SmoothedScrollingEngineTests: XCTestCase {
         XCTAssertEqual(switchedEmission.phase, .touchBegan)
         XCTAssertGreaterThan(abs(switchedEmission.deltaX), 0.01)
         XCTAssertEqual(switchedEmission.deltaY, 0, accuracy: 0.001)
+    }
+
+    private struct TimedScrollInput {
+        var timestamp: TimeInterval
+        var deltaY: Double
+    }
+
+    private struct TimedEmission {
+        var timestamp: TimeInterval
+        var emission: SmoothedScrollingEngine.Emission
+    }
+
+    private enum HighResolutionTraceMode {
+        case raw
+        case normalized
+        case unscaledAccelerated
+    }
+
+    private func touchPeakDeltaY(
+        for inputs: [TimedScrollInput],
+        configuration: Scheme.Scrolling.Smoothed = Scheme.Scrolling.Smoothed.Preset.easeInOut.defaultConfiguration
+    ) -> Double {
+        timedEmissions(for: inputs, configuration: configuration)
+            .filter { $0.emission.phase == .touchBegan || $0.emission.phase == .touchChanged }
+            .map { abs($0.emission.deltaY) }
+            .max() ?? 0
+    }
+
+    private func emissions(
+        for inputs: [TimedScrollInput],
+        configuration: Scheme.Scrolling.Smoothed
+    ) -> [SmoothedScrollingEngine.Emission] {
+        timedEmissions(for: inputs, configuration: configuration).map(\.emission)
+    }
+
+    private func timedEmissions(
+        for inputs: [TimedScrollInput],
+        configuration: Scheme.Scrolling.Smoothed
+    ) -> [TimedEmission] {
+        let engine = SmoothedScrollingEngine(smoothed: .init(vertical: configuration))
+        let sortedInputs = inputs.sorted { $0.timestamp < $1.timestamp }
+        let tickInterval = 1.0 / 120.0
+        let finalTimestamp = (sortedInputs.last?.timestamp ?? 0) + 0.5
+        let tickCount = Int((finalTimestamp / tickInterval).rounded(.up))
+
+        var emissions: [TimedEmission] = []
+        var nextInputIndex = 0
+
+        for tick in 1 ... tickCount {
+            let timestamp = Double(tick) * tickInterval
+
+            while nextInputIndex < sortedInputs.count,
+                  sortedInputs[nextInputIndex].timestamp <= timestamp {
+                let input = sortedInputs[nextInputIndex]
+                engine.feed(deltaX: 0, deltaY: input.deltaY, timestamp: input.timestamp)
+                nextInputIndex += 1
+            }
+
+            if let emission = engine.advance(to: timestamp) {
+                emissions.append(.init(timestamp: timestamp, emission: emission))
+            }
+        }
+
+        return emissions
+    }
+
+    private func splitDetentInputs(
+        count: Int,
+        detentInterval: TimeInterval,
+        multiplier: Int = 8
+    ) -> [TimedScrollInput] {
+        let unitInterval = detentInterval / Double(multiplier)
+        let unitDelta = 36.0 / Double(multiplier)
+
+        return (0 ..< count * multiplier).map { unit in
+            TimedScrollInput(timestamp: Double(unit) * unitInterval, deltaY: unitDelta)
+        }
+    }
+
+    private func highResolutionTraceInputs(mode: HighResolutionTraceMode) -> [TimedScrollInput] {
+        let multiplier = 8
+        let interval = 1.0 / 240.0
+        let integerDeltas = [1.0, 1, 1, 3, 4, 6, 6, 7]
+        let pointDeltas = [1.0, 3, 11, 32, 50, 61, 68, 75]
+        let rawUnits = Array(repeating: 1.0, count: integerDeltas.count)
+
+        return integerDeltas.indices.map { index in
+            let deltaY: Double
+            switch mode {
+            case .raw:
+                deltaY = rawUnits[index] * 36 / Double(multiplier)
+            case .normalized:
+                deltaY = max(rawUnits[index], integerDeltas[index], pointDeltas[index] / 10)
+                    * 36 / Double(multiplier)
+            case .unscaledAccelerated:
+                deltaY = max(rawUnits[index], integerDeltas[index], pointDeltas[index] / 10) * 36
+            }
+
+            return TimedScrollInput(
+                timestamp: Double(index) * interval,
+                deltaY: -deltaY
+            )
+        }
+    }
+
+    private func loggedFastHighResolutionTickInputs(mode: HighResolutionTraceMode) -> [TimedScrollInput] {
+        let multiplier = 8
+        let timestamps = [
+            899_937_042_327,
+            899_937_940_863,
+            899_939_561_641,
+            899_940_281_411,
+            899_940_480_800,
+            899_940_822_651,
+            899_941_188_304,
+            899_942_074_311
+        ]
+        let integerDeltas = [1.0, 1, 2, 3, 5, 6, 7, 7]
+        let pointDeltas = [1.0, 8, 23, 39, 56, 64, 71, 75]
+        let rawUnits = Array(repeating: 1.0, count: timestamps.count)
+        let startTimestamp = timestamps[0]
+
+        return timestamps.indices.map { index in
+            let deltaY: Double
+            switch mode {
+            case .raw:
+                deltaY = rawUnits[index] * 36 / Double(multiplier)
+            case .normalized:
+                deltaY = max(rawUnits[index], integerDeltas[index], pointDeltas[index] / 10)
+                    * 36 / Double(multiplier)
+            case .unscaledAccelerated:
+                deltaY = max(rawUnits[index], integerDeltas[index], pointDeltas[index] / 10) * 36
+            }
+
+            return TimedScrollInput(
+                timestamp: Double(timestamps[index] - startTimestamp) / 1_000_000_000.0,
+                deltaY: -deltaY
+            )
+        }
     }
 }

--- a/LinearMouseUnitTests/EventTransformer/SmoothedScrollingEngineTests.swift
+++ b/LinearMouseUnitTests/EventTransformer/SmoothedScrollingEngineTests.swift
@@ -91,6 +91,32 @@ final class SmoothedScrollingEngineTests: XCTestCase {
         XCTAssertLessThan(abs(easeInEmission?.deltaY ?? 0), abs(easeOutEmission?.deltaY ?? 0))
     }
 
+    func testNewWheelSessionDoesNotUseStaleIdleTickTimestamp() throws {
+        let configuration = Scheme.Scrolling.Smoothed.Preset.easeInOut.defaultConfiguration
+        let reusedEngine = SmoothedScrollingEngine(smoothed: .init(vertical: configuration))
+        let freshEngine = SmoothedScrollingEngine(smoothed: .init(vertical: configuration))
+
+        reusedEngine.feed(deltaX: 0, deltaY: 36, timestamp: 0)
+        for tick in 1 ... 600 {
+            _ = reusedEngine.advance(to: Double(tick) / 120)
+            if !reusedEngine.isRunning {
+                break
+            }
+        }
+        XCTAssertFalse(reusedEngine.isRunning)
+
+        let nextInputTimestamp = 10.0
+        reusedEngine.feed(deltaX: 0, deltaY: 36, timestamp: nextInputTimestamp)
+        freshEngine.feed(deltaX: 0, deltaY: 36, timestamp: nextInputTimestamp)
+
+        let reusedEmission = try XCTUnwrap(reusedEngine.advance(to: nextInputTimestamp + 1.0 / 120.0))
+        let freshEmission = try XCTUnwrap(freshEngine.advance(to: nextInputTimestamp + 1.0 / 120.0))
+
+        XCTAssertEqual(reusedEmission.phase, .touchBegan)
+        XCTAssertEqual(freshEmission.phase, .touchBegan)
+        XCTAssertEqual(abs(reusedEmission.deltaY), abs(freshEmission.deltaY), accuracy: 0.001)
+    }
+
     func testDenseSplitInputMatchesAggregatedInputAtSameOutputTick() throws {
         let configuration = Scheme.Scrolling.Smoothed.Preset.easeInOut.defaultConfiguration
         let aggregatedEngine = SmoothedScrollingEngine(smoothed: .init(vertical: configuration))
@@ -118,19 +144,67 @@ final class SmoothedScrollingEngineTests: XCTestCase {
 
     func testSameRawTickDistanceHasHigherPeakWhenItArrivesDensely() {
         let slowPeak = touchPeakDeltaY(for: splitDetentInputs(count: 4, detentInterval: 0.16))
+        let mediumPeak = touchPeakDeltaY(for: splitDetentInputs(count: 4, detentInterval: 0.08))
         let fastPeak = touchPeakDeltaY(for: splitDetentInputs(count: 4, detentInterval: 1.0 / 55.0))
 
+        XCTAssertGreaterThan(mediumPeak, slowPeak)
+        XCTAssertGreaterThan(fastPeak, mediumPeak)
         XCTAssertGreaterThan(fastPeak, slowPeak * 2.0)
+    }
+
+    func testSameRawTickDistanceHasHigherTotalOutputWhenItArrivesDensely() {
+        let slowOutput = totalDeltaY(for: splitDetentInputs(count: 4, detentInterval: 0.16))
+        let mediumOutput = totalDeltaY(for: splitDetentInputs(count: 4, detentInterval: 0.08))
+        let fastOutput = totalDeltaY(for: splitDetentInputs(count: 4, detentInterval: 1.0 / 55.0))
+
+        XCTAssertGreaterThan(slowOutput, 0)
+        XCTAssertGreaterThan(mediumOutput, slowOutput)
+        XCTAssertGreaterThan(fastOutput, mediumOutput)
     }
 
     func testSingleDetentTimingChangesPeakWithoutGlobalScaling() {
         let aggregatedPeak = touchPeakDeltaY(for: [TimedScrollInput(timestamp: 0, deltaY: 36)])
         let slowSplitPeak = touchPeakDeltaY(for: splitDetentInputs(count: 1, detentInterval: 0.16))
+        let mediumSplitPeak = touchPeakDeltaY(for: splitDetentInputs(count: 1, detentInterval: 0.08))
         let fastSplitPeak = touchPeakDeltaY(for: splitDetentInputs(count: 1, detentInterval: 1.0 / 55.0))
 
         XCTAssertLessThan(slowSplitPeak, aggregatedPeak)
+        XCTAssertGreaterThan(mediumSplitPeak, slowSplitPeak)
+        XCTAssertGreaterThan(fastSplitPeak, mediumSplitPeak)
         XCTAssertGreaterThan(fastSplitPeak, slowSplitPeak * 2.0)
         XCTAssertLessThan(fastSplitPeak, aggregatedPeak * 1.05)
+    }
+
+    func testSlowSplitDetentKeepsMeaningfulPickup() {
+        let aggregatedPeak = touchPeakDeltaY(for: [TimedScrollInput(timestamp: 0, deltaY: 36)])
+        let slowSplitPeak = touchPeakDeltaY(for: splitDetentInputs(count: 1, detentInterval: 0.16))
+
+        XCTAssertGreaterThan(slowSplitPeak, aggregatedPeak * 0.25)
+        XCTAssertLessThan(slowSplitPeak, aggregatedPeak * 0.75)
+    }
+
+    func testSplitInputDirectionChangeDoesNotCarryPreviousRateProjection() {
+        let detentInterval = 1.0 / 55.0
+        let reverseStart = 0.02
+        let forwardInputs = splitDetentInputs(count: 1, detentInterval: detentInterval)
+        let reverseInputs = splitDetentInputs(count: 1, detentInterval: detentInterval)
+            .map {
+                TimedScrollInput(timestamp: $0.timestamp + reverseStart, deltaY: -$0.deltaY)
+            }
+        let freshReverseInputs = splitDetentInputs(count: 1, detentInterval: detentInterval)
+            .map {
+                TimedScrollInput(timestamp: $0.timestamp, deltaY: -$0.deltaY)
+            }
+
+        let reversePeak = touchPeakDeltaY(
+            for: forwardInputs + reverseInputs,
+            after: reverseStart,
+            direction: -1
+        )
+        let freshReversePeak = touchPeakDeltaY(for: freshReverseInputs)
+
+        XCTAssertGreaterThan(reversePeak, freshReversePeak * 0.25)
+        XCTAssertLessThan(reversePeak, freshReversePeak * 1.05)
     }
 
     func testHighResolutionTraceUsesAcceleratedDistanceWithoutSkippingMultiplier() {
@@ -374,6 +448,31 @@ final class SmoothedScrollingEngineTests: XCTestCase {
             .filter { $0.emission.phase == .touchBegan || $0.emission.phase == .touchChanged }
             .map { abs($0.emission.deltaY) }
             .max() ?? 0
+    }
+
+    private func touchPeakDeltaY(
+        for inputs: [TimedScrollInput],
+        after timestamp: TimeInterval,
+        direction: Int,
+        configuration: Scheme.Scrolling.Smoothed = Scheme.Scrolling.Smoothed.Preset.easeInOut.defaultConfiguration
+    ) -> Double {
+        timedEmissions(for: inputs, configuration: configuration)
+            .filter {
+                $0.timestamp >= timestamp
+                    && ($0.emission.phase == .touchBegan || $0.emission.phase == .touchChanged)
+                    && (direction < 0 ? $0.emission.deltaY < 0 : $0.emission.deltaY > 0)
+            }
+            .map { abs($0.emission.deltaY) }
+            .max() ?? 0
+    }
+
+    private func totalDeltaY(
+        for inputs: [TimedScrollInput],
+        configuration: Scheme.Scrolling.Smoothed = Scheme.Scrolling.Smoothed.Preset.easeInOut.defaultConfiguration
+    ) -> Double {
+        timedEmissions(for: inputs, configuration: configuration)
+            .map { abs($0.emission.deltaY) }
+            .reduce(0, +)
     }
 
     private func emissions(

--- a/LinearMouseUnitTests/EventTransformer/SmoothedScrollingTransformerTests.swift
+++ b/LinearMouseUnitTests/EventTransformer/SmoothedScrollingTransformerTests.swift
@@ -266,11 +266,13 @@ final class SmoothedScrollingTransformerTests: XCTestCase {
 
     func testContinuousTrackpadInputWithNativePhaseIsSmoothedInPlace() throws {
         let now = 0.0
+        let currentTime: () -> TimeInterval = { now }
         let transformer = SmoothedScrollingTransformer(
             smoothed: .init(
                 vertical: Scheme.Scrolling.Smoothed.Preset.easeInOut.defaultConfiguration
-            )
-        )            { now }
+            ),
+            now: currentTime
+        )
 
         let originalEvent = try XCTUnwrap(CGEvent(
             scrollWheelEvent2Source: nil,
@@ -331,11 +333,13 @@ final class SmoothedScrollingTransformerTests: XCTestCase {
 
     func testContinuousTrackpadInputCanSuppressBouncingPhases() throws {
         let now = 0.0
+        let currentTime: () -> TimeInterval = { now }
         var configuration = Scheme.Scrolling.Smoothed.Preset.easeInOut.defaultConfiguration
         configuration.bouncing = false
         let transformer = SmoothedScrollingTransformer(
-            smoothed: .init(vertical: configuration)
-        )            { now }
+            smoothed: .init(vertical: configuration),
+            now: currentTime
+        )
 
         let originalEvent = try XCTUnwrap(CGEvent(
             scrollWheelEvent2Source: nil,

--- a/LinearMouseUnitTests/EventTransformer/SmoothedScrollingTransformerTests.swift
+++ b/LinearMouseUnitTests/EventTransformer/SmoothedScrollingTransformerTests.swift
@@ -1,6 +1,7 @@
 // MIT License
 // Copyright (c) 2021-2026 LinearMouse
 
+import AppKit
 @testable import GestureKit
 @testable import LinearMouse
 import XCTest
@@ -264,14 +265,13 @@ final class SmoothedScrollingTransformerTests: XCTestCase {
     }
 
     func testContinuousTrackpadInputWithNativePhaseIsSmoothedInPlace() throws {
-        var now = 0.0
+        let now = 0.0
         let transformer = SmoothedScrollingTransformer(
             smoothed: .init(
                 vertical: Scheme.Scrolling.Smoothed.Preset.easeInOut.defaultConfiguration
-            )
-        ) {
-            now
-        }
+            ),
+            now: { now }
+        )
 
         let originalEvent = try XCTUnwrap(CGEvent(
             scrollWheelEvent2Source: nil,
@@ -331,12 +331,13 @@ final class SmoothedScrollingTransformerTests: XCTestCase {
     }
 
     func testContinuousTrackpadInputCanSuppressBouncingPhases() throws {
-        var now = 0.0
+        let now = 0.0
         var configuration = Scheme.Scrolling.Smoothed.Preset.easeInOut.defaultConfiguration
         configuration.bouncing = false
         let transformer = SmoothedScrollingTransformer(
-            smoothed: .init(vertical: configuration)
-        ) { now }
+            smoothed: .init(vertical: configuration),
+            now: { now }
+        )
 
         let originalEvent = try XCTUnwrap(CGEvent(
             scrollWheelEvent2Source: nil,
@@ -425,6 +426,109 @@ final class SmoothedScrollingTransformerTests: XCTestCase {
         XCTAssertEqual(accumulator.verticalPointDelta(for: 0.6), 0)
     }
 
+    func testSmoothedPointDeltaAccumulatorCanTruncateFractionalTailPixels() {
+        var accumulator = SmoothedScrollPointDeltaAccumulator()
+
+        XCTAssertEqual(accumulator.verticalPointDelta(for: 0.6), 0)
+        XCTAssertEqual(accumulator.verticalPointDelta(for: 0.6, accumulates: false), 0)
+        XCTAssertEqual(accumulator.verticalPointDelta(for: 0.6), 0)
+        XCTAssertEqual(accumulator.verticalPointDelta(for: 1.6, accumulates: false), 1)
+        XCTAssertEqual(accumulator.verticalPointDelta(for: 0.6), 0)
+    }
+
+    func testSyntheticSmoothedScrollingExposesMovementThroughScrollingDelta() throws {
+        var emittedEvents: [CGEvent] = []
+        var now = 0.0
+        let transformer = SmoothedScrollingTransformer(
+            smoothed: .init(vertical: Scheme.Scrolling.Smoothed.Preset.smooth.defaultConfiguration),
+            highResolutionWheelMultiplier: { 8 },
+            now: { now },
+            eventSink: { emittedEvents.append($0.copy() ?? $0) }
+        )
+
+        for step in 0 ..< 8 {
+            now = Double(step) / 120.0
+            let rawEvent = try makeVerticalHighResolutionScrollEvent()
+            XCTAssertNil(transformer.transform(rawEvent))
+
+            now += 1.0 / 120.0
+            transformer.tick()
+        }
+
+        for _ in 0 ..< 60 {
+            now += 1.0 / 120.0
+            transformer.tick()
+        }
+
+        let scrollEvents = emittedEvents.filter { $0.type == .scrollWheel }
+        XCTAssertFalse(scrollEvents.isEmpty)
+
+        let movementEvents = scrollEvents.filter { event in
+            let view = ScrollWheelEventView(event)
+            return hasVerticalDelta(view)
+        }
+        XCTAssertFalse(movementEvents.isEmpty)
+
+        for event in movementEvents {
+            let view = ScrollWheelEventView(event)
+            let nsEvent = try XCTUnwrap(NSEvent(cgEvent: event))
+            XCTAssertNotEqual(nsEvent.scrollingDeltaY, 0)
+            XCTAssertEqual(view.deltaYFixedPt, view.deltaYPt, accuracy: 0.001)
+        }
+
+        let zeroMovementEvents = scrollEvents.filter { event in
+            !hasVerticalDelta(ScrollWheelEventView(event))
+        }
+        for event in zeroMovementEvents {
+            let view = ScrollWheelEventView(event)
+            XCTAssertFalse(view.scrollPhase == .began || view.scrollPhase == .changed)
+            XCTAssertFalse(view.momentumPhase == .begin || view.momentumPhase == .continuous)
+        }
+    }
+
+    func testSmoothedHighResolutionWheelDoesNotForceSingleRawTickToOnePixel() throws {
+        var highResolutionEvents: [CGEvent] = []
+        var now = 0.0
+        let highResolutionTransformer = SmoothedScrollingTransformer(
+            smoothed: .init(vertical: Scheme.Scrolling.Smoothed.Preset.easeInOut.defaultConfiguration),
+            highResolutionWheelMultiplier: { 8 },
+            now: { now },
+            eventSink: { highResolutionEvents.append($0.copy() ?? $0) }
+        )
+
+        XCTAssertNil(try highResolutionTransformer.transform(makeVerticalHighResolutionScrollEvent()))
+        for _ in 0 ..< 10 {
+            now += 1.0 / 120.0
+            highResolutionTransformer.tick()
+        }
+
+        XCTAssertNil(highResolutionEvents.lastScrollWheelEvent)
+    }
+
+    func testSmoothedHighResolutionWheelKeepsSlowAndFastBurstsDistinctThroughTransformer() throws {
+        let slowPeak = try highResolutionTouchPeak(
+            for: highResolutionRawDetentInputs(detentInterval: 0.16)
+        )
+        let fastPeak = try highResolutionTouchPeak(for: loggedFastHighResolutionInputs())
+
+        XCTAssertGreaterThan(slowPeak, 0)
+        XCTAssertGreaterThan(fastPeak, slowPeak * 3.0)
+    }
+
+    func testSmoothedNormalHighResolutionDetentDoesNotOvershootLowResolutionDetentThroughTransformer() throws {
+        let lowResolutionPeak = try lowResolutionSingleDetentTouchPeak()
+        let slowHighResolutionPeak = try highResolutionTouchPeak(
+            for: highResolutionRawDetentInputs(detentInterval: 0.16)
+        )
+        let normalHighResolutionPeak = try highResolutionTouchPeak(
+            for: highResolutionRawDetentInputs(detentInterval: 1.0 / 55.0)
+        )
+
+        XCTAssertGreaterThan(lowResolutionPeak, 0)
+        XCTAssertGreaterThan(normalHighResolutionPeak, slowHighResolutionPeak * 2.0)
+        XCTAssertLessThan(normalHighResolutionPeak, lowResolutionPeak * 1.05)
+    }
+
     private func firstDiscreteEmission(
         configuration: Scheme.Scrolling.Smoothed
     ) throws -> ScrollWheelEventView {
@@ -451,6 +555,200 @@ final class SmoothedScrollingTransformerTests: XCTestCase {
         transformer.tick()
 
         return try ScrollWheelEventView(XCTUnwrap(emittedEvents.firstScrollWheelEvent))
+    }
+
+    private func hasVerticalDelta(_ view: ScrollWheelEventView) -> Bool {
+        view.deltaY != 0 ||
+            view.deltaYPt != 0 ||
+            view.deltaYFixedPt != 0 ||
+            view.ioHidScrollY != 0
+    }
+
+    private func makeVerticalHighResolutionScrollEvent(
+        multiplier: Int = 8,
+        units: Double = 1
+    ) throws -> CGEvent {
+        try makeVerticalHighResolutionScrollEvent(
+            integerDelta: Int64(units.sign == .minus ? -1 : 1),
+            fixedPointDelta: units / Double(multiplier),
+            pointDelta: units * 10 / Double(multiplier),
+            ioHidDelta: units.sign == .minus ? -1 : 1
+        )
+    }
+
+    private struct TimedHighResolutionScrollInput {
+        var timestamp: TimeInterval
+        var integerDelta: Int64
+        var fixedPointDelta: Double
+        var pointDelta: Double
+        var ioHidDelta: Double
+    }
+
+    private func highResolutionTouchPeak(
+        for inputs: [TimedHighResolutionScrollInput]
+    ) throws -> Double {
+        var emittedEvents: [CGEvent] = []
+        var now = 0.0
+        let transformer = SmoothedScrollingTransformer(
+            smoothed: .init(vertical: Scheme.Scrolling.Smoothed.Preset.easeInOut.defaultConfiguration),
+            highResolutionWheelMultiplier: { 8 },
+            now: { now },
+            eventSink: { emittedEvents.append($0.copy() ?? $0) }
+        )
+        let sortedInputs = inputs.sorted { $0.timestamp < $1.timestamp }
+        let tickInterval = 1.0 / 120.0
+        let finalTimestamp = (sortedInputs.last?.timestamp ?? 0) + 0.5
+        let tickCount = Int((finalTimestamp / tickInterval).rounded(.up))
+        var nextInputIndex = 0
+
+        for tick in 1 ... tickCount {
+            let timestamp = Double(tick) * tickInterval
+
+            while nextInputIndex < sortedInputs.count,
+                  sortedInputs[nextInputIndex].timestamp <= timestamp {
+                let input = sortedInputs[nextInputIndex]
+                now = input.timestamp
+                let event = try makeVerticalHighResolutionScrollEvent(
+                    integerDelta: input.integerDelta,
+                    fixedPointDelta: input.fixedPointDelta,
+                    pointDelta: input.pointDelta,
+                    ioHidDelta: input.ioHidDelta
+                )
+                XCTAssertNil(transformer.transform(event))
+                nextInputIndex += 1
+            }
+
+            now = timestamp
+            transformer.tick()
+        }
+
+        return touchPeak(in: emittedEvents)
+    }
+
+    private func lowResolutionSingleDetentTouchPeak() throws -> Double {
+        var emittedEvents: [CGEvent] = []
+        var now = 0.0
+        let transformer = SmoothedScrollingTransformer(
+            smoothed: .init(vertical: Scheme.Scrolling.Smoothed.Preset.easeInOut.defaultConfiguration),
+            now: { now },
+            eventSink: { emittedEvents.append($0.copy() ?? $0) }
+        )
+        let event = try XCTUnwrap(CGEvent(
+            scrollWheelEvent2Source: nil,
+            units: .line,
+            wheelCount: 2,
+            wheel1: 1,
+            wheel2: 0,
+            wheel3: 0
+        ))
+
+        XCTAssertNil(transformer.transform(event))
+        for tick in 1 ... 60 {
+            now = Double(tick) / 120.0
+            transformer.tick()
+        }
+
+        return touchPeak(in: emittedEvents)
+    }
+
+    private func touchPeak(in emittedEvents: [CGEvent]) -> Double {
+        let scrollEvents = emittedEvents.filter { $0.type == .scrollWheel }
+        let scrollViews = scrollEvents.map(ScrollWheelEventView.init)
+        let touchViews = scrollViews.filter { view in
+            view.scrollPhase == .began || view.scrollPhase == .changed
+        }
+        let touchDeltas = touchViews.map { abs($0.deltaYPt) }
+
+        return touchDeltas.max() ?? 0
+    }
+
+    private func slowHighResolutionRawTickInputs(
+        count: Int,
+        interval: TimeInterval
+    ) -> [TimedHighResolutionScrollInput] {
+        (0 ..< count).map { index in
+            TimedHighResolutionScrollInput(
+                timestamp: Double(index) * interval,
+                integerDelta: 1,
+                fixedPointDelta: 0.100006103515625,
+                pointDelta: 1,
+                ioHidDelta: 1
+            )
+        }
+    }
+
+    private func highResolutionRawDetentInputs(
+        detentInterval: TimeInterval,
+        multiplier: Int = 8
+    ) -> [TimedHighResolutionScrollInput] {
+        let unitInterval = detentInterval / Double(multiplier)
+
+        return (0 ..< multiplier).map { index in
+            TimedHighResolutionScrollInput(
+                timestamp: Double(index) * unitInterval,
+                integerDelta: 1,
+                fixedPointDelta: 0.100006103515625,
+                pointDelta: 1,
+                ioHidDelta: 1
+            )
+        }
+    }
+
+    private func loggedFastHighResolutionInputs() -> [TimedHighResolutionScrollInput] {
+        let timestamps = [
+            899_937_042_327,
+            899_937_940_863,
+            899_939_561_641,
+            899_940_281_411,
+            899_940_480_800,
+            899_940_822_651,
+            899_941_188_304,
+            899_942_074_311
+        ]
+        let integerDeltas: [Int64] = [1, 1, 2, 3, 5, 6, 7, 7]
+        let fixedPointDeltas = [
+            0.100006103515625,
+            0.790863037109375,
+            2.229400634765625,
+            3.87945556640625,
+            5.57720947265625,
+            6.332366943359375,
+            7.0001983642578125,
+            7.4188232421875
+        ]
+        let pointDeltas = [1.0, 8, 23, 39, 56, 64, 71, 75]
+        let startTimestamp = timestamps[0]
+
+        return timestamps.indices.map { index in
+            TimedHighResolutionScrollInput(
+                timestamp: Double(timestamps[index] - startTimestamp) / 1_000_000_000.0,
+                integerDelta: integerDeltas[index],
+                fixedPointDelta: fixedPointDeltas[index],
+                pointDelta: pointDeltas[index],
+                ioHidDelta: 1
+            )
+        }
+    }
+
+    private func makeVerticalHighResolutionScrollEvent(
+        integerDelta: Int64,
+        fixedPointDelta: Double,
+        pointDelta: Double,
+        ioHidDelta: Double
+    ) throws -> CGEvent {
+        let event = try XCTUnwrap(CGEvent(
+            scrollWheelEvent2Source: nil,
+            units: .line,
+            wheelCount: 2,
+            wheel1: Int32(integerDelta),
+            wheel2: 0,
+            wheel3: 0
+        ))
+        let view = ScrollWheelEventView(event)
+        view.deltaYFixedPt = fixedPointDelta
+        view.deltaYPt = pointDelta
+        view.ioHidScrollY = ioHidDelta
+        return event
     }
 }
 

--- a/LinearMouseUnitTests/EventTransformer/SmoothedScrollingTransformerTests.swift
+++ b/LinearMouseUnitTests/EventTransformer/SmoothedScrollingTransformerTests.swift
@@ -410,6 +410,21 @@ final class SmoothedScrollingTransformerTests: XCTestCase {
         XCTAssertGreaterThan(abs(extended.deltaYPt), abs(baseline.deltaYPt) * 1.25)
     }
 
+    func testSmoothedPointDeltaAccumulatorCarriesFractionalPixels() {
+        var accumulator = SmoothedScrollPointDeltaAccumulator()
+
+        XCTAssertEqual(accumulator.verticalPointDelta(for: 0.4), 0)
+        XCTAssertEqual(accumulator.verticalPointDelta(for: 0.4), 0)
+        XCTAssertEqual(accumulator.verticalPointDelta(for: 0.4), 1)
+        XCTAssertEqual(accumulator.verticalPointDelta(for: -0.2), 0)
+
+        XCTAssertEqual(accumulator.horizontalPointDelta(for: -0.6), 0)
+        XCTAssertEqual(accumulator.horizontalPointDelta(for: -0.6), -1)
+
+        accumulator.reset()
+        XCTAssertEqual(accumulator.verticalPointDelta(for: 0.6), 0)
+    }
+
     private func firstDiscreteEmission(
         configuration: Scheme.Scrolling.Smoothed
     ) throws -> ScrollWheelEventView {

--- a/LinearMouseUnitTests/EventTransformer/SmoothedScrollingTransformerTests.swift
+++ b/LinearMouseUnitTests/EventTransformer/SmoothedScrollingTransformerTests.swift
@@ -269,9 +269,8 @@ final class SmoothedScrollingTransformerTests: XCTestCase {
         let transformer = SmoothedScrollingTransformer(
             smoothed: .init(
                 vertical: Scheme.Scrolling.Smoothed.Preset.easeInOut.defaultConfiguration
-            ),
-            now: { now }
-        )
+            )
+        )            { now }
 
         let originalEvent = try XCTUnwrap(CGEvent(
             scrollWheelEvent2Source: nil,
@@ -335,9 +334,8 @@ final class SmoothedScrollingTransformerTests: XCTestCase {
         var configuration = Scheme.Scrolling.Smoothed.Preset.easeInOut.defaultConfiguration
         configuration.bouncing = false
         let transformer = SmoothedScrollingTransformer(
-            smoothed: .init(vertical: configuration),
-            now: { now }
-        )
+            smoothed: .init(vertical: configuration)
+        )            { now }
 
         let originalEvent = try XCTUnwrap(CGEvent(
             scrollWheelEvent2Source: nil,
@@ -509,10 +507,14 @@ final class SmoothedScrollingTransformerTests: XCTestCase {
         let slowPeak = try highResolutionTouchPeak(
             for: highResolutionRawDetentInputs(detentInterval: 0.16)
         )
+        let normalPeak = try highResolutionTouchPeak(
+            for: highResolutionRawDetentInputs(detentInterval: 1.0 / 55.0)
+        )
         let fastPeak = try highResolutionTouchPeak(for: loggedFastHighResolutionInputs())
 
         XCTAssertGreaterThan(slowPeak, 0)
-        XCTAssertGreaterThan(fastPeak, slowPeak * 3.0)
+        XCTAssertGreaterThan(normalPeak, slowPeak * 2.0)
+        XCTAssertGreaterThan(fastPeak, normalPeak)
     }
 
     func testSmoothedNormalHighResolutionDetentDoesNotOvershootLowResolutionDetentThroughTransformer() throws {
@@ -525,8 +527,58 @@ final class SmoothedScrollingTransformerTests: XCTestCase {
         )
 
         XCTAssertGreaterThan(lowResolutionPeak, 0)
+        XCTAssertGreaterThan(slowHighResolutionPeak, lowResolutionPeak * 0.25)
+        XCTAssertLessThan(slowHighResolutionPeak, lowResolutionPeak * 0.75)
         XCTAssertGreaterThan(normalHighResolutionPeak, slowHighResolutionPeak * 2.0)
         XCTAssertLessThan(normalHighResolutionPeak, lowResolutionPeak * 1.05)
+    }
+
+    func testSmoothedHighResolutionSingleDetentTotalOutputStaysCloseToLowResolutionThroughTransformer() throws {
+        let lowResolutionOutput = try lowResolutionSingleDetentTotalDelta()
+        let slowHighResolutionOutput = try highResolutionTotalDelta(
+            for: highResolutionRawDetentInputs(detentInterval: 0.16)
+        )
+        let normalHighResolutionOutput = try highResolutionTotalDelta(
+            for: highResolutionRawDetentInputs(detentInterval: 1.0 / 55.0)
+        )
+
+        XCTAssertGreaterThan(lowResolutionOutput, 0)
+        XCTAssertGreaterThan(slowHighResolutionOutput, lowResolutionOutput * 0.25)
+        XCTAssertLessThan(slowHighResolutionOutput, lowResolutionOutput * 0.75)
+        XCTAssertGreaterThan(normalHighResolutionOutput, slowHighResolutionOutput * 2.0)
+        XCTAssertLessThan(normalHighResolutionOutput, lowResolutionOutput * 1.25)
+    }
+
+    func testSmoothedHighResolutionWheelTotalOutputTracksInputDensityThroughTransformer() throws {
+        let slowOutput = try highResolutionTotalDelta(
+            for: highResolutionRawDetentInputs(detentInterval: 0.16, count: 4)
+        )
+        let normalOutput = try highResolutionTotalDelta(
+            for: highResolutionRawDetentInputs(detentInterval: 0.08, count: 4)
+        )
+        let fastOutput = try highResolutionTotalDelta(
+            for: highResolutionRawDetentInputs(detentInterval: 1.0 / 55.0, count: 4)
+        )
+
+        XCTAssertGreaterThan(slowOutput, 0)
+        XCTAssertGreaterThan(normalOutput, slowOutput)
+        XCTAssertGreaterThan(fastOutput, normalOutput)
+    }
+
+    func testSmoothedHighResolutionSingleRawTickIgnoresNativeAccelerationHint() {
+        let units = SmoothedScrollingTransformer.smoothedHighResolutionUnits(
+            from: .init(rawUnits: 1, acceleratedUnits: 14, units: 14)
+        )
+
+        XCTAssertEqual(units, 1, accuracy: 0.001)
+    }
+
+    func testSmoothedHighResolutionCoalescedRawTicksUseNativeAccelerationHint() {
+        let units = SmoothedScrollingTransformer.smoothedHighResolutionUnits(
+            from: .init(rawUnits: 4, acceleratedUnits: 14, units: 14)
+        )
+
+        XCTAssertEqual(units, 11.5, accuracy: 0.001)
     }
 
     private func firstDiscreteEmission(
@@ -587,6 +639,18 @@ final class SmoothedScrollingTransformerTests: XCTestCase {
     private func highResolutionTouchPeak(
         for inputs: [TimedHighResolutionScrollInput]
     ) throws -> Double {
+        try touchPeak(in: highResolutionEvents(for: inputs))
+    }
+
+    private func highResolutionTotalDelta(
+        for inputs: [TimedHighResolutionScrollInput]
+    ) throws -> Double {
+        try totalDelta(in: highResolutionEvents(for: inputs))
+    }
+
+    private func highResolutionEvents(
+        for inputs: [TimedHighResolutionScrollInput]
+    ) throws -> [CGEvent] {
         var emittedEvents: [CGEvent] = []
         var now = 0.0
         let transformer = SmoothedScrollingTransformer(
@@ -622,10 +686,18 @@ final class SmoothedScrollingTransformerTests: XCTestCase {
             transformer.tick()
         }
 
-        return touchPeak(in: emittedEvents)
+        return emittedEvents
     }
 
     private func lowResolutionSingleDetentTouchPeak() throws -> Double {
+        try touchPeak(in: lowResolutionSingleDetentEvents())
+    }
+
+    private func lowResolutionSingleDetentTotalDelta() throws -> Double {
+        try totalDelta(in: lowResolutionSingleDetentEvents())
+    }
+
+    private func lowResolutionSingleDetentEvents() throws -> [CGEvent] {
         var emittedEvents: [CGEvent] = []
         var now = 0.0
         let transformer = SmoothedScrollingTransformer(
@@ -648,7 +720,7 @@ final class SmoothedScrollingTransformerTests: XCTestCase {
             transformer.tick()
         }
 
-        return touchPeak(in: emittedEvents)
+        return emittedEvents
     }
 
     private func touchPeak(in emittedEvents: [CGEvent]) -> Double {
@@ -660,6 +732,13 @@ final class SmoothedScrollingTransformerTests: XCTestCase {
         let touchDeltas = touchViews.map { abs($0.deltaYPt) }
 
         return touchDeltas.max() ?? 0
+    }
+
+    private func totalDelta(in emittedEvents: [CGEvent]) -> Double {
+        emittedEvents
+            .filter { $0.type == .scrollWheel }
+            .map { abs(ScrollWheelEventView($0).deltaYPt) }
+            .reduce(0, +)
     }
 
     private func slowHighResolutionRawTickInputs(
@@ -679,16 +758,19 @@ final class SmoothedScrollingTransformerTests: XCTestCase {
 
     private func highResolutionRawDetentInputs(
         detentInterval: TimeInterval,
+        count: Int = 1,
         multiplier: Int = 8
     ) -> [TimedHighResolutionScrollInput] {
         let unitInterval = detentInterval / Double(multiplier)
+        let fixedPointDelta = 1.0 / Double(multiplier)
+        let pointDelta = 10.0 / Double(multiplier)
 
-        return (0 ..< multiplier).map { index in
+        return (0 ..< count * multiplier).map { index in
             TimedHighResolutionScrollInput(
                 timestamp: Double(index) * unitInterval,
                 integerDelta: 1,
-                fixedPointDelta: 0.100006103515625,
-                pointDelta: 1,
+                fixedPointDelta: fixedPointDelta,
+                pointDelta: pointDelta,
                 ioHidDelta: 1
             )
         }

--- a/LinearMouseUnitTests/Model/ConfigurationTests.swift
+++ b/LinearMouseUnitTests/Model/ConfigurationTests.swift
@@ -38,6 +38,24 @@ final class ConfigurationTests: XCTestCase {
         XCTAssertEqual(scheme.scrolling.reverse.horizontal, true)
     }
 
+    func testMergeLogitechSettings() {
+        var scheme = Scheme()
+
+        XCTAssertNil(scheme.$logitech)
+
+        var base = Scheme()
+        base.logitech.highResolutionWheel = true
+        base.merge(into: &scheme)
+
+        XCTAssertEqual(scheme.logitech.highResolutionWheel, true)
+
+        var override = Scheme()
+        override.logitech.highResolutionWheel = false
+        override.merge(into: &scheme)
+
+        XCTAssertEqual(scheme.logitech.highResolutionWheel, false)
+    }
+
     func testMatchSchemeWithDeviceCategoryDoesNotMergeDeviceSpecificSchemes() {
         var categoryScheme = Scheme(if: [.init(device: DeviceMatcher(category: .mouse))])
         categoryScheme.pointer.disableAcceleration = true


### PR DESCRIPTION
## Summary

- Add Logitech HID++ high-resolution wheel support for BLE devices that expose the HIRES_WHEEL feature.
- Add a Scrolling settings toggle and persist the setting under Logitech-specific configuration.
- Normalize high-resolution wheel deltas using the reported multiplier, restore the initial wheel mode on app exit, and update docs, localizations, and tests.

## Notes

This currently targets BLE Logitech devices only. Receiver-backed devices can be handled separately later.

Related to #1179.

## Test Plan

- `xcodebuild test -project LinearMouse.xcodeproj -scheme LinearMouse -destination 'platform=macOS'`\n- `swiftformat LinearMouse LinearMouseUnitTests --lint`\n- `swiftlint lint LinearMouse LinearMouseUnitTests`\n- `git diff --check`