### PR TITLE
Add Logitech DPI support for Bolt receivers

### DIFF
--- a/LinearMouse/Device/Device.swift
+++ b/LinearMouse/Device/Device.swift
@@ -35,7 +35,20 @@ class Device {
     private weak var manager: DeviceManager?
     private var inputReportHandlers: [InputReportHandler] = []
     private var logitechReprogrammableControlsMonitor: LogitechReprogrammableControlsMonitor?
-    lazy var logitechDPIController = LogitechHIDPPDeviceDPIController(device: device)
+    private var cachedLogitechDPIController: LogitechHIDPPDeviceDPIController?
+    var logitechDPIController: LogitechHIDPPDeviceDPIController? {
+        if let cachedLogitechDPIController {
+            return cachedLogitechDPIController
+        }
+
+        guard let controller = LogitechHIDPPDeviceDPIController(device: device) else {
+            return nil
+        }
+
+        cachedLogitechDPIController = controller
+        return controller
+    }
+
     private var logitechControlsMonitorSubscriptions = Set<AnyCancellable>()
     private let device: PointerDevice
 

--- a/LinearMouse/Device/VendorSpecific/Logitech/LogitechHIDPPDeviceDPIController.swift
+++ b/LinearMouse/Device/VendorSpecific/Logitech/LogitechHIDPPDeviceDPIController.swift
@@ -101,7 +101,11 @@ struct LogitechHIDPPDeviceDPIController {
             function: Constants.setSensorDPIFunction,
             parameters: [0x00, UInt8((targetDPI >> 8) & 0xFF), UInt8(targetDPI & 0xFF)]
         )
-        return response == nil ? nil : targetDPI
+        if response != nil || currentDPI() == targetDPI {
+            return targetDPI
+        }
+
+        return nil
     }
 
     func supportedDPI(nearestTo dpi: Int) -> Int {
@@ -143,7 +147,7 @@ struct LogitechHIDPPDeviceDPIController {
     ) -> Self? {
         guard device.transport == PointerDeviceTransportName.usb,
               let receiverChannel = provider.openReceiverChannel(for: device),
-              let slot = provider.receiverSlot(for: device, using: receiverChannel),
+              let slot = receiverSlot(for: device, using: receiverChannel, provider: provider),
               let transport = LogitechHIDPPTransport(device: receiverChannel, deviceIndex: slot),
               let featureIndex = transport.featureIndex(for: .adjustableDPI)
         else {
@@ -156,6 +160,26 @@ struct LogitechHIDPPDeviceDPIController {
             featureIndex: featureIndex,
             supportedDPI: supportedDPI
         )
+    }
+
+    private static func receiverSlot(
+        for device: VendorSpecificDeviceContext,
+        using receiverChannel: LogitechReceiverChannel,
+        provider: LogitechHIDPPDeviceMetadataProvider
+    ) -> UInt8? {
+        switch LogitechHIDPPDeviceMetadataProvider.receiverProtocolFamily(
+            vendorID: device.vendorID,
+            productID: device.productID,
+            transport: device.transport
+        ) {
+        case .classic:
+            return provider.receiverSlot(for: device, using: receiverChannel)
+        case .bolt:
+            let discovery = provider.receiverPointingDeviceDiscovery(for: device, using: receiverChannel)
+            return provider.receiverSlot(for: device, identities: discovery.identities)
+        case nil:
+            return provider.receiverSlot(for: device, using: receiverChannel)
+        }
     }
 
     private static func readSupportedDPI(transport: LogitechHIDPPTransport, featureIndex: UInt8) -> [Int] {

--- a/LinearMouse/Device/VendorSpecific/Logitech/LogitechHIDPPDeviceMetadataProvider.swift
+++ b/LinearMouse/Device/VendorSpecific/Logitech/LogitechHIDPPDeviceMetadataProvider.swift
@@ -350,6 +350,36 @@ struct LogitechHIDPPDeviceMetadataProvider: VendorSpecificDeviceMetadataProvider
         receiverPointingDeviceDiscovery(for: device).identities
     }
 
+    func receiverSlot(
+        for device: VendorSpecificDeviceContext,
+        identities: [ReceiverLogicalDeviceIdentity]
+    ) -> UInt8? {
+        let normalizedSerial = normalizeSerial(device.serialNumber)
+        if let serialMatch = uniqueIdentityMatch(identities, matching: {
+            normalizedSerial != nil && normalizeSerial($0.serialNumber) == normalizedSerial
+        }) {
+            return serialMatch.slot
+        }
+
+        if let productID = device.productID,
+           let productIDMatch = uniqueIdentityMatch(identities, matching: { $0.productID == productID }) {
+            return productIDMatch.slot
+        }
+
+        let normalizedName = normalizeName(device.product ?? device.name)
+        if let nameMatch = uniqueIdentityMatch(identities, matching: {
+            normalizeName($0.name) == normalizedName
+        }) {
+            return nameMatch.slot
+        }
+
+        guard identities.count == 1 else {
+            return nil
+        }
+
+        return identities[0].slot
+    }
+
     func openReceiverChannel(for device: VendorSpecificDeviceContext) -> LogitechReceiverChannel? {
         guard device.transport == PointerDeviceTransportName.usb,
               let locationID = device.locationID
@@ -746,12 +776,29 @@ struct LogitechHIDPPDeviceMetadataProvider: VendorSpecificDeviceMetadataProvider
         name.lowercased().trimmingCharacters(in: .whitespacesAndNewlines)
     }
 
+    private func normalizeName(_ name: String?) -> String? {
+        guard let name else {
+            return nil
+        }
+
+        let normalized = normalizeName(name)
+        return normalized.isEmpty ? nil : normalized
+    }
+
     private func normalizeSerial(_ serialNumber: String?) -> String? {
         guard let serialNumber, !serialNumber.isEmpty else {
             return nil
         }
 
         return serialNumber.uppercased().replacingOccurrences(of: ":", with: "")
+    }
+
+    private func uniqueIdentityMatch(
+        _ identities: [ReceiverLogicalDeviceIdentity],
+        matching matches: (ReceiverLogicalDeviceIdentity) -> Bool
+    ) -> ReceiverLogicalDeviceIdentity? {
+        let matchingIdentities = identities.filter(matches)
+        return matchingIdentities.count == 1 ? matchingIdentities[0] : nil
     }
 
     static func parseReceiverConnectionNotification(

--- a/LinearMouse/UI/PointerSettings/PointerSettingsState.swift
+++ b/LinearMouse/UI/PointerSettings/PointerSettingsState.swift
@@ -194,17 +194,15 @@ extension PointerSettingsState {
 
             if !result.info.supportsAdjustableDPI {
                 self.pointerHardwareDPIStatusMessage = "Unsupported device"
-            } else if result.targetDPI == nil {
-                self.pointerHardwareDPIStatusMessage = "Unable to apply DPI"
-            } else if let currentDPI = result.info.currentDPI {
-                self.pointerHardwareDPITargetDPI = currentDPI
+            } else if let targetDPI = result.targetDPI {
+                self.pointerHardwareDPITargetDPI = targetDPI
                 self.pointerHardwareDPITargetDPIEdited = false
                 var deviceScheme = self.schemeState.deviceScheme
-                deviceScheme.pointer.hardwareDPI = currentDPI
+                deviceScheme.pointer.hardwareDPI = targetDPI
                 self.schemeState.deviceScheme = deviceScheme
                 self.pointerHardwareDPIStatusMessage = nil
             } else {
-                self.pointerHardwareDPIStatusMessage = "Unable to read DPI after apply"
+                self.pointerHardwareDPIStatusMessage = "Unable to apply DPI"
             }
 
             self.pointerHardwareDPIInfo = result.info

--- a/LinearMouseUnitTests/Device/VendorSpecific/LogitechHIDPPDeviceDPIControllerTests.swift
+++ b/LinearMouseUnitTests/Device/VendorSpecific/LogitechHIDPPDeviceDPIControllerTests.swift
@@ -19,6 +19,64 @@ final class LogitechHIDPPDeviceDPIControllerTests: XCTestCase {
         )
     }
 
+    func testBoltReceiverSlotFallsBackToOnlyDiscoveredPointingDevice() {
+        let device = Self.boltReceiver()
+        let identities = [Self.receiverIdentity(slot: 2, name: "MX Master 3S")]
+        let provider = LogitechHIDPPDeviceMetadataProvider()
+
+        XCTAssertEqual(
+            provider.receiverSlot(for: device, identities: identities),
+            2
+        )
+    }
+
+    func testBoltReceiverSlotUsesSerialMatchWhenMultipleDevicesArePaired() {
+        let device = Self.boltReceiver(product: "MX Master 3S", serialNumber: "AB:CD:EF:01")
+        let identities = [
+            Self.receiverIdentity(slot: 1, name: "MX Master 3S", serialNumber: "12345678", productID: 0xB03E),
+            Self.receiverIdentity(slot: 3, name: "MX Master 3S", serialNumber: "ABCDEF01", productID: 0xB034)
+        ]
+        let provider = LogitechHIDPPDeviceMetadataProvider()
+
+        XCTAssertEqual(
+            provider.receiverSlot(for: device, identities: identities),
+            3
+        )
+    }
+
+    func testBoltReceiverSlotRejectsAmbiguousPairedDevices() {
+        let device = Self.boltReceiver()
+        let identities = [
+            Self.receiverIdentity(slot: 1, name: "MX Ergo S"),
+            Self.receiverIdentity(slot: 3, name: "MX Master 3S")
+        ]
+        let provider = LogitechHIDPPDeviceMetadataProvider()
+
+        XCTAssertNil(provider.receiverSlot(for: device, identities: identities))
+    }
+
+    func testBoltReceiverSlotRejectsDuplicateProductIDMatches() {
+        let device = Self.boltReceiver()
+        let identities = [
+            Self.receiverIdentity(slot: 1, name: "MX Ergo S", productID: 0xC548),
+            Self.receiverIdentity(slot: 3, name: "MX Master 3S", productID: 0xC548)
+        ]
+        let provider = LogitechHIDPPDeviceMetadataProvider()
+
+        XCTAssertNil(provider.receiverSlot(for: device, identities: identities))
+    }
+
+    func testBoltReceiverSlotRejectsDuplicateNameMatches() {
+        let device = Self.boltReceiver(product: "MX Master 3S")
+        let identities = [
+            Self.receiverIdentity(slot: 1, name: "MX Master 3S"),
+            Self.receiverIdentity(slot: 3, name: "MX Master 3S")
+        ]
+        let provider = LogitechHIDPPDeviceMetadataProvider()
+
+        XCTAssertNil(provider.receiverSlot(for: device, identities: identities))
+    }
+
     func testReadsAndWritesAdjustableDPI() {
         let device = MockVendorSpecificDeviceContext(
             vendorID: 0x046D,
@@ -147,6 +205,49 @@ final class LogitechHIDPPDeviceDPIControllerTests: XCTestCase {
         XCTAssertEqual(controller?.canRepresentDPI(260), false)
     }
 
+    func testSetDPISucceedsWhenDeviceAppliesWithoutAcknowledgingWrite() {
+        let device = MockVendorSpecificDeviceContext(
+            vendorID: 0x046D,
+            productID: 0xB015,
+            transport: PointerDeviceTransportName.bluetoothLowEnergy,
+            maxInputReportSize: 20,
+            maxOutputReportSize: 20
+        )
+        var currentDPI = 800
+        device.responseProvider = { report in
+            let bytes = [UInt8](report)
+            guard bytes.count >= 4 else {
+                return nil
+            }
+
+            switch (bytes[2], bytes[3]) {
+            case (0x00, 0x08):
+                return Self.hidppLongReply(featureIndex: 0x00, address: 0x08, payload: [0x05])
+            case (0x05, 0x18):
+                return Self.hidppLongReply(
+                    featureIndex: 0x05,
+                    address: 0x18,
+                    payload: [0x00, 0x03, 0x20, 0x06, 0x40, 0x00, 0x00]
+                )
+            case (0x05, 0x28):
+                return Self.hidppLongReply(
+                    featureIndex: 0x05,
+                    address: 0x28,
+                    payload: [0x00, UInt8((currentDPI >> 8) & 0xFF), UInt8(currentDPI & 0xFF), 0x00, 0x00]
+                )
+            case (0x05, 0x38):
+                currentDPI = Int(bytes[5]) << 8 | Int(bytes[6])
+                return nil
+            default:
+                return nil
+            }
+        }
+
+        let controller = LogitechHIDPPDeviceDPIController(device: device)
+
+        XCTAssertEqual(controller?.setDPI(1600), 1600)
+    }
+
     func testCurrentDPIUsesSupportedDefaultWhenCurrentBytesAreNotSupported() {
         let device = MockVendorSpecificDeviceContext(
             vendorID: 0x046D,
@@ -184,6 +285,40 @@ final class LogitechHIDPPDeviceDPIControllerTests: XCTestCase {
         let controller = LogitechHIDPPDeviceDPIController(device: device)
 
         XCTAssertEqual(controller?.currentDPI(), 1000)
+    }
+
+    private static func boltReceiver(
+        product: String? = nil,
+        serialNumber: String? = nil
+    ) -> MockVendorSpecificDeviceContext {
+        MockVendorSpecificDeviceContext(
+            vendorID: 0x046D,
+            productID: 0xC548,
+            product: product,
+            name: product ?? "Logi Bolt Receiver",
+            serialNumber: serialNumber,
+            transport: PointerDeviceTransportName.usb,
+            locationID: 1,
+            maxInputReportSize: 20,
+            maxOutputReportSize: 20
+        )
+    }
+
+    private static func receiverIdentity(
+        slot: UInt8,
+        name: String,
+        serialNumber: String? = nil,
+        productID: Int? = nil
+    ) -> ReceiverLogicalDeviceIdentity {
+        ReceiverLogicalDeviceIdentity(
+            receiverLocationID: 1,
+            slot: slot,
+            kind: .mouse,
+            name: name,
+            serialNumber: serialNumber,
+            productID: productID,
+            batteryLevel: nil
+        )
     }
 
     private static func hidppLongReply(featureIndex: UInt8, address: UInt8, payload: [UInt8]) -> Data {


### PR DESCRIPTION
Addresses #1235.

## Summary

- Add Bolt-aware receiver slot discovery for Logitech hardware DPI
- Route Bolt DPI commands to the matched logical receiver child
- Avoid targeting ambiguous receiver children when product ID or name is not unique
- Retry Logitech DPI controller creation when early receiver discovery returns nil
- Persist the confirmed target DPI without requiring immediate read-back

## Verification

- `make lint`
- `xcodebuild test -project LinearMouse.xcodeproj -scheme LinearMouse -only-testing:LinearMouseUnitTests/LogitechHIDPPDeviceDPIControllerTests`