### PR TITLE
Fix button mapping recording crash when switching devices

### DIFF
--- a/LinearMouse/State/DeviceState.swift
+++ b/LinearMouse/State/DeviceState.swift
@@ -74,6 +74,10 @@ extension DeviceState {
     }
 
     private func setCurrentDeviceRef(_ deviceRef: WeakRef<Device>?) {
+        if currentDeviceRef?.value !== deviceRef?.value {
+            SettingsState.shared.endButtonMappingRecording()
+        }
+
         isUpdatingCurrentDeviceRef = true
         currentDeviceRef = deviceRef
         isUpdatingCurrentDeviceRef = false

--- a/LinearMouse/UI/ButtonsSettings/ButtonMappingsSection/ButtonMapping.swift
+++ b/LinearMouse/UI/ButtonsSettings/ButtonMappingsSection/ButtonMapping.swift
@@ -5,11 +5,9 @@ import SwiftUI
 
 struct ButtonMappingListItem: View {
     @Binding var mapping: Scheme.Buttons.Mapping
+    var onEdit: (Scheme.Buttons.Mapping) -> Void
 
     @State private var hover = false
-
-    @State private var showEditSheet = false
-    @State private var mappingToEdit: Scheme.Buttons.Mapping = .init()
 
     var body: some View {
         HStack {
@@ -21,17 +19,11 @@ struct ButtonMappingListItem: View {
             Spacer()
 
             Button("Edit") {
-                mappingToEdit = mapping
-                showEditSheet.toggle()
+                onEdit(mapping)
             }
             .opacity(hover ? 1 : 0)
         }
         .padding(.vertical, 4)
-        .sheet(isPresented: $showEditSheet) {
-            ButtonMappingEditSheet(isPresented: $showEditSheet, mapping: $mappingToEdit) { mapping in
-                self.mapping = mapping
-            }
-        }
         .onHover {
             hover = $0
         }

--- a/LinearMouse/UI/ButtonsSettings/ButtonMappingsSection/ButtonMappingEditSheet.swift
+++ b/LinearMouse/UI/ButtonsSettings/ButtonMappingsSection/ButtonMappingEditSheet.swift
@@ -11,7 +11,7 @@ struct ButtonMappingEditSheet: View {
     @Binding var mapping: Scheme.Buttons.Mapping
     let completion: ((Scheme.Buttons.Mapping) -> Void)?
 
-    @State private var mode: Mode
+    let mode: Mode
 
     init(
         isPresented: Binding<Bool>,
@@ -84,9 +84,8 @@ struct ButtonMappingEditSheet: View {
                 }
 
                 Button(mode == .create ? "Create" : "OK") {
-                    isPresented = false
-                    mode = .edit
                     completion?(mapping)
+                    isPresented = false
                 }
                 .disabled(!valid)
                 .asDefaultAction()

--- a/LinearMouse/UI/ButtonsSettings/ButtonMappingsSection/ButtonMappingsSection.swift
+++ b/LinearMouse/UI/ButtonsSettings/ButtonMappingsSection/ButtonMappingsSection.swift
@@ -8,20 +8,21 @@ struct ButtonMappingsSection: View {
 
     @State private var selection: Set<Scheme.Buttons.Mapping> = []
 
-    @State private var showAddSheet = false
-    @State private var mappingToAdd: Scheme.Buttons.Mapping = .init()
+    @State private var activeSheet: ActiveSheet?
+    @State private var mappingDraft: Scheme.Buttons.Mapping = .init()
+    @State private var editingOriginalMapping: Scheme.Buttons.Mapping?
 
     var body: some View {
         Section {
             if #available(macOS 13.0, *) {
                 if !state.mappings.isEmpty {
                     List($state.mappings, id: \.self, selection: $selection) { $mapping in
-                        ButtonMappingListItem(mapping: $mapping)
+                        ButtonMappingListItem(mapping: $mapping, onEdit: beginEditing)
                     }
                 }
             } else {
                 List($state.mappings, id: \.self, selection: $selection) { $mapping in
-                    ButtonMappingListItem(mapping: $mapping)
+                    ButtonMappingListItem(mapping: $mapping, onEdit: beginEditing)
                 }
                 .frame(height: 200)
             }
@@ -30,8 +31,7 @@ struct ButtonMappingsSection: View {
         } footer: {
             HStack(spacing: 4) {
                 Button {
-                    mappingToAdd = .init()
-                    showAddSheet.toggle()
+                    beginAdding()
                 } label: {
                     VStack {
                         Image("Plus")
@@ -39,15 +39,6 @@ struct ButtonMappingsSection: View {
                     .frame(width: 16, height: 16)
                 }
                 .buttonStyle(.plain)
-                .sheet(isPresented: $showAddSheet) {
-                    ButtonMappingEditSheet(
-                        isPresented: $showAddSheet,
-                        mapping: $mappingToAdd,
-                        mode: .create
-                    ) { mapping in
-                        state.appendMapping(mapping)
-                    }
-                }
 
                 Button {
                     state.mappings = state.mappings.filter { !selection.contains($0) }
@@ -63,5 +54,72 @@ struct ButtonMappingsSection: View {
             }
         }
         .modifier(SectionViewModifier())
+        .sheet(item: $activeSheet) { sheet in
+            ButtonMappingEditSheet(
+                isPresented: sheetPresented,
+                mapping: $mappingDraft,
+                mode: sheet.mode
+            ) { mapping in
+                apply(mapping, from: sheet)
+            }
+        }
+    }
+
+    private var sheetPresented: Binding<Bool> {
+        Binding(
+            get: { activeSheet != nil },
+            set: { isPresented in
+                if !isPresented {
+                    activeSheet = nil
+                    editingOriginalMapping = nil
+                }
+            }
+        )
+    }
+
+    private func beginAdding() {
+        mappingDraft = .init()
+        editingOriginalMapping = nil
+        activeSheet = .create
+    }
+
+    private func beginEditing(_ mapping: Scheme.Buttons.Mapping) {
+        mappingDraft = mapping
+        editingOriginalMapping = mapping
+        activeSheet = .edit
+    }
+
+    private func apply(_ mapping: Scheme.Buttons.Mapping, from sheet: ActiveSheet) {
+        switch sheet {
+        case .create:
+            state.appendMapping(mapping)
+
+        case .edit:
+            guard let editingOriginalMapping,
+                  let index = state.mappings.firstIndex(of: editingOriginalMapping) else {
+                return
+            }
+            state.mappings[index] = mapping
+        }
+    }
+}
+
+private extension ButtonMappingsSection {
+    enum ActiveSheet: String, Identifiable {
+        case create
+        case edit
+
+        var id: String {
+            rawValue
+        }
+
+        var mode: ButtonMappingEditSheet.Mode {
+            switch self {
+            case .create:
+                return .create
+            case .edit:
+                return .edit
+            }
+        }
     }
 }


### PR DESCRIPTION
## Summary
- End button mapping recording when the current device changes so recording state does not survive a device switch.
- Present the button mapping editor from the section instead of individual list rows to keep the sheet presenter stable while mappings change.
- Avoid mutating local sheet mode state during dismissal.

## Testing
- `xcodebuild test -quiet -project LinearMouse.xcodeproj -scheme LinearMouse`
- `xcodebuild build -quiet -project LinearMouse.xcodeproj -scheme LinearMouse -configuration Debug`