### PR TITLE
Fix high-resolution wheel restore after wake

### DIFF
--- a/LinearMouse/Device/Device+HighResolutionWheel.swift
+++ b/LinearMouse/Device/Device+HighResolutionWheel.swift
@@ -4,6 +4,11 @@
 import Foundation
 
 extension Device {
+    private enum HighResolutionWheelApplyRetry {
+        static let maxAttempts = 8
+        static let delay: TimeInterval = 5
+    }
+
     private static let highResolutionWheelQueue = DispatchQueue(
         label: "app.linearmouse.high-resolution-wheel",
         qos: .userInitiated
@@ -16,9 +21,29 @@ extension Device {
     }
 
     func applyConfiguredHighResolutionWheel(_ enabled: Bool) {
+        let requestID = nextHighResolutionWheelApplyRequestID()
         Self.highResolutionWheelQueue.async {
-            _ = self.applyHighResolutionWheelSynchronously(enabled)
+            self.applyHighResolutionWheel(enabled, requestID: requestID, attempt: 1)
         }
+    }
+
+    private func applyHighResolutionWheel(_ enabled: Bool, requestID: UUID, attempt: Int) {
+        guard isCurrentHighResolutionWheelApplyRequest(requestID), !isRemoved else {
+            return
+        }
+
+        guard applyHighResolutionWheelSynchronously(enabled) == nil else {
+            return
+        }
+
+        guard attempt < HighResolutionWheelApplyRetry.maxAttempts else {
+            return
+        }
+
+        Self.highResolutionWheelQueue
+            .asyncAfter(deadline: .now() + HighResolutionWheelApplyRetry.delay) { [weak self] in
+                self?.applyHighResolutionWheel(enabled, requestID: requestID, attempt: attempt + 1)
+            }
     }
 
     func refreshHighResolutionWheelInfo(completion: @escaping (HighResolutionWheelInfo) -> Void) {
@@ -77,6 +102,7 @@ extension Device {
         highResolutionWheelLock.unlock()
 
         guard let applied = controller.setHighResolutionWheelEnabled(enabled) else {
+            invalidateLogitechHighResolutionWheelController()
             return nil
         }
 
@@ -102,6 +128,7 @@ extension Device {
     }
 
     func restoreHighResolutionWheel() {
+        cancelHighResolutionWheelApplyRequests()
         Self.highResolutionWheelQueue.sync {
             self.restoreHighResolutionWheelSynchronously()
         }
@@ -111,6 +138,7 @@ extension Device {
         guard !isRemoved,
               let controller = logitechHighResolutionWheelController else {
             clearHighResolutionWheelCache()
+            invalidateLogitechHighResolutionWheelController()
             return
         }
 
@@ -122,6 +150,7 @@ extension Device {
             _ = controller.setHighResolutionWheelEnabled(initialEnabled)
         }
 
+        invalidateLogitechHighResolutionWheelController()
         clearHighResolutionWheelCache()
     }
 
@@ -131,6 +160,28 @@ extension Device {
         cachedHighResolutionWheelMultiplier = nil
         initialHighResolutionWheelEnabled = nil
         highResolutionWheelLock.unlock()
+    }
+
+    private func nextHighResolutionWheelApplyRequestID() -> UUID {
+        highResolutionWheelLock.lock()
+        defer { highResolutionWheelLock.unlock() }
+
+        let requestID = UUID()
+        highResolutionWheelApplyRequestID = requestID
+        return requestID
+    }
+
+    private func cancelHighResolutionWheelApplyRequests() {
+        highResolutionWheelLock.lock()
+        highResolutionWheelApplyRequestID = UUID()
+        highResolutionWheelLock.unlock()
+    }
+
+    private func isCurrentHighResolutionWheelApplyRequest(_ requestID: UUID) -> Bool {
+        highResolutionWheelLock.lock()
+        defer { highResolutionWheelLock.unlock() }
+
+        return highResolutionWheelApplyRequestID == requestID
     }
 
     private func updateHighResolutionWheelCache(enabled: Bool?, multiplier: Int?) {

--- a/LinearMouse/Device/Device.swift
+++ b/LinearMouse/Device/Device.swift
@@ -36,6 +36,7 @@ class Device {
     private var inputReportHandlers: [InputReportHandler] = []
     private var logitechReprogrammableControlsMonitor: LogitechReprogrammableControlsMonitor?
     private var cachedLogitechDPIController: LogitechHIDPPDeviceDPIController?
+    private var cachedLogitechHighResolutionWheelController: LogitechHIDPPHighResolutionWheelController?
     var logitechDPIController: LogitechHIDPPDeviceDPIController? {
         if let cachedLogitechDPIController {
             return cachedLogitechDPIController
@@ -49,7 +50,23 @@ class Device {
         return controller
     }
 
-    lazy var logitechHighResolutionWheelController = LogitechHIDPPHighResolutionWheelController(device: device)
+    var logitechHighResolutionWheelController: LogitechHIDPPHighResolutionWheelController? {
+        if let cachedLogitechHighResolutionWheelController {
+            return cachedLogitechHighResolutionWheelController
+        }
+
+        guard let controller = LogitechHIDPPHighResolutionWheelController(device: device) else {
+            return nil
+        }
+
+        cachedLogitechHighResolutionWheelController = controller
+        return controller
+    }
+
+    func invalidateLogitechHighResolutionWheelController() {
+        cachedLogitechHighResolutionWheelController = nil
+    }
+
     private var logitechControlsMonitorSubscriptions = Set<AnyCancellable>()
     private let device: PointerDevice
 
@@ -68,6 +85,7 @@ class Device {
     var cachedHighResolutionWheelEnabled: Bool?
     var cachedHighResolutionWheelMultiplier: Int?
     var initialHighResolutionWheelEnabled: Bool?
+    var highResolutionWheelApplyRequestID = UUID()
 
     var isRemoved: Bool {
         hardwareDPILock.lock()
@@ -157,6 +175,7 @@ class Device {
         removed = true
         cachedHardwareDPI = nil
         hardwareDPILock.unlock()
+        invalidateLogitechHighResolutionWheelController()
         highResolutionWheelLock.lock()
         cachedHighResolutionWheelEnabled = nil
         cachedHighResolutionWheelMultiplier = nil

--- a/LinearMouse/Device/DeviceManager.swift
+++ b/LinearMouse/Device/DeviceManager.swift
@@ -133,6 +133,10 @@ class DeviceManager: ObservableObject {
             )
             self?.updatePointerSpeed()
         }
+
+        updatePointerSpeed()
+        updateHardwareDPI()
+        updateHighResolutionWheel()
     }
 
     private func deviceAdded(_: PointerDeviceManager, _ pointerDevice: PointerDevice) {

--- a/LinearMouse/UI/ScrollingSettings/ScrollingSettingsState.swift
+++ b/LinearMouse/UI/ScrollingSettings/ScrollingSettingsState.swift
@@ -1,6 +1,7 @@
 // MIT License
 // Copyright (c) 2021-2026 LinearMouse
 
+import AppKit
 import Combine
 import Foundation
 import PublishedObject
@@ -21,6 +22,16 @@ class ScrollingSettingsState: ObservableObject {
         deviceState.$currentDeviceRef
             .debounce(for: 0.1, scheduler: RunLoop.main)
             .removeDuplicates()
+            .sink { [weak self] _ in
+                self?.resetHighResolutionWheelInfo()
+                self?.refreshHighResolutionWheelInfo()
+            }
+            .store(in: &subscriptions)
+
+        NSWorkspace.shared
+            .notificationCenter
+            .publisher(for: NSWorkspace.didWakeNotification)
+            .delay(for: .seconds(2), scheduler: RunLoop.main)
             .sink { [weak self] _ in
                 self?.resetHighResolutionWheelInfo()
                 self?.refreshHighResolutionWheelInfo()
@@ -96,12 +107,23 @@ extension ScrollingSettingsState {
 
             self.highResolutionWheelInfo = info
             self.highResolutionWheelInfoRefreshing = false
+            self.applyConfiguredHighResolutionWheelIfNeeded(info: info, device: device)
         }
     }
 
     private func resetHighResolutionWheelInfo() {
         highResolutionWheelInfo = nil
         highResolutionWheelInfoRefreshing = false
+    }
+
+    private func applyConfiguredHighResolutionWheelIfNeeded(info: Device.HighResolutionWheelInfo, device: Device) {
+        guard info.supportsHighResolutionWheel,
+              let configuredHighResolutionWheel = schemeState.deviceScheme.logitech.highResolutionWheel,
+              info.enabled != configuredHighResolutionWheel else {
+            return
+        }
+
+        DeviceManager.shared.updateHighResolutionWheel(for: device)
     }
 
     enum ScrollingMode: String, Identifiable, CaseIterable {


### PR DESCRIPTION
## Summary
- Retry applying Logitech high-resolution wheel mode when the HID++ feature is temporarily unavailable after wake.
- Avoid permanently caching failed high-resolution wheel controller creation, and invalidate stale controllers after restore or failed writes.
- Reapply hardware-specific settings when device observation starts, and refresh the scrolling settings state after wake.

## Testing
- `git diff --check`
- `xcodebuild test -quiet -project LinearMouse.xcodeproj -scheme LinearMouse`
- `xcodebuild build -quiet -project LinearMouse.xcodeproj -scheme LinearMouse -configuration Debug`