### PR TITLE
fix: ensure CMD keyup always fires when non-Latin input causes unsupportedKey

### DIFF
--- a/Modules/KeyKit/Sources/KeyKit/KeySimulator.swift
+++ b/Modules/KeyKit/Sources/KeyKit/KeySimulator.swift
@@ -2,6 +2,7 @@
 // Copyright (c) 2021-2026 LinearMouse
 
 import AppKit
+import os
 
 public enum KeySimulatorError: Error {
     case unsupportedKey
@@ -116,10 +117,18 @@ public extension KeySimulator {
     func press(keys: [Key], tap: CGEventTapLocation? = nil) throws {
         try lock.withLock {
             for key in keys {
-                try postKeyLocked(key, keyDown: true, tap: tap)
+                do {
+                    try postKeyLocked(key, keyDown: true, tap: tap)
+                } catch {
+                    os_log(.error, "KeySimulator: keyDown failed for %{public}@: %{public}@", "\(key)", "\(error)")
+                }
             }
             for key in keys.reversed() {
-                try postKeyLocked(key, keyDown: false, tap: tap)
+                do {
+                    try postKeyLocked(key, keyDown: false, tap: tap)
+                } catch {
+                    os_log(.error, "KeySimulator: keyUp failed for %{public}@: %{public}@", "\(key)", "\(error)")
+                }
             }
         }
     }


### PR DESCRIPTION
Fixes #1078

## Problem

When a keyboard shortcut action (e.g. `cmd+[`) is triggered via a mouse button and the active input method is non-Latin (e.g. Ukrainian), `postKeyLocked` throws `unsupportedKey` for the character key (`[`). Because `press()` uses `try` without error handling, the exception exits the keyDown loop early — `CMD` keydown has already fired but the keyUp loop never runs. `CMD` stays stuck in `CGEventFlags` until LinearMouse is relaunched.

## Fix

Wrap both the keyDown and keyUp loops in `press()` with individual `do/catch` blocks so the keyUp loop always executes regardless of any keyDown failures. Keys that failed to press down will silently no-op on keyUp (harmless).

Also adds `import os` for `os_log` error logging.

## Repro

1. Set a mouse button to keyboard shortcut `cmd+[`
2. Switch input method to a non-Latin language (e.g. Ukrainian)
3. Click the mouse button → CMD gets permanently stuck until app relaunch