### PR TITLE
Fix Brave tab middle-click with Auto Scroll

### DIFF
--- a/LinearMouse/Accessibility/AccessibilityBypassRule.swift
+++ b/LinearMouse/Accessibility/AccessibilityBypassRule.swift
@@ -34,6 +34,19 @@ extension AccessibilityBypassRule {
                 .parentRole("AXWindow"),
                 .frameMatchesParent
             ]
+        ),
+        AccessibilityBypassRule(
+            name: "braveTabStripGroupHitTestHole",
+            bundleIdentifiers: ["com.brave.Browser"],
+            conditions: [
+                .depth(0),
+                .role("AXGroup"),
+                .subrole(nil),
+                .actionsEmpty,
+                .noScrollabilitySignal,
+                .noChildContainingPoint,
+                .domClassListContains("TabStrip::TabDragContextImpl")
+            ]
         )
     ]
 }
@@ -47,6 +60,7 @@ enum AccessibilityBypassCondition {
     case noChildContainingPoint
     case parentRole(String)
     case frameMatchesParent
+    case domClassListContains(String)
 }
 
 struct AccessibilityBypassRuleContext {
@@ -65,6 +79,7 @@ struct AccessibilityBypassElementSnapshot {
     let children: [AccessibilityBypassChildSnapshot]
     let hasVerticalScrollBar: Bool
     let hasHorizontalScrollBar: Bool
+    let domClassList: [String]
 
     init(
         depth: Int,
@@ -76,7 +91,8 @@ struct AccessibilityBypassElementSnapshot {
         parentFrame: CGRect? = nil,
         children: [AccessibilityBypassChildSnapshot] = [],
         hasVerticalScrollBar: Bool = false,
-        hasHorizontalScrollBar: Bool = false
+        hasHorizontalScrollBar: Bool = false,
+        domClassList: [String] = []
     ) {
         self.depth = depth
         self.role = role
@@ -88,6 +104,7 @@ struct AccessibilityBypassElementSnapshot {
         self.children = children
         self.hasVerticalScrollBar = hasVerticalScrollBar
         self.hasHorizontalScrollBar = hasHorizontalScrollBar
+        self.domClassList = domClassList
     }
 }
 
@@ -160,6 +177,8 @@ struct AccessibilityBypassRuleMatcher {
             }
 
             return framesApproximatelyMatch(frame, parentFrame)
+        case let .domClassListContains(expectedClass):
+            return element.domClassList.contains(expectedClass)
         }
     }
 

--- a/LinearMouse/Accessibility/AutoScrollAccessibilityActivationClassifier.swift
+++ b/LinearMouse/Accessibility/AutoScrollAccessibilityActivationClassifier.swift
@@ -5,6 +5,7 @@ import ApplicationServices
 import CoreGraphics
 
 struct AutoScrollAccessibilityActivationClassifier {
+    private static let domClassListAttribute = "AXDOMClassList" as CFString
     private static let maxParentDepth = 20
     private static let probeRadius: CGFloat = 4
     private static let excludedRoles: Set<String> = [
@@ -252,8 +253,20 @@ struct AutoScrollAccessibilityActivationClassifier {
             parentFrame: parent.flatMap { frame(of: $0) },
             children: immediateChildren(of: element).map(childSnapshot),
             hasVerticalScrollBar: hasAttributeValue(kAXVerticalScrollBarAttribute as CFString, on: element),
-            hasHorizontalScrollBar: hasAttributeValue(kAXHorizontalScrollBarAttribute as CFString, on: element)
+            hasHorizontalScrollBar: hasAttributeValue(kAXHorizontalScrollBarAttribute as CFString, on: element),
+            domClassList: domClassList(of: element)
         )
+    }
+
+    private func domClassList(of element: AXUIElement) -> [String] {
+        guard case let .success(value) = elementQuery.optionalAttributeValue(
+            of: Self.domClassListAttribute,
+            on: element
+        ) else {
+            return []
+        }
+
+        return value as? [String] ?? []
     }
 
     private func hasAttributeValue(_ attribute: CFString, on element: AXUIElement) -> Bool {

--- a/LinearMouseUnitTests/Accessibility/AccessibilityBypassRuleTests.swift
+++ b/LinearMouseUnitTests/Accessibility/AccessibilityBypassRuleTests.swift
@@ -66,6 +66,33 @@ final class AccessibilityBypassRuleTests: XCTestCase {
         XCTAssertNil(rule)
     }
 
+    func testBraveTabStripRuleMatchesDomClassListHitTestHole() {
+        let rule = matcher.firstMatchingRule(
+            for: braveTabStripGroupSnapshot(),
+            in: braveContext()
+        )
+
+        XCTAssertEqual(rule?.name, "braveTabStripGroupHitTestHole")
+    }
+
+    func testBraveTabStripRuleRequiresBraveBundle() {
+        let rule = matcher.firstMatchingRule(
+            for: braveTabStripGroupSnapshot(),
+            in: chromeContext()
+        )
+
+        XCTAssertNil(rule)
+    }
+
+    func testBraveTabStripRuleRequiresTabStripDomClass() {
+        let rule = matcher.firstMatchingRule(
+            for: braveTabStripGroupSnapshot(domClassList: []),
+            in: braveContext()
+        )
+
+        XCTAssertNil(rule)
+    }
+
     private var testPoint: CGPoint {
         CGPoint(x: 1067, y: 59)
     }
@@ -77,6 +104,13 @@ final class AccessibilityBypassRuleTests: XCTestCase {
     private func chromeContext() -> AccessibilityBypassRuleContext {
         AccessibilityBypassRuleContext(
             bundleIdentifier: "com.google.Chrome",
+            point: testPoint
+        )
+    }
+
+    private func braveContext() -> AccessibilityBypassRuleContext {
+        AccessibilityBypassRuleContext(
+            bundleIdentifier: "com.brave.Browser",
             point: testPoint
         )
     }
@@ -101,6 +135,22 @@ final class AccessibilityBypassRuleTests: XCTestCase {
             parentFrame: parentFrame ?? fullWindowFrame,
             children: children,
             hasVerticalScrollBar: hasVerticalScrollBar
+        )
+    }
+
+    private func braveTabStripGroupSnapshot(
+        domClassList: [String] = ["TabStrip::TabDragContextImpl"]
+    ) -> AccessibilityBypassElementSnapshot {
+        AccessibilityBypassElementSnapshot(
+            depth: 0,
+            role: "AXGroup",
+            subrole: nil,
+            actions: [],
+            frame: CGRect(x: 166, y: 52, width: 494, height: 41),
+            parentRole: "AXGroup",
+            parentFrame: CGRect(x: 166, y: 52, width: 494, height: 41),
+            children: [],
+            domClassList: domClassList
         )
     }
 }


### PR DESCRIPTION
## Summary
- add a Brave-specific Auto Scroll bypass rule for Chromium tab-strip AX hit-test holes
- read `AXDOMClassList` into accessibility bypass snapshots
- cover the Brave tab-strip rule and its bundle/class guards with unit tests

## Related issues
- Closes #1262

## Testing
- `xcodebuild test -project LinearMouse.xcodeproj -scheme LinearMouse -destination 'platform=macOS' -only-testing:LinearMouseUnitTests/AccessibilityBypassRuleTests`
- `xcodebuild test -project LinearMouse.xcodeproj -scheme LinearMouse -destination 'platform=macOS' -only-testing:LinearMouseUnitTests/AutoScrollAccessibilityActivationClassifierTests`
