### PR TITLE
Add pointer location reveal shortcut

### DIFF
--- a/LinearMouse/DefaultsKeys.swift
+++ b/LinearMouse/DefaultsKeys.swift
@@ -1,7 +1,9 @@
 // MIT License
 // Copyright (c) 2021-2026 LinearMouse
 
+import CoreGraphics
 import Defaults
+import Foundation
 
 enum MenuBarBatteryDisplayMode: String, Codable, Defaults.Serializable {
     case off
@@ -29,11 +31,54 @@ enum MenuBarBatteryDisplayMode: String, Codable, Defaults.Serializable {
     }
 }
 
+enum PointerLocationTriggerModifier: String, CaseIterable, Codable, Defaults.Serializable, Identifiable {
+    case control
+    case option
+    case shift
+    case command
+
+    var id: Self {
+        self
+    }
+
+    var flag: CGEventFlags {
+        switch self {
+        case .control:
+            .maskControl
+        case .option:
+            .maskAlternate
+        case .shift:
+            .maskShift
+        case .command:
+            .maskCommand
+        }
+    }
+
+    var label: String {
+        switch self {
+        case .control:
+            NSLocalizedString("⌃ (Control)", comment: "")
+        case .option:
+            NSLocalizedString("⌥ (Option)", comment: "")
+        case .shift:
+            NSLocalizedString("⇧ (Shift)", comment: "")
+        case .command:
+            NSLocalizedString("⌘ (Command)", comment: "")
+        }
+    }
+}
+
 extension Defaults.Keys {
     static let showInMenuBar = Key<Bool>("showInMenuBar", default: true)
     static let menuBarBatteryDisplayMode = Key<MenuBarBatteryDisplayMode>("menuBarBatteryDisplayMode", default: .off)
 
     static let showInDock = Key<Bool>("showInDock", default: true)
+
+    static let showPointerLocation = Key<Bool>("showPointerLocation", default: false)
+    static let pointerLocationTriggerModifier = Key<PointerLocationTriggerModifier>(
+        "pointerLocationTriggerModifier",
+        default: .control
+    )
 
     static let betaChannelOn = Key("betaChannelOn", default: false)
 

--- a/LinearMouse/EventTap/GlobalEventTap.swift
+++ b/LinearMouse/EventTap/GlobalEventTap.swift
@@ -19,6 +19,7 @@ class GlobalEventTap {
     init() {}
 
     private func callback(_ event: CGEvent) -> CGEvent? {
+        PointerLocationTriggerController.shared.handle(event)
         ModifierState.shared.update(with: event)
 
         let mouseEventView = MouseEventView(event)

--- a/LinearMouse/Localizable.xcstrings
+++ b/LinearMouse/Localizable.xcstrings
@@ -40455,6 +40455,214 @@
         }
       }
     },
+    "Press %@ twice to reveal the pointer." : {
+      "localizations" : {
+        "af" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Druk twee keer op %@ om die wyser te wys."
+          }
+        },
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "اضغط على %@ مرتين لإظهار المؤشر."
+          }
+        },
+        "bs" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pritisnite %@ dvaput da prikažete pokazivač."
+          }
+        },
+        "ca" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Prem %@ dues vegades per mostrar el punter."
+          }
+        },
+        "cs" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dvojím stisknutím %@ zobrazíte ukazatel."
+          }
+        },
+        "da" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tryk på %@ to gange for at vise markøren."
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Drücken Sie die Taste %@ zweimal, um den Zeiger anzuzeigen."
+          }
+        },
+        "el" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Πατήστε δύο φορές το %@ για να εμφανιστεί ο δείκτης."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pulsa %@ dos veces para mostrar el puntero."
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Näytä osoitin painamalla %@ kahdesti."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Appuyez deux fois sur %@ pour afficher le pointeur."
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "לחץ על %@ פעמיים כדי להציג את המצביע."
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nyomja meg kétszer a(z) %@ billentyűt a mutató megjelenítéséhez."
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tekan %@ dua kali untuk menampilkan penunjuk."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Premi %@ due volte per mostrare il puntatore."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ を2回押すとポインタを表示します。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@을(를) 두 번 눌러 포인터를 표시합니다."
+          }
+        },
+        "my" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ညွှန်တံကို ပြရန် %@ ကို နှစ်ကြိမ်နှိပ်ပါ။"
+          }
+        },
+        "nb-NO" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Trykk på %@ to ganger for å vise pekeren."
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Druk twee keer op %@ om de aanwijzer weer te geven."
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Naciśnij %@ dwa razy, aby pokazać wskaźnik."
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Prima %@ duas vezes para mostrar o ponteiro."
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pressione %@ duas vezes para mostrar o ponteiro."
+          }
+        },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Apasă %@ de două ori pentru a afișa indicatorul."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Нажмите %@ дважды, чтобы показать указатель."
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dvojitým stlačením %@ zobrazíte ukazovateľ."
+          }
+        },
+        "sr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Притисните %@ двапут да бисте приказали показивач."
+          }
+        },
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tryck på %@ två gånger för att visa pekaren."
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "İşaretçiyi göstermek için %@ tuşuna iki kez basın."
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Натисніть %@ двічі, щоб показати вказівник."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nhấn %@ hai lần để hiển thị con trỏ."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "按两次 %@ 以显示指针。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "按兩次 %@ 以顯示指標。"
+          }
+        },
+        "zh-Hant-HK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "按兩次 %@ 以顯示指標。"
+          }
+        }
+      }
+    },
     "Press and hold a button while dragging to trigger gestures like switching desktop spaces or opening Mission Control." : {
       "localizations" : {
         "af" : {
@@ -53166,6 +53374,214 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "在選單列中顯示"
+          }
+        }
+      }
+    },
+    "Show pointer location" : {
+      "localizations" : {
+        "af" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Wys wyserligging"
+          }
+        },
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "إظهار موقع المؤشر"
+          }
+        },
+        "bs" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Prikaži lokaciju pokazivača"
+          }
+        },
+        "ca" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mostra la ubicació del punter"
+          }
+        },
+        "cs" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Zobrazit polohu ukazatele"
+          }
+        },
+        "da" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Vis markørens placering"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Zeigerposition anzeigen"
+          }
+        },
+        "el" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Εμφάνιση θέσης δείκτη"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mostrar ubicación del puntero"
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Näytä osoittimen sijainti"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Afficher l’emplacement du pointeur"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "הצג את מיקום המצביע"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mutató helyének megjelenítése"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tampilkan lokasi penunjuk"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mostra posizione del puntatore"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ポインタの位置を表示"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "포인터 위치 표시"
+          }
+        },
+        "my" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ညွှန်တံ တည်နေရာကို ပြပါ"
+          }
+        },
+        "nb-NO" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Vis pekerens plassering"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Toon locatie van aanwijzer"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pokaż położenie wskaźnika"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mostrar localização do ponteiro"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mostrar localização do ponteiro"
+          }
+        },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Afișează poziția indicatorului"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Показать положение указателя"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Zobraziť polohu ukazovateľa"
+          }
+        },
+        "sr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Прикажи локацију показивача"
+          }
+        },
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Visa pekarens plats"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "İşaretçinin konumunu göster"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Показати розташування вказівника"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hiển thị vị trí con trỏ"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "显示指针位置"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "顯示指標位置"
+          }
+        },
+        "zh-Hant-HK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "顯示指標位置"
           }
         }
       }

--- a/LinearMouse/PointerLocation/PointerLocationIndicatorWindowController.swift
+++ b/LinearMouse/PointerLocation/PointerLocationIndicatorWindowController.swift
@@ -1,0 +1,148 @@
+// MIT License
+// Copyright (c) 2021-2026 LinearMouse
+
+import AppKit
+import QuartzCore
+
+private let pointerLocationIndicatorSize = CGSize(width: 180, height: 180)
+private let pointerLocationIndicatorDuration: TimeInterval = 0.8
+
+final class PointerLocationIndicatorWindowController {
+    private var animationTimer: Timer?
+    private var animationStartTime: CFTimeInterval?
+
+    private lazy var indicatorView = PointerLocationIndicatorView(
+        frame: CGRect(origin: .zero, size: pointerLocationIndicatorSize)
+    )
+
+    private lazy var window: NSPanel = {
+        let panel = NSPanel(
+            contentRect: CGRect(origin: .zero, size: pointerLocationIndicatorSize),
+            styleMask: [.borderless, .nonactivatingPanel],
+            backing: .buffered,
+            defer: false
+        )
+        panel.isOpaque = false
+        panel.backgroundColor = .clear
+        panel.hasShadow = false
+        panel.level = .statusBar
+        panel.ignoresMouseEvents = true
+        panel.collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary, .stationary]
+        panel.contentView = indicatorView
+        return panel
+    }()
+
+    deinit {
+        animationTimer?.invalidate()
+    }
+
+    func show(at point: CGPoint) {
+        let origin = CGPoint(
+            x: point.x - pointerLocationIndicatorSize.width / 2,
+            y: point.y - pointerLocationIndicatorSize.height / 2
+        )
+        window.setFrame(CGRect(origin: origin, size: pointerLocationIndicatorSize), display: true)
+        window.orderFrontRegardless()
+        startAnimation()
+    }
+
+    private func startAnimation() {
+        animationTimer?.invalidate()
+        animationStartTime = CACurrentMediaTime()
+        indicatorView.progress = 0
+
+        let framesPerSecond: Int
+        if #available(macOS 12.0, *) {
+            framesPerSecond = min(NSScreen.main?.maximumFramesPerSecond ?? 60, 120)
+        } else {
+            framesPerSecond = 60
+        }
+        let timer = Timer(timeInterval: 1.0 / TimeInterval(framesPerSecond), repeats: true) { [weak self] timer in
+            self?.updateAnimation(timer)
+        }
+        animationTimer = timer
+        RunLoop.main.add(timer, forMode: .common)
+    }
+
+    private func updateAnimation(_ timer: Timer) {
+        guard let animationStartTime else {
+            timer.invalidate()
+            return
+        }
+
+        let elapsed = CACurrentMediaTime() - animationStartTime
+        let progress = min(1, elapsed / pointerLocationIndicatorDuration)
+        indicatorView.progress = progress
+
+        if progress >= 1 {
+            timer.invalidate()
+            animationTimer = nil
+            window.orderOut(nil)
+        }
+    }
+}
+
+private final class PointerLocationIndicatorView: NSView {
+    var progress: TimeInterval = 0 {
+        didSet {
+            needsDisplay = true
+        }
+    }
+
+    override var isOpaque: Bool {
+        false
+    }
+
+    override func draw(_ dirtyRect: NSRect) {
+        super.draw(dirtyRect)
+
+        guard let context = NSGraphicsContext.current?.cgContext else {
+            return
+        }
+
+        let bounds = bounds
+        let center = CGPoint(x: bounds.midX, y: bounds.midY)
+        let reducedMotion = NSWorkspace.shared.accessibilityDisplayShouldReduceMotion
+        let pulseProgress = reducedMotion ? 1 : progress
+        let fadeProgress = max(0, (progress - 0.75) / 0.25)
+        let alpha = CGFloat(1 - fadeProgress)
+        let easedPulse = easeOutCubic(CGFloat(pulseProgress))
+        let radius = reducedMotion ? CGFloat(26) : CGFloat(76 - 52 * easedPulse)
+
+        context.setShouldAntialias(true)
+        drawRing(
+            center: center,
+            radius: radius,
+            backingLineWidth: 5,
+            lineWidth: 2,
+            alpha: alpha
+        )
+    }
+
+    private func drawRing(
+        center: CGPoint,
+        radius: CGFloat,
+        backingLineWidth: CGFloat,
+        lineWidth: CGFloat,
+        alpha: CGFloat
+    ) {
+        let rect = CGRect(
+            x: center.x - radius,
+            y: center.y - radius,
+            width: radius * 2,
+            height: radius * 2
+        )
+        let path = NSBezierPath(ovalIn: rect)
+        NSColor.white.withAlphaComponent(0.75 * alpha).setStroke()
+        path.lineWidth = backingLineWidth
+        path.stroke()
+
+        NSColor.black.withAlphaComponent(0.9 * alpha).setStroke()
+        path.lineWidth = lineWidth
+        path.stroke()
+    }
+
+    private func easeOutCubic(_ value: CGFloat) -> CGFloat {
+        1 - pow(1 - value, 3)
+    }
+}

--- a/LinearMouse/PointerLocation/PointerLocationTriggerController.swift
+++ b/LinearMouse/PointerLocation/PointerLocationTriggerController.swift
@@ -1,0 +1,150 @@
+// MIT License
+// Copyright (c) 2021-2026 LinearMouse
+
+import AppKit
+import Darwin
+import Defaults
+import Foundation
+
+final class PointerLocationTriggerController {
+    static let shared = PointerLocationTriggerController()
+
+    private var trigger = PointerLocationDoubleModifierTrigger()
+    private let indicatorController = PointerLocationIndicatorWindowController()
+
+    private init() {}
+
+    func handle(_ event: CGEvent) {
+        guard Defaults[.showPointerLocation],
+              !event.isLinearMouseSyntheticEvent else {
+            trigger.reset()
+            return
+        }
+
+        guard trigger.handle(event, triggerModifier: Defaults[.pointerLocationTriggerModifier]) else {
+            return
+        }
+
+        DispatchQueue.main.async { [indicatorController] in
+            indicatorController.show(at: NSEvent.mouseLocation)
+        }
+    }
+}
+
+struct PointerLocationDoubleModifierTrigger {
+    private static let maximumTapDuration: TimeInterval = 0.35
+    private static let maximumDoubleTapInterval: TimeInterval = 1
+
+    private var previousFlags: CGEventFlags
+    private var pendingTapStart: TimeInterval?
+    private var firstTapTime: TimeInterval?
+
+    init(initialFlags: CGEventFlags = []) {
+        previousFlags = ModifierState.generic(from: initialFlags)
+    }
+
+    mutating func handle(_ event: CGEvent, triggerModifier: PointerLocationTriggerModifier) -> Bool {
+        handle(
+            eventType: event.type,
+            flags: event.flags,
+            timestamp: CGEventTimestampConverter.seconds(from: event.timestamp),
+            triggerModifier: triggerModifier
+        )
+    }
+
+    mutating func handle(
+        eventType: CGEventType,
+        flags: CGEventFlags,
+        timestamp: TimeInterval,
+        triggerModifier: PointerLocationTriggerModifier
+    ) -> Bool {
+        switch eventType {
+        case .flagsChanged:
+            return handleFlagsChanged(
+                flags: flags,
+                timestamp: timestamp,
+                triggerModifier: triggerModifier
+            )
+        case .keyDown, .leftMouseDown, .rightMouseDown, .otherMouseDown, .scrollWheel:
+            reset()
+            previousFlags = ModifierState.generic(from: flags)
+            return false
+        default:
+            previousFlags = ModifierState.generic(from: flags)
+            return false
+        }
+    }
+
+    mutating func reset() {
+        pendingTapStart = nil
+        firstTapTime = nil
+    }
+
+    private mutating func handleFlagsChanged(
+        flags: CGEventFlags,
+        timestamp: TimeInterval,
+        triggerModifier: PointerLocationTriggerModifier
+    ) -> Bool {
+        let currentFlags = ModifierState.generic(from: flags)
+        defer {
+            previousFlags = currentFlags
+        }
+
+        let triggerFlag = triggerModifier.flag
+        let pressed = !previousFlags.contains(triggerFlag) && currentFlags == triggerFlag
+        let released = previousFlags == triggerFlag && currentFlags.isEmpty
+
+        if let firstTapTime,
+           timestamp - firstTapTime > Self.maximumDoubleTapInterval {
+            reset()
+        }
+
+        if pressed {
+            pendingTapStart = timestamp
+            return false
+        }
+
+        if released, let pendingTapStart {
+            self.pendingTapStart = nil
+            guard timestamp - pendingTapStart <= Self.maximumTapDuration else {
+                reset()
+                return false
+            }
+            return registerTap(at: timestamp)
+        }
+
+        if currentFlags != triggerFlag {
+            reset()
+        }
+
+        return false
+    }
+
+    private mutating func registerTap(at timestamp: TimeInterval) -> Bool {
+        guard let firstTapTime else {
+            firstTapTime = timestamp
+            return false
+        }
+
+        if timestamp - firstTapTime <= Self.maximumDoubleTapInterval {
+            self.firstTapTime = nil
+            return true
+        }
+
+        self.firstTapTime = timestamp
+        return false
+    }
+}
+
+private enum CGEventTimestampConverter {
+    private static let timebase: mach_timebase_info_data_t = {
+        var timebase = mach_timebase_info_data_t()
+        mach_timebase_info(&timebase)
+        return timebase
+    }()
+
+    static func seconds(from timestamp: CGEventTimestamp) -> TimeInterval {
+        let nanoseconds = Double(timestamp) * Double(timebase.numer) / Double(timebase.denom)
+        return nanoseconds / 1_000_000_000
+    }
+}

--- a/LinearMouse/UI/GeneralSettings/GeneralSettings.swift
+++ b/LinearMouse/UI/GeneralSettings/GeneralSettings.swift
@@ -9,6 +9,8 @@ struct GeneralSettings: View {
     @Default(.showInMenuBar) var showInMenuBar
     @Default(.menuBarBatteryDisplayMode) var menuBarBatteryDisplayMode
     @Default(.showInDock) var showInDock
+    @Default(.showPointerLocation) var showPointerLocation
+    @Default(.pointerLocationTriggerModifier) var pointerLocationTriggerModifier
     @Default(.bypassEventsFromOtherApplications) var bypassEventsFromOtherApplications
 
     var body: some View {
@@ -46,6 +48,26 @@ struct GeneralSettings: View {
                 Section {
                     LaunchAtLogin.Toggle {
                         Text("Start at login")
+                    }
+                }
+                .modifier(SectionViewModifier())
+
+                Section {
+                    Toggle(isOn: $showPointerLocation.animation()) {
+                        withDescription {
+                            Text("Show pointer location")
+                            Text("Press \(pointerLocationTriggerModifier.label) twice to reveal the pointer.")
+                        }
+                    }
+
+                    if showPointerLocation {
+                        Picker("Trigger", selection: $pointerLocationTriggerModifier.animation()) {
+                            ForEach(PointerLocationTriggerModifier.allCases) { modifier in
+                                Text(modifier.label).tag(modifier)
+                            }
+                        }
+                        .padding(.leading, 20)
+                        .modifier(PickerViewModifier())
                     }
                 }
                 .modifier(SectionViewModifier())

--- a/LinearMouseUnitTests/PointerLocation/PointerLocationDoubleModifierTriggerTests.swift
+++ b/LinearMouseUnitTests/PointerLocation/PointerLocationDoubleModifierTriggerTests.swift
@@ -1,0 +1,103 @@
+// MIT License
+// Copyright (c) 2021-2026 LinearMouse
+
+@testable import LinearMouse
+import XCTest
+
+final class PointerLocationDoubleModifierTriggerTests: XCTestCase {
+    func testDoubleControlTapTriggersPointerLocation() {
+        var trigger = PointerLocationDoubleModifierTrigger()
+
+        XCTAssertFalse(flagsChanged(&trigger, flags: [.maskControl], at: 1.00))
+        XCTAssertFalse(flagsChanged(&trigger, flags: [], at: 1.08))
+        XCTAssertFalse(flagsChanged(&trigger, flags: [.maskControl], at: 1.32))
+        XCTAssertTrue(flagsChanged(&trigger, flags: [], at: 1.40))
+    }
+
+    func testSingleControlTapDoesNotTriggerPointerLocation() {
+        var trigger = PointerLocationDoubleModifierTrigger()
+
+        XCTAssertFalse(flagsChanged(&trigger, flags: [.maskControl], at: 1.00))
+        XCTAssertFalse(flagsChanged(&trigger, flags: [], at: 1.08))
+    }
+
+    func testDelayedSecondTapDoesNotTriggerPointerLocation() {
+        var trigger = PointerLocationDoubleModifierTrigger()
+
+        XCTAssertFalse(flagsChanged(&trigger, flags: [.maskControl], at: 1.00))
+        XCTAssertFalse(flagsChanged(&trigger, flags: [], at: 1.08))
+        XCTAssertFalse(flagsChanged(&trigger, flags: [.maskControl], at: 4.00))
+        XCTAssertFalse(flagsChanged(&trigger, flags: [], at: 4.08))
+    }
+
+    func testLongSecondPressDoesNotTriggerPointerLocation() {
+        var trigger = PointerLocationDoubleModifierTrigger()
+
+        XCTAssertFalse(flagsChanged(&trigger, flags: [.maskControl], at: 1.00))
+        XCTAssertFalse(flagsChanged(&trigger, flags: [], at: 1.08))
+        XCTAssertFalse(flagsChanged(&trigger, flags: [.maskControl], at: 1.30))
+        XCTAssertFalse(flagsChanged(&trigger, flags: [], at: 1.80))
+    }
+
+    func testControlShortcutCancelsPendingTap() {
+        var trigger = PointerLocationDoubleModifierTrigger()
+
+        XCTAssertFalse(flagsChanged(&trigger, flags: [.maskControl], at: 1.00))
+        XCTAssertFalse(trigger.handle(
+            eventType: .keyDown,
+            flags: [.maskControl],
+            timestamp: 1.10,
+            triggerModifier: .control
+        ))
+        XCTAssertFalse(flagsChanged(&trigger, flags: [], at: 1.18))
+        XCTAssertFalse(flagsChanged(&trigger, flags: [.maskControl], at: 1.30))
+        XCTAssertFalse(flagsChanged(&trigger, flags: [], at: 1.38))
+    }
+
+    func testOtherKeyBetweenTapsCancelsPendingSequence() {
+        var trigger = PointerLocationDoubleModifierTrigger()
+
+        XCTAssertFalse(flagsChanged(&trigger, flags: [.maskControl], at: 1.00))
+        XCTAssertFalse(flagsChanged(&trigger, flags: [], at: 1.08))
+        XCTAssertFalse(trigger.handle(
+            eventType: .keyDown,
+            flags: [],
+            timestamp: 1.20,
+            triggerModifier: .control
+        ))
+        XCTAssertFalse(flagsChanged(&trigger, flags: [.maskControl], at: 1.30))
+        XCTAssertFalse(flagsChanged(&trigger, flags: [], at: 1.38))
+    }
+
+    func testDifferentModifierDoesNotTriggerControlConfiguration() {
+        var trigger = PointerLocationDoubleModifierTrigger()
+
+        XCTAssertFalse(flagsChanged(&trigger, flags: [.maskAlternate], at: 1.00))
+        XCTAssertFalse(flagsChanged(&trigger, flags: [], at: 1.08))
+        XCTAssertFalse(flagsChanged(&trigger, flags: [.maskAlternate], at: 1.30))
+        XCTAssertFalse(flagsChanged(&trigger, flags: [], at: 1.38))
+    }
+
+    func testOptionConfigurationTriggersOnDoubleOptionTap() {
+        var trigger = PointerLocationDoubleModifierTrigger()
+
+        XCTAssertFalse(flagsChanged(&trigger, flags: [.maskAlternate], at: 1.00, triggerModifier: .option))
+        XCTAssertFalse(flagsChanged(&trigger, flags: [], at: 1.08, triggerModifier: .option))
+        XCTAssertFalse(flagsChanged(&trigger, flags: [.maskAlternate], at: 1.30, triggerModifier: .option))
+        XCTAssertTrue(flagsChanged(&trigger, flags: [], at: 1.38, triggerModifier: .option))
+    }
+
+    private func flagsChanged(
+        _ trigger: inout PointerLocationDoubleModifierTrigger,
+        flags: CGEventFlags,
+        at timestamp: TimeInterval,
+        triggerModifier: PointerLocationTriggerModifier = .control
+    ) -> Bool {
+        trigger.handle(
+            eventType: .flagsChanged,
+            flags: flags,
+            timestamp: timestamp,
+            triggerModifier: triggerModifier
+        )
+    }
+}


### PR DESCRIPTION
## Summary
- Add a General setting to reveal the pointer location by double-tapping a configurable modifier key.
- Show a lightweight Windows-style shrinking ring overlay at the pointer location.
- Add focused tests for valid double-taps, delayed taps, long presses, and intervening input cancellation.
- Extract and translate the new UI strings in `Localizable.xcstrings`.

## Testing
- `xcodebuild test -project LinearMouse.xcodeproj -scheme LinearMouse -destination 'platform=macOS' -only-testing:LinearMouseUnitTests/PointerLocationDoubleModifierTriggerTests`
- `xcodebuild build -project LinearMouse.xcodeproj -scheme LinearMouse -configuration Debug -destination 'platform=macOS'`

Closes #1257
