### PR TITLE
Keep pointer movement during repeated clicks

### DIFF
--- a/LinearMouse/EventTransformer/ButtonActionsTransformer.swift
+++ b/LinearMouse/EventTransformer/ButtonActionsTransformer.swift
@@ -150,7 +150,7 @@ extension ButtonActionsTransformer: EventTransformer, LogitechControlEventHandli
             queueActions(event: event.copy(), action: action)
         } else {
             if handleKeyPressHold(event: event, mapping: mapping, action: action) {
-                return nil
+                return mouseMovedEventIfDragging(event)
             }
 
             // FIXME: `NSEvent.keyRepeatDelay` and `NSEvent.keyRepeatInterval` are not kept up to date
@@ -163,6 +163,10 @@ extension ButtonActionsTransformer: EventTransformer, LogitechControlEventHandli
                 if handleButtonSwaps(event: event, action: action) {
                     return event
                 }
+            }
+
+            if mapping.repeat == true, let mouseMovedEvent = mouseMovedEventIfDragging(event) {
+                return mouseMovedEvent
             }
 
             // Actions are executed when button is down if key repeat is enabled; otherwise, actions are
@@ -720,6 +724,15 @@ extension ButtonActionsTransformer: EventTransformer, LogitechControlEventHandli
         if runtimeState.heldKeysByButton.isEmpty {
             keySimulator.reset()
         }
+    }
+
+    private func mouseMovedEventIfDragging(_ event: CGEvent) -> CGEvent? {
+        guard mouseDraggedEventTypes.contains(event.type) else {
+            return nil
+        }
+
+        event.type = .mouseMoved
+        return event
     }
 
     private func postClickEvent(mouseButton: CGMouseButton, clickState: Int64? = nil) {

--- a/LinearMouseUnitTests/EventTransformer/ButtonActionsTransformerTests.swift
+++ b/LinearMouseUnitTests/EventTransformer/ButtonActionsTransformerTests.swift
@@ -54,6 +54,18 @@ private func logitechContext(
     )
 }
 
+private func mouseDraggedEvent(button: CGMouseButton, deltaX: Double, deltaY: Double = 0) throws -> CGEvent {
+    let event = try XCTUnwrap(CGEvent(
+        mouseEventSource: nil,
+        mouseType: button.fixedCGEventType(of: .otherMouseDragged),
+        mouseCursorPosition: .zero,
+        mouseButton: button
+    ))
+    event.setDoubleValueField(.mouseEventDeltaX, value: deltaX)
+    event.setDoubleValueField(.mouseEventDeltaY, value: deltaY)
+    return event
+}
+
 final class ButtonActionsTransformerTests: XCTestCase {
     func testSharedRuntimeStateLetsScrollMappingsCancelButtonRepeatTimer() throws {
         let runtimeState = ButtonActionsTransformer.RuntimeState()
@@ -86,6 +98,52 @@ final class ButtonActionsTransformerTests: XCTestCase {
         XCTAssertNotNil(buttonTransformer.repeatTimer)
         XCTAssertNil(scrollTransformer.transform(event, in: EventTransformerContext(device: nil)))
         XCTAssertNil(buttonTransformer.repeatTimer)
+    }
+
+    func testRepeatMouseClickMappingPassesDraggedMovementAsMouseMoved() throws {
+        let transformer = ButtonActionsTransformer(
+            mappings: [
+                .init(button: .mouse(4), repeat: true, action: .arg0(.mouseButtonLeftDouble))
+            ]
+        )
+        let button = try XCTUnwrap(CGMouseButton(rawValue: 4))
+        let event = try mouseDraggedEvent(button: button, deltaX: 7, deltaY: -3)
+
+        let transformed = try XCTUnwrap(transformer.transform(event, in: EventTransformerContext(device: nil)))
+
+        XCTAssertEqual(transformed.type, .mouseMoved)
+        XCTAssertEqual(transformed.getDoubleValueField(.mouseEventDeltaX), 7)
+        XCTAssertEqual(transformed.getDoubleValueField(.mouseEventDeltaY), -3)
+    }
+
+    func testRepeatMouseClickMappingDoesNotCancelRepeatTimerOnDraggedMovement() throws {
+        let transformer = ButtonActionsTransformer(
+            mappings: [
+                .init(button: .mouse(4), repeat: true, action: .arg0(.mouseButtonLeftDouble))
+            ]
+        )
+        transformer.repeatTimer = EventThreadTimer(
+            timer: Timer(timeInterval: 60, repeats: false) { _ in },
+            eventThread: .shared
+        )
+        let button = try XCTUnwrap(CGMouseButton(rawValue: 4))
+        let event = try mouseDraggedEvent(button: button, deltaX: 1)
+
+        XCTAssertNotNil(transformer.repeatTimer)
+        XCTAssertNotNil(transformer.transform(event, in: EventTransformerContext(device: nil)))
+        XCTAssertNotNil(transformer.repeatTimer)
+    }
+
+    func testNonRepeatMouseClickMappingKeepsConsumingDraggedMovement() throws {
+        let transformer = ButtonActionsTransformer(
+            mappings: [
+                .init(button: .mouse(4), action: .arg0(.mouseButtonLeftDouble))
+            ]
+        )
+        let button = try XCTUnwrap(CGMouseButton(rawValue: 4))
+        let event = try mouseDraggedEvent(button: button, deltaX: 7, deltaY: -3)
+
+        XCTAssertNil(transformer.transform(event, in: EventTransformerContext(device: nil)))
     }
 
     func testLogitechControlEventMatchesGenericCommandMappingWithRightCommandFlag() {


### PR DESCRIPTION
## Summary
- Keep pointer movement flowing while repeated button-click mappings are held.
- Convert repeated button drag events into mouse movement events instead of consuming them.
- Cover repeat and non-repeat behavior with tests.

Closes #1238
