### PR TITLE
Fix Chromium tab-strip middle-click with Auto Scroll

### DIFF
--- a/Documentation/Configuration.d.ts
+++ b/Documentation/Configuration.d.ts
@@ -515,12 +515,6 @@ declare namespace Scheme {
       speed?: number;
 
       /**
-       * @description If true, a plain middle click on a pressable element such as a link will keep its native behavior when possible.
-       * @default false
-       */
-      preserveNativeMiddleClick?: boolean;
-
-      /**
        * @title Trigger
        * @description Choose the mouse button and modifier keys used to activate auto scroll.
        */

--- a/Documentation/Configuration.json
+++ b/Documentation/Configuration.json
@@ -169,11 +169,6 @@
           "description": "Use \\\"toggle\\\" to click once and move until clicking again, \\\"hold\\\" to scroll only while the trigger stays pressed, or provide both to support both behaviors.",
           "title": "Activation mode"
         },
-        "preserveNativeMiddleClick": {
-          "default": false,
-          "description": "If true, a plain middle click on a pressable element such as a link will keep its native behavior when possible.",
-          "type": "boolean"
-        },
         "speed": {
           "default": 1,
           "description": "Adjust the auto scroll speed multiplier.",

--- a/LinearMouse/Accessibility/AccessibilityBypassRule.swift
+++ b/LinearMouse/Accessibility/AccessibilityBypassRule.swift
@@ -35,16 +35,10 @@ extension AccessibilityBypassRule {
                 .frameMatchesParent
             ]
         ),
+        // Chromium can expose this drag-only overlay instead of the underlying tab during AX hit testing.
         AccessibilityBypassRule(
-            name: "braveTabStripGroupHitTestHole",
-            bundleIdentifiers: ["com.brave.Browser"],
+            name: "chromiumTabStripDragContextHitTestHole",
             conditions: [
-                .depth(0),
-                .role("AXGroup"),
-                .subrole(nil),
-                .actionsEmpty,
-                .noScrollabilitySignal,
-                .noChildContainingPoint,
                 .domClassListContains("TabStrip::TabDragContextImpl")
             ]
         )

--- a/LinearMouse/Accessibility/AccessibilityBypassRule.swift
+++ b/LinearMouse/Accessibility/AccessibilityBypassRule.swift
@@ -5,25 +5,13 @@ import CoreGraphics
 
 struct AccessibilityBypassRule {
     let name: String
-    let bundleIdentifiers: Set<String>?
     let conditions: [AccessibilityBypassCondition]
-
-    init(
-        name: String,
-        bundleIdentifiers: Set<String>? = nil,
-        conditions: [AccessibilityBypassCondition]
-    ) {
-        self.name = name
-        self.bundleIdentifiers = bundleIdentifiers
-        self.conditions = conditions
-    }
 }
 
 extension AccessibilityBypassRule {
     static let autoScrollRules: [AccessibilityBypassRule] = [
         AccessibilityBypassRule(
-            name: "chromeFullWindowGroupHitTestHole",
-            bundleIdentifiers: ["com.google.Chrome"],
+            name: "chromiumFullWindowGroupHitTestHole",
             conditions: [
                 .depth(0),
                 .role("AXGroup"),
@@ -32,7 +20,8 @@ extension AccessibilityBypassRule {
                 .noScrollabilitySignal,
                 .noChildContainingPoint,
                 .parentRole("AXWindow"),
-                .frameMatchesParent
+                .frameMatchesParent,
+                .domClassListContainsSuffix("BrowserRootView")
             ]
         ),
         // Chromium can expose this drag-only overlay instead of the underlying tab during AX hit testing.
@@ -55,10 +44,10 @@ enum AccessibilityBypassCondition {
     case parentRole(String)
     case frameMatchesParent
     case domClassListContains(String)
+    case domClassListContainsSuffix(String)
 }
 
 struct AccessibilityBypassRuleContext {
-    let bundleIdentifier: String?
     let point: CGPoint
 }
 
@@ -130,14 +119,7 @@ struct AccessibilityBypassRuleMatcher {
         element: AccessibilityBypassElementSnapshot,
         context: AccessibilityBypassRuleContext
     ) -> Bool {
-        if let bundleIdentifiers = rule.bundleIdentifiers {
-            guard let bundleIdentifier = context.bundleIdentifier,
-                  bundleIdentifiers.contains(bundleIdentifier) else {
-                return false
-            }
-        }
-
-        return rule.conditions.allSatisfy { condition in
+        rule.conditions.allSatisfy { condition in
             matches(condition, element: element, context: context)
         }
     }
@@ -173,6 +155,8 @@ struct AccessibilityBypassRuleMatcher {
             return framesApproximatelyMatch(frame, parentFrame)
         case let .domClassListContains(expectedClass):
             return element.domClassList.contains(expectedClass)
+        case let .domClassListContainsSuffix(expectedSuffix):
+            return element.domClassList.contains { $0.hasSuffix(expectedSuffix) }
         }
     }
 

--- a/LinearMouse/Accessibility/AutoScrollAccessibilityActivationClassifier.swift
+++ b/LinearMouse/Accessibility/AutoScrollAccessibilityActivationClassifier.swift
@@ -78,21 +78,16 @@ struct AutoScrollAccessibilityActivationClassifier {
         }
 
         // Browser accessibility trees can return a generic container chain for a point that
-        // is visually still inside a link. Probe a few nearby points and trust any result
-        // that clearly says "do not start autoscroll".
-        var bestProbe = initialProbe
+        // is visually still inside a pressable element. Probe nearby points and preserve the
+        // native event if any sample resolves as pressable.
         for point in accessibilityProbePoints(around: initialProbe.point) {
             let sampledProbe = AutoScrollActivationProbe(point: point, hit: hitAccessibilityElement(at: point))
-            if sampledProbe.hit.suppressesAutoscroll {
+            if sampledProbe.hit.isPressable {
                 return sampledProbe
-            }
-
-            if sampledProbe.hit.priority > bestProbe.hit.priority {
-                bestProbe = sampledProbe
             }
         }
 
-        return bestProbe
+        return initialProbe
     }
 
     private func accessibilityProbePoints(around point: CGPoint) -> [CGPoint] {
@@ -119,11 +114,11 @@ struct AutoScrollAccessibilityActivationClassifier {
         case let .success(value):
             hitElement = value
         case let .failure(error):
-            return .unknown(reason: "hitTest.\(error.linearMouseDescription)", path: [])
+            return .nonPressable(diagnostic: "hitTest.\(error.linearMouseDescription)", path: [])
         }
 
         guard let hitElement else {
-            return .nonPressable(path: [])
+            return .nonPressable(diagnostic: nil, path: [])
         }
 
         var currentElement: AXUIElement? = hitElement
@@ -131,7 +126,7 @@ struct AutoScrollAccessibilityActivationClassifier {
         var isInsideWebContent = false
         for depth in 0 ..< Self.maxParentDepth {
             guard let element = currentElement else {
-                return .nonPressable(path: path)
+                return .nonPressable(diagnostic: nil, path: path)
             }
 
             let role: String?
@@ -139,7 +134,7 @@ struct AutoScrollAccessibilityActivationClassifier {
             case let .success(value):
                 role = value
             case let .failure(error):
-                return .unknown(reason: "role.\(error.linearMouseDescription)", path: path)
+                return .nonPressable(diagnostic: "role.\(error.linearMouseDescription)", path: path)
             }
 
             let subrole: String?
@@ -147,7 +142,7 @@ struct AutoScrollAccessibilityActivationClassifier {
             case let .success(value):
                 subrole = value
             case let .failure(error):
-                return .unknown(reason: "subrole.\(error.linearMouseDescription)", path: path)
+                return .nonPressable(diagnostic: "subrole.\(error.linearMouseDescription)", path: path)
             }
 
             let actions: [String]
@@ -155,7 +150,7 @@ struct AutoScrollAccessibilityActivationClassifier {
             case let .success(value):
                 actions = value
             case let .failure(error):
-                return .unknown(reason: "actions.\(error.linearMouseDescription)", path: path)
+                return .nonPressable(diagnostic: "actions.\(error.linearMouseDescription)", path: path)
             }
 
             path.append(Self.pathEntry(role: role, subrole: subrole, actions: actions))
@@ -168,7 +163,7 @@ struct AutoScrollAccessibilityActivationClassifier {
                 actions: actions,
                 at: point
             ) != nil {
-                return .excludedChrome(path: path)
+                return .pressable(path: path)
             }
 
             if let role, Self.webContentRoles.contains(role) {
@@ -181,7 +176,7 @@ struct AutoScrollAccessibilityActivationClassifier {
             // normal page clicks.
             if !isInsideWebContent,
                Self.isExcludedActivationElement(role: role, subrole: subrole) {
-                return .excludedChrome(path: path)
+                return .pressable(path: path)
             }
 
             if Self.isPressableActivationElement(role: role, actions: actions) {
@@ -192,11 +187,11 @@ struct AutoScrollAccessibilityActivationClassifier {
             case let .success(value):
                 currentElement = value
             case let .failure(error):
-                return .unknown(reason: "parent.\(error.linearMouseDescription)", path: path)
+                return .nonPressable(diagnostic: "parent.\(error.linearMouseDescription)", path: path)
             }
         }
 
-        return .unknown(reason: "depthLimit", path: path)
+        return .nonPressable(diagnostic: "depthLimit", path: path)
     }
 
     private static func isExcludedActivationElement(role: String?, subrole: String?) -> Bool {
@@ -352,19 +347,13 @@ struct AutoScrollActivationProbe {
 
 enum AutoScrollActivationHit {
     case pressable(path: [String])
-    case excludedChrome(path: [String])
-    case nonPressable(path: [String])
-    case unknown(reason: String, path: [String])
+    case nonPressable(diagnostic: String?, path: [String])
 
     var path: [String] {
         switch self {
         case let .pressable(path):
             path
-        case let .excludedChrome(path):
-            path
-        case let .nonPressable(path):
-            path
-        case let .unknown(_, path):
+        case let .nonPressable(_, path):
             path
         }
     }
@@ -373,41 +362,19 @@ enum AutoScrollActivationHit {
         switch self {
         case .pressable:
             "pressable"
-        case .excludedChrome:
-            "excludedChrome"
-        case .nonPressable:
-            "nonPressable"
-        case let .unknown(reason, _):
-            "unknown.\(reason)"
+        case let .nonPressable(diagnostic, _):
+            diagnostic.map { "nonPressable.\($0)" } ?? "nonPressable"
         }
     }
 
-    var suppressesAutoscroll: Bool {
-        switch self {
-        case .pressable, .excludedChrome:
-            true
-        case .nonPressable, .unknown:
-            false
+    var isPressable: Bool {
+        if case .pressable = self {
+            return true
         }
+        return false
     }
 
     var requiresAdditionalSampling: Bool {
-        switch self {
-        case .nonPressable, .unknown:
-            true
-        case .pressable, .excludedChrome:
-            false
-        }
-    }
-
-    var priority: Int {
-        switch self {
-        case .pressable, .excludedChrome:
-            3
-        case .nonPressable:
-            2
-        case .unknown:
-            1
-        }
+        !isPressable
     }
 }

--- a/LinearMouse/Accessibility/AutoScrollAccessibilityActivationClassifier.swift
+++ b/LinearMouse/Accessibility/AutoScrollAccessibilityActivationClassifier.swift
@@ -223,7 +223,6 @@ struct AutoScrollAccessibilityActivationClassifier {
                 actions: actions
             ),
             in: AccessibilityBypassRuleContext(
-                bundleIdentifier: point.topmostWindowOwnerPid?.bundleIdentifier,
                 point: point
             )
         )

--- a/LinearMouse/EventTransformer/AutoScrollTransformer.swift
+++ b/LinearMouse/EventTransformer/AutoScrollTransformer.swift
@@ -15,7 +15,6 @@ final class AutoScrollTransformer {
     private let trigger: Scheme.Buttons.Mapping
     private let modes: [Scheme.Buttons.AutoScroll.Mode]
     private let speed: Double
-    private let preserveNativeMiddleClick: Bool
 
     private enum Session {
         case toggle
@@ -25,7 +24,6 @@ final class AutoScrollTransformer {
 
     private enum State {
         case idle
-        case pendingPreservedClick(anchor: CGPoint, current: CGPoint, downEvent: CGEvent)
         case active(anchor: CGPoint, current: CGPoint, session: Session)
     }
 
@@ -36,16 +34,18 @@ final class AutoScrollTransformer {
     private let indicatorController = AutoScrollIndicatorWindowController()
     private let accessibilityActivationClassifier = AutoScrollAccessibilityActivationClassifier()
 
+    static func shouldStartAutoScroll(for hit: AutoScrollActivationHit?) -> Bool {
+        hit?.isPressable != true
+    }
+
     init(
         trigger: Scheme.Buttons.Mapping,
         modes: [Scheme.Buttons.AutoScroll.Mode],
-        speed: Double,
-        preserveNativeMiddleClick: Bool
+        speed: Double
     ) {
         self.trigger = trigger
         self.modes = modes
         self.speed = speed
-        self.preserveNativeMiddleClick = preserveNativeMiddleClick
     }
 
     deinit {
@@ -126,25 +126,8 @@ extension AutoScrollTransformer: EventTransformer {
         }
 
         let activationHit = activationHit(for: event)
-        switch activationHit {
-        case .excludedChrome:
+        guard Self.shouldStartAutoScroll(for: activationHit) else {
             return event
-        case .pressable:
-            guard shouldPreserveNativeMiddleClick else {
-                break
-            }
-
-            if hasHoldMode {
-                let point = pointerLocation(for: event)
-                let downEvent = event.copy() ?? event
-                state = .pendingPreservedClick(anchor: point, current: point, downEvent: downEvent)
-                suppressTriggerUp = true
-                return nil
-            }
-
-            return event
-        case .nonPressable, .unknown, nil:
-            break
         }
 
         activate(at: pointerLocation(for: event), session: activationSession)
@@ -162,11 +145,6 @@ extension AutoScrollTransformer: EventTransformer {
         }
 
         switch state {
-        case let .pendingPreservedClick(anchor, current, downEvent):
-            if !exceedsDeadZone(from: anchor, to: current) {
-                postDeferredNativeClick(from: downEvent)
-            }
-            state = .idle
         case let .active(anchor, current, session):
             switch session {
             case .hold:
@@ -190,27 +168,6 @@ extension AutoScrollTransformer: EventTransformer {
 
     private func handlePointerMoved(_ event: CGEvent) -> CGEvent? {
         switch state {
-        case let .pendingPreservedClick(anchor, _, downEvent):
-            let point = pointerLocation(for: event)
-
-            if event.type == triggerMouseDraggedEventType,
-               exceedsDeadZone(from: anchor, to: point) {
-                activate(at: anchor, session: .hold)
-                state = .active(anchor: anchor, current: point, session: .hold)
-                let delta = CGVector(dx: point.x - anchor.x, dy: point.y - anchor.y)
-                DispatchQueue.main.async { [indicatorController] in
-                    indicatorController.update(delta: delta)
-                }
-                return nil
-            }
-
-            state = .pendingPreservedClick(anchor: anchor, current: point, downEvent: downEvent)
-
-            if event.type == triggerMouseDraggedEventType, suppressTriggerUp {
-                return nil
-            }
-
-            return event
         case let .active(anchor, _, session):
             let point = pointerLocation(for: event)
             let resolvedSession: Session
@@ -391,17 +348,6 @@ extension AutoScrollTransformer: EventTransformer {
         abs(point.x - anchor.x) > Self.deadZone || abs(point.y - anchor.y) > Self.deadZone
     }
 
-    private var shouldPreserveNativeMiddleClick: Bool {
-        guard preserveNativeMiddleClick,
-              hasToggleMode,
-              triggerMouseButton == .center,
-              trigger.modifierFlags.isEmpty else {
-            return false
-        }
-
-        return true
-    }
-
     private func hitTestPoint(for event: CGEvent) -> CGPoint {
         event.location
     }
@@ -453,38 +399,6 @@ extension AutoScrollTransformer: EventTransformer {
             resolvedPointDescription,
             resolvedPathDescription
         )
-    }
-
-    private func postDeferredNativeClick(from downEvent: CGEvent) {
-        guard let eventButton = MouseEventView(downEvent).mouseButton else {
-            return
-        }
-
-        let location = downEvent.location
-        let flags = downEvent.flags
-
-        guard let mouseDownEvent = CGEvent(
-            mouseEventSource: nil,
-            mouseType: eventButton.fixedCGEventType(of: .leftMouseDown),
-            mouseCursorPosition: location,
-            mouseButton: eventButton
-        ) else {
-            return
-        }
-
-        guard let mouseUpEvent = CGEvent(
-            mouseEventSource: nil,
-            mouseType: eventButton.fixedCGEventType(of: .leftMouseUp),
-            mouseCursorPosition: location,
-            mouseButton: eventButton
-        ) else {
-            return
-        }
-
-        mouseDownEvent.flags = flags
-        mouseUpEvent.flags = flags
-        mouseDownEvent.post(tap: .cgSessionEventTap)
-        mouseUpEvent.post(tap: .cgSessionEventTap)
     }
 }
 
@@ -556,12 +470,10 @@ extension AutoScrollTransformer {
     func matchesConfiguration(
         trigger: Scheme.Buttons.Mapping,
         modes: [Scheme.Buttons.AutoScroll.Mode],
-        speed: Double,
-        preserveNativeMiddleClick: Bool
+        speed: Double
     ) -> Bool {
         self.trigger == trigger &&
             self.modes == modes &&
-            abs(self.speed - speed) < 0.0001 &&
-            self.preserveNativeMiddleClick == preserveNativeMiddleClick
+            abs(self.speed - speed) < 0.0001
     }
 }

--- a/LinearMouse/EventTransformer/EventTransformerManager.swift
+++ b/LinearMouse/EventTransformer/EventTransformerManager.swift
@@ -433,14 +433,12 @@ class EventTransformerManager {
 
         let modes = autoScroll.normalizedModes
         let speed = autoScroll.speed?.asTruncatedDouble ?? 1
-        let preserveNativeMiddleClick = autoScroll.preserveNativeMiddleClick ?? true
 
         if let sharedAutoScrollTransformer,
            sharedAutoScrollTransformer.matchesConfiguration(
                trigger: trigger,
                modes: modes,
-               speed: speed,
-               preserveNativeMiddleClick: preserveNativeMiddleClick
+               speed: speed
            ) {
             return sharedAutoScrollTransformer
         }
@@ -450,8 +448,7 @@ class EventTransformerManager {
         let transformer = AutoScrollTransformer(
             trigger: trigger,
             modes: modes,
-            speed: speed,
-            preserveNativeMiddleClick: preserveNativeMiddleClick
+            speed: speed
         )
         sharedAutoScrollTransformer = transformer
         return transformer

--- a/LinearMouse/Localizable.xcstrings
+++ b/LinearMouse/Localizable.xcstrings
@@ -40664,6 +40664,7 @@
       }
     },
     "Preserve native middle-click on links and buttons" : {
+      "extractionState" : "stale",
       "localizations" : {
         "af" : {
           "stringUnit" : {
@@ -57123,6 +57124,7 @@
       }
     },
     "The native middle-click check only applies when click once to toggle is enabled." : {
+      "extractionState" : "stale",
       "localizations" : {
         "af" : {
           "stringUnit" : {
@@ -57331,6 +57333,7 @@
       }
     },
     "The native middle-click check only applies when the trigger is middle click without modifier keys." : {
+      "extractionState" : "stale",
       "localizations" : {
         "af" : {
           "stringUnit" : {
@@ -62330,6 +62333,7 @@
       }
     },
     "When using plain middle click, keep browser-style middle-click behavior on pressable elements instead of entering autoscroll." : {
+      "extractionState" : "stale",
       "localizations" : {
         "af" : {
           "stringUnit" : {

--- a/LinearMouse/Model/Configuration/Scheme/Buttons/AutoScroll/AutoScroll.swift
+++ b/LinearMouse/Model/Configuration/Scheme/Buttons/AutoScroll/AutoScroll.swift
@@ -17,7 +17,6 @@ extension Scheme.Buttons {
         var enabled: Bool?
         var modes: [Mode]?
         var speed: Decimal?
-        var preserveNativeMiddleClick: Bool?
         var trigger: Mapping?
 
         init() {}
@@ -29,7 +28,6 @@ extension Scheme.Buttons.AutoScroll: Codable {
         case enabled
         case mode
         case speed
-        case preserveNativeMiddleClick
         case trigger
     }
 
@@ -39,7 +37,6 @@ extension Scheme.Buttons.AutoScroll: Codable {
         enabled = try container.decodeIfPresent(Bool.self, forKey: .enabled)
         modes = try container.decodeIfPresent(SingleValueOrArray<Mode>.self, forKey: .mode)?.wrappedValue
         speed = try container.decodeIfPresent(Decimal.self, forKey: .speed)
-        preserveNativeMiddleClick = try container.decodeIfPresent(Bool.self, forKey: .preserveNativeMiddleClick)
         trigger = try container.decodeIfPresent(Scheme.Buttons.Mapping.self, forKey: .trigger)
     }
 
@@ -49,7 +46,6 @@ extension Scheme.Buttons.AutoScroll: Codable {
         try container.encodeIfPresent(enabled, forKey: .enabled)
         try container.encode(SingleValueOrArray(wrappedValue: modes), forKey: .mode)
         try container.encodeIfPresent(speed, forKey: .speed)
-        try container.encodeIfPresent(preserveNativeMiddleClick, forKey: .preserveNativeMiddleClick)
         try container.encodeIfPresent(trigger, forKey: .trigger)
     }
 }
@@ -79,10 +75,6 @@ extension Scheme.Buttons.AutoScroll {
 
         if let speed {
             autoScroll.speed = speed
-        }
-
-        if let preserveNativeMiddleClick {
-            autoScroll.preserveNativeMiddleClick = preserveNativeMiddleClick
         }
 
         if let trigger {

--- a/LinearMouse/UI/ButtonsSettings/AutoScrollSection/AutoScrollSection.swift
+++ b/LinearMouse/UI/ButtonsSettings/AutoScrollSection/AutoScrollSection.swift
@@ -56,30 +56,6 @@ struct AutoScrollSection: View {
                     Slider(value: $state.autoScrollSpeed, in: 0.3 ... 3.0, step: 0.1)
                 }
 
-                Toggle(isOn: $state.autoScrollPreserveNativeMiddleClick.animation()) {
-                    withDescription {
-                        Text("Preserve native middle-click on links and buttons")
-                        Text(
-                            "When using plain middle click, keep browser-style middle-click behavior on pressable elements instead of entering autoscroll."
-                        )
-                    }
-                }
-                .disabled(!state.autoScrollPreserveNativeMiddleClickAvailable)
-
-                if !state.autoScrollUsesPlainMiddleClick {
-                    Text(
-                        "The native middle-click check only applies when the trigger is middle click without modifier keys."
-                    )
-                    .foregroundColor(.secondary)
-                    .controlSize(.small)
-                    .fixedSize(horizontal: false, vertical: true)
-                } else if !state.autoScrollToggleModeEnabled {
-                    Text("The native middle-click check only applies when click once to toggle is enabled.")
-                        .foregroundColor(.secondary)
-                        .controlSize(.small)
-                        .fixedSize(horizontal: false, vertical: true)
-                }
-
                 Text(modeDescription)
                     .font(.caption)
                     .foregroundColor(.secondary)

--- a/LinearMouse/UI/ButtonsSettings/ButtonsSettingsState.swift
+++ b/LinearMouse/UI/ButtonsSettings/ButtonsSettingsState.swift
@@ -132,9 +132,6 @@ extension ButtonsSettingsState {
                 if scheme.buttons.autoScroll.speed == nil {
                     scheme.buttons.autoScroll.speed = 1
                 }
-                if scheme.buttons.autoScroll.preserveNativeMiddleClick == nil {
-                    scheme.buttons.autoScroll.preserveNativeMiddleClick = true
-                }
             } else {
                 scheme.buttons.autoScroll.enabled = false
             }
@@ -197,15 +194,6 @@ extension ButtonsSettingsState {
         String(format: "%.1fx", autoScrollSpeed)
     }
 
-    var autoScrollPreserveNativeMiddleClick: Bool {
-        get {
-            mergedScheme.buttons.autoScroll.preserveNativeMiddleClick ?? true
-        }
-        set {
-            scheme.buttons.autoScroll.preserveNativeMiddleClick = newValue
-        }
-    }
-
     var autoScrollTrigger: Scheme.Buttons.Mapping {
         get {
             mergedScheme.buttons.autoScroll.trigger ?? defaultAutoScrollTrigger
@@ -233,15 +221,6 @@ extension ButtonsSettingsState {
 
     var autoScrollTriggerValid: Bool {
         autoScrollTrigger.valid
-    }
-
-    var autoScrollUsesPlainMiddleClick: Bool {
-        let trigger = autoScrollTrigger
-        return trigger.button == .mouse(Int(CGMouseButton.center.rawValue)) && trigger.modifierFlags.isEmpty
-    }
-
-    var autoScrollPreserveNativeMiddleClickAvailable: Bool {
-        autoScrollUsesPlainMiddleClick && autoScrollToggleModeEnabled
     }
 
     var mappings: [Scheme.Buttons.Mapping] {

--- a/LinearMouseUnitTests/Accessibility/AccessibilityBypassRuleTests.swift
+++ b/LinearMouseUnitTests/Accessibility/AccessibilityBypassRuleTests.swift
@@ -11,56 +11,80 @@ final class AccessibilityBypassRuleTests: XCTestCase {
         scrollableRoles: ["AXWebArea", "AXScrollArea"]
     )
 
-    func testChromeFullWindowGroupRuleMatchesHitTestHole() {
+    func testChromiumFullWindowGroupRuleMatchesChromeHitTestHole() {
         let rule = matcher.firstMatchingRule(
-            for: chromeFullWindowGroupSnapshot(),
-            in: chromeContext()
+            for: chromiumFullWindowGroupSnapshot(),
+            in: testContext()
         )
 
-        XCTAssertEqual(rule?.name, "chromeFullWindowGroupHitTestHole")
+        XCTAssertEqual(rule?.name, "chromiumFullWindowGroupHitTestHole")
     }
 
-    func testChromeFullWindowGroupRuleRequiresChromeBundle() {
+    func testChromiumFullWindowGroupRuleMatchesBraveHitTestHole() {
         let rule = matcher.firstMatchingRule(
-            for: chromeFullWindowGroupSnapshot(),
-            in: AccessibilityBypassRuleContext(
-                bundleIdentifier: "com.apple.Safari",
-                point: testPoint
-            )
+            for: chromiumFullWindowGroupSnapshot(domClassList: ["BraveBrowserRootView"]),
+            in: testContext()
+        )
+
+        XCTAssertEqual(rule?.name, "chromiumFullWindowGroupHitTestHole")
+    }
+
+    func testChromiumFullWindowGroupRuleMatchesDerivedBrowserRootView() {
+        let rule = matcher.firstMatchingRule(
+            for: chromiumFullWindowGroupSnapshot(domClassList: ["ExampleBrowserRootView"]),
+            in: testContext()
+        )
+
+        XCTAssertEqual(rule?.name, "chromiumFullWindowGroupHitTestHole")
+    }
+
+    func testChromiumFullWindowGroupRuleRequiresBrowserRootViewClass() {
+        let rule = matcher.firstMatchingRule(
+            for: chromiumFullWindowGroupSnapshot(domClassList: ["RootView"]),
+            in: testContext()
         )
 
         XCTAssertNil(rule)
     }
 
-    func testChromeFullWindowGroupRuleDoesNotMatchWhenChildContainsPoint() {
+    func testChromiumFullWindowGroupRuleDoesNotMatchWebContentContainer() {
         let rule = matcher.firstMatchingRule(
-            for: chromeFullWindowGroupSnapshot(children: [
+            for: chromiumFullWindowGroupSnapshot(parentRole: "AXWebArea"),
+            in: testContext()
+        )
+
+        XCTAssertNil(rule)
+    }
+
+    func testChromiumFullWindowGroupRuleDoesNotMatchWhenChildContainsPoint() {
+        let rule = matcher.firstMatchingRule(
+            for: chromiumFullWindowGroupSnapshot(children: [
                 AccessibilityBypassChildSnapshot(
                     role: "AXGroup",
                     frame: CGRect(x: 1000, y: 40, width: 120, height: 40)
                 )
             ]),
-            in: chromeContext()
+            in: testContext()
         )
 
         XCTAssertNil(rule)
     }
 
-    func testChromeFullWindowGroupRuleDoesNotMatchScrollableElement() {
+    func testChromiumFullWindowGroupRuleDoesNotMatchScrollableElement() {
         let rule = matcher.firstMatchingRule(
-            for: chromeFullWindowGroupSnapshot(hasVerticalScrollBar: true),
-            in: chromeContext()
+            for: chromiumFullWindowGroupSnapshot(hasVerticalScrollBar: true),
+            in: testContext()
         )
 
         XCTAssertNil(rule)
     }
 
-    func testChromeFullWindowGroupRuleRequiresMatchingParentFrame() {
+    func testChromiumFullWindowGroupRuleRequiresMatchingParentFrame() {
         let rule = matcher.firstMatchingRule(
-            for: chromeFullWindowGroupSnapshot(
+            for: chromiumFullWindowGroupSnapshot(
                 parentFrame: CGRect(x: 63, y: 30, width: 1600, height: 900)
             ),
-            in: chromeContext()
+            in: testContext()
         )
 
         XCTAssertNil(rule)
@@ -69,7 +93,7 @@ final class AccessibilityBypassRuleTests: XCTestCase {
     func testChromiumTabStripRuleMatchesBraveHitTestHole() {
         let rule = matcher.firstMatchingRule(
             for: chromiumTabStripGroupSnapshot(),
-            in: braveContext()
+            in: testContext()
         )
 
         XCTAssertEqual(rule?.name, "chromiumTabStripDragContextHitTestHole")
@@ -78,19 +102,7 @@ final class AccessibilityBypassRuleTests: XCTestCase {
     func testChromiumTabStripRuleMatchesChromeHitTestHole() {
         let rule = matcher.firstMatchingRule(
             for: chromiumTabStripGroupSnapshot(),
-            in: chromeContext()
-        )
-
-        XCTAssertEqual(rule?.name, "chromiumTabStripDragContextHitTestHole")
-    }
-
-    func testChromiumTabStripRuleDoesNotDependOnBrowserBundle() {
-        let rule = matcher.firstMatchingRule(
-            for: chromiumTabStripGroupSnapshot(),
-            in: AccessibilityBypassRuleContext(
-                bundleIdentifier: "com.example.ChromiumDerivative",
-                point: testPoint
-            )
+            in: testContext()
         )
 
         XCTAssertEqual(rule?.name, "chromiumTabStripDragContextHitTestHole")
@@ -111,7 +123,7 @@ final class AccessibilityBypassRuleTests: XCTestCase {
             domClassList: ["unrelated", "TabStrip::TabDragContextImpl"]
         )
 
-        let rule = matcher.firstMatchingRule(for: snapshot, in: braveContext())
+        let rule = matcher.firstMatchingRule(for: snapshot, in: testContext())
 
         XCTAssertEqual(rule?.name, "chromiumTabStripDragContextHitTestHole")
     }
@@ -119,7 +131,7 @@ final class AccessibilityBypassRuleTests: XCTestCase {
     func testChromiumTabStripRuleRequiresExactTabStripDomClass() {
         let rule = matcher.firstMatchingRule(
             for: chromiumTabStripGroupSnapshot(domClassList: ["TabStrip::TabDragContext"]),
-            in: braveContext()
+            in: testContext()
         )
 
         XCTAssertNil(rule)
@@ -133,21 +145,12 @@ final class AccessibilityBypassRuleTests: XCTestCase {
         CGRect(x: 63, y: 30, width: 1857, height: 1050)
     }
 
-    private func chromeContext() -> AccessibilityBypassRuleContext {
-        AccessibilityBypassRuleContext(
-            bundleIdentifier: "com.google.Chrome",
-            point: testPoint
-        )
+    private func testContext() -> AccessibilityBypassRuleContext {
+        AccessibilityBypassRuleContext(point: testPoint)
     }
 
-    private func braveContext() -> AccessibilityBypassRuleContext {
-        AccessibilityBypassRuleContext(
-            bundleIdentifier: "com.brave.Browser",
-            point: testPoint
-        )
-    }
-
-    private func chromeFullWindowGroupSnapshot(
+    private func chromiumFullWindowGroupSnapshot(
+        parentRole: String? = "AXWindow",
         parentFrame: CGRect? = nil,
         children: [AccessibilityBypassChildSnapshot] = [
             AccessibilityBypassChildSnapshot(
@@ -155,7 +158,8 @@ final class AccessibilityBypassRuleTests: XCTestCase {
                 frame: CGRect(x: 1322, y: 102, width: 403, height: 84)
             )
         ],
-        hasVerticalScrollBar: Bool = false
+        hasVerticalScrollBar: Bool = false,
+        domClassList: [String] = ["BrowserRootView"]
     ) -> AccessibilityBypassElementSnapshot {
         AccessibilityBypassElementSnapshot(
             depth: 0,
@@ -163,10 +167,11 @@ final class AccessibilityBypassRuleTests: XCTestCase {
             subrole: nil,
             actions: [],
             frame: fullWindowFrame,
-            parentRole: "AXWindow",
+            parentRole: parentRole,
             parentFrame: parentFrame ?? fullWindowFrame,
             children: children,
-            hasVerticalScrollBar: hasVerticalScrollBar
+            hasVerticalScrollBar: hasVerticalScrollBar,
+            domClassList: domClassList
         )
     }
 

--- a/LinearMouseUnitTests/Accessibility/AccessibilityBypassRuleTests.swift
+++ b/LinearMouseUnitTests/Accessibility/AccessibilityBypassRuleTests.swift
@@ -66,27 +66,59 @@ final class AccessibilityBypassRuleTests: XCTestCase {
         XCTAssertNil(rule)
     }
 
-    func testBraveTabStripRuleMatchesDomClassListHitTestHole() {
+    func testChromiumTabStripRuleMatchesBraveHitTestHole() {
         let rule = matcher.firstMatchingRule(
-            for: braveTabStripGroupSnapshot(),
+            for: chromiumTabStripGroupSnapshot(),
             in: braveContext()
         )
 
-        XCTAssertEqual(rule?.name, "braveTabStripGroupHitTestHole")
+        XCTAssertEqual(rule?.name, "chromiumTabStripDragContextHitTestHole")
     }
 
-    func testBraveTabStripRuleRequiresBraveBundle() {
+    func testChromiumTabStripRuleMatchesChromeHitTestHole() {
         let rule = matcher.firstMatchingRule(
-            for: braveTabStripGroupSnapshot(),
+            for: chromiumTabStripGroupSnapshot(),
             in: chromeContext()
         )
 
-        XCTAssertNil(rule)
+        XCTAssertEqual(rule?.name, "chromiumTabStripDragContextHitTestHole")
     }
 
-    func testBraveTabStripRuleRequiresTabStripDomClass() {
+    func testChromiumTabStripRuleDoesNotDependOnBrowserBundle() {
         let rule = matcher.firstMatchingRule(
-            for: braveTabStripGroupSnapshot(domClassList: []),
+            for: chromiumTabStripGroupSnapshot(),
+            in: AccessibilityBypassRuleContext(
+                bundleIdentifier: "com.example.ChromiumDerivative",
+                point: testPoint
+            )
+        )
+
+        XCTAssertEqual(rule?.name, "chromiumTabStripDragContextHitTestHole")
+    }
+
+    func testChromiumTabStripRuleDependsOnlyOnTabStripDomClass() {
+        let snapshot = AccessibilityBypassElementSnapshot(
+            depth: 8,
+            role: "AXWebArea",
+            subrole: "AXUnexpectedSubrole",
+            actions: ["AXPress"],
+            frame: nil,
+            parentRole: nil,
+            parentFrame: nil,
+            children: [AccessibilityBypassChildSnapshot(role: "AXScrollBar")],
+            hasVerticalScrollBar: true,
+            hasHorizontalScrollBar: true,
+            domClassList: ["unrelated", "TabStrip::TabDragContextImpl"]
+        )
+
+        let rule = matcher.firstMatchingRule(for: snapshot, in: braveContext())
+
+        XCTAssertEqual(rule?.name, "chromiumTabStripDragContextHitTestHole")
+    }
+
+    func testChromiumTabStripRuleRequiresExactTabStripDomClass() {
+        let rule = matcher.firstMatchingRule(
+            for: chromiumTabStripGroupSnapshot(domClassList: ["TabStrip::TabDragContext"]),
             in: braveContext()
         )
 
@@ -138,7 +170,7 @@ final class AccessibilityBypassRuleTests: XCTestCase {
         )
     }
 
-    private func braveTabStripGroupSnapshot(
+    private func chromiumTabStripGroupSnapshot(
         domClassList: [String] = ["TabStrip::TabDragContextImpl"]
     ) -> AccessibilityBypassElementSnapshot {
         AccessibilityBypassElementSnapshot(

--- a/LinearMouseUnitTests/Accessibility/AutoScrollAccessibilityActivationClassifierTests.swift
+++ b/LinearMouseUnitTests/Accessibility/AutoScrollAccessibilityActivationClassifierTests.swift
@@ -6,6 +6,34 @@ import ApplicationServices
 import XCTest
 
 final class AutoScrollAccessibilityActivationClassifierTests: XCTestCase {
+    func testPressableHitPreservesNativeEventWithoutAdditionalSampling() {
+        let hit = AutoScrollActivationHit.pressable(path: ["AXButton[press]"])
+
+        XCTAssertTrue(hit.isPressable)
+        XCTAssertFalse(hit.requiresAdditionalSampling)
+        XCTAssertEqual(hit.summary, "pressable")
+    }
+
+    func testAccessibilityFailureIsNonPressableWithDiagnostic() {
+        let hit = AutoScrollActivationHit.nonPressable(
+            diagnostic: "role.cannotComplete",
+            path: ["AXGroup"]
+        )
+
+        XCTAssertFalse(hit.isPressable)
+        XCTAssertTrue(hit.requiresAdditionalSampling)
+        XCTAssertEqual(hit.summary, "nonPressable.role.cannotComplete")
+    }
+
+    func testAutoScrollStartsOnlyForNonPressableOrUnavailableHit() {
+        XCTAssertFalse(AutoScrollTransformer.shouldStartAutoScroll(for: .pressable(path: [])))
+        XCTAssertTrue(AutoScrollTransformer.shouldStartAutoScroll(for: .nonPressable(
+            diagnostic: nil,
+            path: []
+        )))
+        XCTAssertTrue(AutoScrollTransformer.shouldStartAutoScroll(for: nil))
+    }
+
     func testPressableActivationElementAcceptsExplicitControls() {
         XCTAssertTrue(AutoScrollAccessibilityActivationClassifier.isPressableActivationElement(
             role: "AXLink",

--- a/LinearMouseUnitTests/Model/ConfigurationTests.swift
+++ b/LinearMouseUnitTests/Model/ConfigurationTests.swift
@@ -285,6 +285,21 @@ final class ConfigurationTests: XCTestCase {
         XCTAssertEqual(autoScroll.normalizedModes, [.toggle, .hold])
     }
 
+    func testDecodeAutoScrollIgnoresRemovedPreserveNativeMiddleClickOption() throws {
+        let autoScroll = try JSONDecoder().decode(
+            Scheme.Buttons.AutoScroll.self,
+            from: XCTUnwrap(
+                #"{"enabled":true,"preserveNativeMiddleClick":false}"#.data(using: .utf8)
+            )
+        )
+
+        XCTAssertEqual(autoScroll.enabled, true)
+
+        let encoded = try JSONEncoder().encode(autoScroll)
+        let object = try XCTUnwrap(JSONSerialization.jsonObject(with: encoded) as? [String: Any])
+        XCTAssertNil(object["preserveNativeMiddleClick"])
+    }
+
     func testMergeSmoothedScrollingPreservesInheritedFields() {
         var scheme = Scheme(
             scrolling: .init(


### PR DESCRIPTION
## Summary

- fix native middle-click handling on Chromium tab strips, including while Find in Page is focused
- preserve native clicks on pressable elements by default and remove the related setting
- simplify Auto Scroll activation to pressable and non-pressable outcomes

## Testing

- Full xcodebuild test suite (289 tests)