### PR TITLE
Restore Logitech LIGHTSPEED receiver battery monitoring

### DIFF
--- a/LinearMouse/Device/ReceiverMonitor.swift
+++ b/LinearMouse/Device/ReceiverMonitor.swift
@@ -266,6 +266,27 @@ private final class ReceiverContext {
                 continue
             }
             hasLoggedMissingChannel = false
+
+            if LogitechHIDPPDeviceMetadataProvider.receiverProtocolFamily(
+                vendorID: device.pointerDevice.vendorID,
+                productID: device.pointerDevice.productID,
+                transport: device.pointerDevice.transport
+            ) == .lightspeed,
+                !provider.receiverChannelIsReachable(for: device.pointerDevice, using: receiverChannel) {
+                os_log(
+                    "Lightspeed receiver did not respond to the HID++ capability probe, stopping monitor: locationID=%{public}d device=%{public}@",
+                    log: ReceiverMonitor.log,
+                    type: .info,
+                    locationID,
+                    String(describing: device)
+                )
+                setCurrentChannel(nil)
+                DispatchQueue.main.async { [weak self] in
+                    self?.onDiscoveryTimedOut?()
+                }
+                break
+            }
+
             hasOpenedChannel = true
 
             // Full discovery only once per channel open

--- a/LinearMouse/Device/VendorSpecific/Logitech/LogitechHIDPPDeviceDPIController.swift
+++ b/LinearMouse/Device/VendorSpecific/Logitech/LogitechHIDPPDeviceDPIController.swift
@@ -172,7 +172,7 @@ struct LogitechHIDPPDeviceDPIController {
             productID: device.productID,
             transport: device.transport
         ) {
-        case .classic:
+        case .classic, .lightspeed:
             return provider.receiverSlot(for: device, using: receiverChannel)
         case .bolt:
             let discovery = provider.receiverPointingDeviceDiscovery(for: device, using: receiverChannel)

--- a/LinearMouse/Device/VendorSpecific/Logitech/LogitechHIDPPDeviceMetadataProvider.swift
+++ b/LinearMouse/Device/VendorSpecific/Logitech/LogitechHIDPPDeviceMetadataProvider.swift
@@ -35,13 +35,23 @@ struct LogitechHIDPPDeviceMetadataProvider: VendorSpecificDeviceMetadataProvider
         /// - Solaar receiver catalog: https://pwr-solaar.github.io/Solaar/devices/
         /// - Linux receiver driver IDs: https://codebrowser.dev/linux/linux/drivers/hid/hid-logitech-dj.c.html
         ///
-        /// Receiver monitoring currently uses the classic Unifying/DJ HID++ path:
-        /// vendor HID application 0xFF000001, receiver index 0xFF, and HID++ 1.0
-        /// receiver registers 0x00/0x02/0xB5. Keep this whitelist limited to
-        /// receiver kinds covered by that implementation.
-        static let monitorableReceiverProductIDs: Set<Int> = [
+        /// Classic and Lightspeed receiver monitoring use the same receiver-level
+        /// HID++ path: vendor HID application 0xFF000001, receiver index 0xFF,
+        /// and HID++ 1.0 receiver registers 0x00/0x02/0xB5.
+        static let monitorableClassicReceiverProductIDs: Set<Int> = [
             0xC52B, // Unifying receiver
             0xC532 // Unifying receiver
+        ]
+        static let monitorableLightspeedReceiverProductIDs: Set<Int> = [
+            0xC539,
+            0xC53A,
+            0xC53D,
+            0xC53F,
+            0xC541,
+            0xC543,
+            0xC545,
+            0xC547,
+            0xC54D
         ]
         static let monitorableBoltReceiverProductIDs: Set<Int> = [
             0xC548 // Bolt receiver
@@ -65,22 +75,13 @@ struct LogitechHIDPPDeviceMetadataProvider: VendorSpecificDeviceMetadataProvider
             0xC534,
             0xC535,
             0xC542,
-            // Gaming / Lightspeed receiver kinds use different Linux driver data
-            // and have not been validated against this monitor path.
+            // Early gaming receivers need Nano-specific handling.
             0xC531,
-            0xC537,
-            0xC539,
-            0xC53A,
-            0xC53D,
-            0xC53F,
-            0xC541,
-            0xC543,
-            0xC545,
-            0xC547,
-            0xC54D
+            0xC537
         ]
         static let knownReceiverProductIDs: Set<Int> = [
-            monitorableReceiverProductIDs,
+            monitorableClassicReceiverProductIDs,
+            monitorableLightspeedReceiverProductIDs,
             monitorableBoltReceiverProductIDs,
             knownReceiverProductIDsWithoutMonitoringSupport
         ].reduce(into: []) { result, productIDs in
@@ -225,8 +226,9 @@ struct LogitechHIDPPDeviceMetadataProvider: VendorSpecificDeviceMetadataProvider
         transports: [PointerDeviceTransportName.bluetoothLowEnergy, PointerDeviceTransportName.usb]
     )
 
-    enum ReceiverProtocolFamily {
+    enum ReceiverProtocolFamily: Equatable {
         case classic
+        case lightspeed
         case bolt
     }
 
@@ -238,8 +240,12 @@ struct LogitechHIDPPDeviceMetadataProvider: VendorSpecificDeviceMetadataProvider
             return nil
         }
 
-        if Constants.monitorableReceiverProductIDs.contains(productID) {
+        if Constants.monitorableClassicReceiverProductIDs.contains(productID) {
             return .classic
+        }
+
+        if Constants.monitorableLightspeedReceiverProductIDs.contains(productID) {
+            return .lightspeed
         }
 
         if Constants.monitorableBoltReceiverProductIDs.contains(productID) {
@@ -505,7 +511,7 @@ struct LogitechHIDPPDeviceMetadataProvider: VendorSpecificDeviceMetadataProvider
             productID: device.productID,
             transport: device.transport
         ) {
-        case .classic:
+        case .classic, .lightspeed:
             receiverChannel.enableWirelessNotifications()
             return receiverChannel.waitForConnectionSnapshots(timeout: timeout, until: shouldContinue)
         case .bolt:
@@ -524,7 +530,7 @@ struct LogitechHIDPPDeviceMetadataProvider: VendorSpecificDeviceMetadataProvider
             productID: device.productID,
             transport: device.transport
         ) {
-        case .classic:
+        case .classic, .lightspeed:
             return receiverChannel.readNotificationFlags() != nil
         case .bolt:
             return receiverChannel.isBoltReceiverReachable()

--- a/LinearMouseUnitTests/Device/VendorSpecificDeviceMetadataTests.swift
+++ b/LinearMouseUnitTests/Device/VendorSpecificDeviceMetadataTests.swift
@@ -99,25 +99,50 @@ final class VendorSpecificDeviceMetadataTests: XCTestCase {
         )
     }
 
+    func testLogitechReceiverMonitoringAllowsSupportedLightspeedReceiverProductIDs() {
+        let productIDs = [
+            0xC539,
+            0xC53A,
+            0xC53D,
+            0xC53F,
+            0xC541,
+            0xC543,
+            0xC545,
+            0xC547,
+            0xC54D
+        ]
+
+        for productID in productIDs {
+            XCTAssertTrue(
+                LogitechHIDPPDeviceMetadataProvider.supportsReceiverMonitoring(
+                    vendorID: 0x046D,
+                    productID: productID,
+                    transport: PointerDeviceTransportName.usb
+                )
+            )
+            XCTAssertEqual(
+                LogitechHIDPPDeviceMetadataProvider.receiverProtocolFamily(
+                    vendorID: 0x046D,
+                    productID: productID,
+                    transport: PointerDeviceTransportName.usb
+                ),
+                .lightspeed
+            )
+            XCTAssertFalse(
+                LogitechHIDPPDeviceMetadataProvider.supportsClassicReceiverMonitoring(
+                    vendorID: 0x046D,
+                    productID: productID,
+                    transport: PointerDeviceTransportName.usb
+                )
+            )
+        }
+    }
+
     func testLogitechReceiverMonitoringRejectsReceiversWithoutImplementedProtocolSupport() {
         XCTAssertFalse(
             LogitechHIDPPDeviceMetadataProvider.supportsReceiverMonitoring(
                 vendorID: 0x046D,
                 productID: 0xC52F,
-                transport: PointerDeviceTransportName.usb
-            )
-        )
-        XCTAssertFalse(
-            LogitechHIDPPDeviceMetadataProvider.supportsReceiverMonitoring(
-                vendorID: 0x046D,
-                productID: 0xC539,
-                transport: PointerDeviceTransportName.usb
-            )
-        )
-        XCTAssertFalse(
-            LogitechHIDPPDeviceMetadataProvider.supportsReceiverMonitoring(
-                vendorID: 0x046D,
-                productID: 0xC541,
                 transport: PointerDeviceTransportName.usb
             )
         )


### PR DESCRIPTION
## Summary

- Enable receiver monitoring for the known Logitech LIGHTSPEED receiver family.
- Reuse the existing HID++ receiver discovery and notification path for routed battery metadata.
- Stop monitoring safely when the initial LIGHTSPEED receiver capability probe fails.

## Testing

- swiftformat --lint on changed files
- xcodebuild test -project LinearMouse.xcodeproj -scheme LinearMouse (290 tests)

Fixes #1268