### PR TITLE
Fix Bolt receiver notification loop

### DIFF
--- a/LinearMouse/Device/VendorSpecific/Logitech/LogitechBoltReceiverSupport.swift
+++ b/LinearMouse/Device/VendorSpecific/Logitech/LogitechBoltReceiverSupport.swift
@@ -37,9 +37,8 @@ extension LogitechReceiverChannel: LogitechReceiverMonitoringChannel {
 
 extension LogitechReceiverMonitoringChannel {
     func discoverBoltSlots() -> LogitechHIDPPDeviceMetadataProvider.ReceiverSlotDiscovery? {
-        // Connection notifications are persistent receiver state. Enable them once
-        // when establishing the monitoring session, then request one initial
-        // snapshot below. Subsequent monitoring must remain passive.
+        // Enable connection notifications before requesting the initial snapshot.
+        // Ongoing monitoring revalidates the flags before each passive wait.
         enableWirelessNotifications()
 
         guard readBoltUniqueID() != nil else {
@@ -168,6 +167,10 @@ extension LogitechReceiverMonitoringChannel {
         timeout: TimeInterval,
         until shouldContinue: (() -> Bool)? = nil
     ) -> [UInt8: LogitechHIDPPDeviceMetadataProvider.ReceiverConnectionSnapshot] {
+        // Retrying this idempotent setup recovers from a transient failure without
+        // triggering a connection snapshot or short-circuiting the bounded wait.
+        enableWirelessNotifications()
+
         guard let initialNotification = waitForReceiverConnectionNotification(
             timeout: timeout,
             until: shouldContinue

--- a/LinearMouse/Device/VendorSpecific/Logitech/LogitechBoltReceiverSupport.swift
+++ b/LinearMouse/Device/VendorSpecific/Logitech/LogitechBoltReceiverSupport.swift
@@ -8,8 +8,40 @@ private struct BoltHIDPP10Report {
     let bytes: [UInt8]
 }
 
-extension LogitechReceiverChannel {
+protocol LogitechReceiverMonitoringChannel: VendorSpecificDeviceContext {
+    func enableWirelessNotifications()
+    func waitForReceiverConnectionNotification(
+        timeout: TimeInterval,
+        until shouldContinue: (() -> Bool)?
+    ) -> (slot: UInt8, snapshot: LogitechHIDPPDeviceMetadataProvider.ReceiverConnectionSnapshot)?
+}
+
+extension LogitechReceiverChannel: LogitechReceiverMonitoringChannel {
+    func waitForReceiverConnectionNotification(
+        timeout: TimeInterval,
+        until shouldContinue: (() -> Bool)?
+    ) -> (slot: UInt8, snapshot: LogitechHIDPPDeviceMetadataProvider.ReceiverConnectionSnapshot)? {
+        guard let report = waitForHIDPPNotification(
+            timeout: timeout,
+            matching: { response in
+                LogitechHIDPPDeviceMetadataProvider.parseReceiverConnectionNotification(response) != nil
+            },
+            until: shouldContinue
+        ) else {
+            return nil
+        }
+
+        return LogitechHIDPPDeviceMetadataProvider.parseReceiverConnectionNotification(report)
+    }
+}
+
+extension LogitechReceiverMonitoringChannel {
     func discoverBoltSlots() -> LogitechHIDPPDeviceMetadataProvider.ReceiverSlotDiscovery? {
+        // Connection notifications are persistent receiver state. Enable them once
+        // when establishing the monitoring session, then request one initial
+        // snapshot below. Subsequent monitoring must remain passive.
+        enableWirelessNotifications()
+
         guard readBoltUniqueID() != nil else {
             os_log(
                 "Bolt receiver unique ID is unavailable: locationID=%{public}@",
@@ -136,11 +168,7 @@ extension LogitechReceiverChannel {
         timeout: TimeInterval,
         until shouldContinue: (() -> Bool)? = nil
     ) -> [UInt8: LogitechHIDPPDeviceMetadataProvider.ReceiverConnectionSnapshot] {
-        guard triggerBoltConnectionNotifications() else {
-            return [:]
-        }
-
-        guard let initialNotification = waitForBoltConnectionNotification(
+        guard let initialNotification = waitForReceiverConnectionNotification(
             timeout: timeout,
             until: shouldContinue
         ) else {
@@ -150,7 +178,7 @@ extension LogitechReceiverChannel {
         var snapshots = [initialNotification.slot: initialNotification.snapshot]
         let deadline = Date().addingTimeInterval(0.1)
         while Date() < deadline, shouldContinue?() ?? true {
-            guard let notification = waitForBoltConnectionNotification(timeout: 0.02, until: shouldContinue) else {
+            guard let notification = waitForReceiverConnectionNotification(timeout: 0.02, until: shouldContinue) else {
                 continue
             }
 
@@ -172,22 +200,14 @@ extension LogitechReceiverChannel {
         var snapshots = [UInt8: LogitechHIDPPDeviceMetadataProvider.ReceiverConnectionSnapshot]()
         let deadline = Date().addingTimeInterval(timeout)
         while Date() < deadline, shouldContinue?() ?? true {
-            guard let report = waitForHIDPPNotification(
+            guard let notification = waitForReceiverConnectionNotification(
                 timeout: 0.05,
-                matching: { response in
-                    LogitechHIDPPDeviceMetadataProvider.parseReceiverConnectionNotification(response) != nil
-                },
                 until: shouldContinue
             ) else {
                 if let expectedCount,
                    snapshots.values.filter(\.isConnected).count >= expectedCount {
                     break
                 }
-                continue
-            }
-
-            guard let notification = LogitechHIDPPDeviceMetadataProvider
-                .parseReceiverConnectionNotification(report) else {
                 continue
             }
 
@@ -199,23 +219,6 @@ extension LogitechReceiverChannel {
         }
 
         return snapshots
-    }
-
-    private func waitForBoltConnectionNotification(
-        timeout: TimeInterval,
-        until shouldContinue: (() -> Bool)?
-    ) -> (slot: UInt8, snapshot: LogitechHIDPPDeviceMetadataProvider.ReceiverConnectionSnapshot)? {
-        guard let report = waitForHIDPPNotification(
-            timeout: timeout,
-            matching: { response in
-                LogitechHIDPPDeviceMetadataProvider.parseReceiverConnectionNotification(response) != nil
-            },
-            until: shouldContinue
-        ) else {
-            return nil
-        }
-
-        return LogitechHIDPPDeviceMetadataProvider.parseReceiverConnectionNotification(report)
     }
 
     private func boltReceiverInfoRequest(

--- a/LinearMouseUnitTests/Device/VendorSpecificDeviceMetadataTests.swift
+++ b/LinearMouseUnitTests/Device/VendorSpecificDeviceMetadataTests.swift
@@ -282,6 +282,66 @@ final class VendorSpecificDeviceMetadataTests: XCTestCase {
         XCTAssertNil(LogitechReceiverChannel.parseBoltReceiverName([0x11, 0xFF, 0x83]))
     }
 
+    func testBoltReceiverDiscoveryEnablesNotificationsAndTriggersOneInitialSnapshot() {
+        let device = MockVendorSpecificDeviceContext(
+            vendorID: 0x046D,
+            productID: 0xC548,
+            transport: PointerDeviceTransportName.usb,
+            locationID: 1
+        )
+        device.responseProvider = { report in
+            let bytes = [UInt8](report)
+            guard bytes.count >= 4 else {
+                return nil
+            }
+
+            switch (bytes[2], bytes[3]) {
+            case (0x83, 0xFB):
+                return Data([0x10, 0xFF, 0x83, 0xFB, 0x00, 0x00, 0x00])
+            case (0x81, 0x02):
+                return Data([0x10, 0xFF, 0x81, 0x02, 0x00, 0x00, 0x00])
+            case (0x80, 0x02):
+                return Data([0x10, 0xFF, 0x80, 0x02, 0x02, 0x00, 0x00])
+            default:
+                return nil
+            }
+        }
+
+        XCTAssertNil(device.discoverBoltSlots())
+        XCTAssertEqual(device.wirelessNotificationEnableCount, 1)
+        XCTAssertEqual(
+            device.sentReports
+                .filter { report in
+                    let bytes = [UInt8](report)
+                    return bytes.count >= 5
+                        && bytes[2] == 0x80
+                        && bytes[3] == 0x02
+                        && bytes[4] == 0x02
+                }
+                .count,
+            1
+        )
+    }
+
+    func testBoltReceiverConnectionWaitIsPassive() {
+        let device = MockVendorSpecificDeviceContext(
+            vendorID: 0x046D,
+            productID: 0xC548,
+            transport: PointerDeviceTransportName.usb,
+            locationID: 1
+        )
+        device.queuedHIDPPNotifications = [
+            [0x10, 0x01, 0x41, 0x00, 0x02, 0x00, 0x00]
+        ]
+
+        let snapshots = device.waitForBoltConnectionSnapshots(timeout: 0.1)
+
+        XCTAssertEqual(snapshots[1], .init(isConnected: true, kind: 0x02))
+        XCTAssertEqual(device.wirelessNotificationEnableCount, 0)
+        XCTAssertEqual(device.outputReportRequestCount, 0)
+        XCTAssertTrue(device.sentReports.isEmpty)
+    }
+
     func testLogitechControlsMonitorNeedsMatchingDirectBluetoothLowEnergyConfiguration() {
         var mapping = Scheme.Buttons.Mapping()
         mapping.button = .logitechControl(.init(controlID: 0x00D0, productID: 0xB015, serialNumber: "ABC"))

--- a/LinearMouseUnitTests/Device/VendorSpecificDeviceMetadataTests.swift
+++ b/LinearMouseUnitTests/Device/VendorSpecificDeviceMetadataTests.swift
@@ -323,7 +323,7 @@ final class VendorSpecificDeviceMetadataTests: XCTestCase {
         )
     }
 
-    func testBoltReceiverConnectionWaitIsPassive() {
+    func testBoltReceiverConnectionWaitRetriesNotificationEnableWithoutTriggeringSnapshot() {
         let device = MockVendorSpecificDeviceContext(
             vendorID: 0x046D,
             productID: 0xC548,
@@ -335,9 +335,11 @@ final class VendorSpecificDeviceMetadataTests: XCTestCase {
         ]
 
         let snapshots = device.waitForBoltConnectionSnapshots(timeout: 0.1)
+        let secondSnapshots = device.waitForBoltConnectionSnapshots(timeout: 0)
 
         XCTAssertEqual(snapshots[1], .init(isConnected: true, kind: 0x02))
-        XCTAssertEqual(device.wirelessNotificationEnableCount, 0)
+        XCTAssertTrue(secondSnapshots.isEmpty)
+        XCTAssertEqual(device.wirelessNotificationEnableCount, 2)
         XCTAssertEqual(device.outputReportRequestCount, 0)
         XCTAssertTrue(device.sentReports.isEmpty)
     }

--- a/LinearMouseUnitTests/Device/VendorSpecificDeviceTestSupport.swift
+++ b/LinearMouseUnitTests/Device/VendorSpecificDeviceTestSupport.swift
@@ -4,7 +4,7 @@
 import Foundation
 @testable import LinearMouse
 
-final class MockVendorSpecificDeviceContext: VendorSpecificDeviceContext {
+final class MockVendorSpecificDeviceContext: LogitechReceiverMonitoringChannel {
     var vendorID: Int?
     var productID: Int?
     var product: String?
@@ -20,6 +20,8 @@ final class MockVendorSpecificDeviceContext: VendorSpecificDeviceContext {
     var outputReportRequestCount = 0
     var sentReports = [Data]()
     var responseProvider: ((Data) -> Data?)?
+    var wirelessNotificationEnableCount = 0
+    var queuedHIDPPNotifications = [[UInt8]]()
 
     init(
         vendorID: Int?,
@@ -61,5 +63,30 @@ final class MockVendorSpecificDeviceContext: VendorSpecificDeviceContext {
             return nil
         }
         return response
+    }
+
+    func enableWirelessNotifications() {
+        wirelessNotificationEnableCount += 1
+    }
+
+    func waitForReceiverConnectionNotification(
+        timeout: TimeInterval,
+        until shouldContinue: (() -> Bool)?
+    ) -> (slot: UInt8, snapshot: LogitechHIDPPDeviceMetadataProvider.ReceiverConnectionSnapshot)? {
+        guard shouldContinue?() ?? true else {
+            return nil
+        }
+
+        if let index = queuedHIDPPNotifications.firstIndex(where: {
+            LogitechHIDPPDeviceMetadataProvider.parseReceiverConnectionNotification($0) != nil
+        }) {
+            let report = queuedHIDPPNotifications.remove(at: index)
+            return LogitechHIDPPDeviceMetadataProvider.parseReceiverConnectionNotification(report)
+        }
+
+        if timeout > 0 {
+            Thread.sleep(forTimeInterval: timeout)
+        }
+        return nil
     }
 }


### PR DESCRIPTION
## Summary

- Enable receiver notifications when starting Bolt discovery and request a single initial connection snapshot.
- Keep ongoing Bolt connection monitoring passive while rechecking notification flags before each bounded wait, so transient setup failures recover without triggering connection reports.
- Add a testable receiver monitoring abstraction and regression coverage for the initial request count, notification setup retries, and passive snapshot wait behavior.

Fixes #1276.

## Testing

- swiftformat --lint on the changed Swift files
- swiftlint lint on the production file and test support
- xcodebuild test -project LinearMouse.xcodeproj -scheme LinearMouse (292 tests)
- git diff --check

## Hardware validation

Not tested with a physical Bolt receiver because one was not available.