### PR TITLE
Support high-resolution wheel through Bolt receivers

### DIFF
--- a/LinearMouse/Device/VendorSpecific/Logitech/LogitechHIDPPDeviceDPIController.swift
+++ b/LinearMouse/Device/VendorSpecific/Logitech/LogitechHIDPPDeviceDPIController.swift
@@ -2,7 +2,6 @@
 // Copyright (c) 2021-2026 LinearMouse
 
 import Foundation
-import PointerKit
 
 struct LogitechHIDPPDeviceDPIController {
     private enum Constants {
@@ -19,29 +18,19 @@ struct LogitechHIDPPDeviceDPIController {
     private let featureIndex: UInt8
 
     init?(device: VendorSpecificDeviceContext) {
-        guard device.vendorID == LogitechHIDPPDeviceMetadataProvider.Constants.vendorID,
-              [PointerDeviceTransportName.usb, PointerDeviceTransportName.bluetoothLowEnergy].contains(device.transport)
+        guard let target = LogitechHIDPPFeatureTargetResolver.resolve(.adjustableDPI, for: device)
         else {
             return nil
         }
 
-        let provider = LogitechHIDPPDeviceMetadataProvider()
-        if !LogitechHIDPPDeviceMetadataProvider.isKnownReceiver(vendorID: device.vendorID, productID: device.productID),
-           let directTarget = Self.makeTarget(device: device) {
-            self = directTarget
-            return
-        }
-
-        if let receiverTarget = Self.makeReceiverTarget(device: device, provider: provider) {
-            self = receiverTarget
-            return
-        }
-
-        guard let directTarget = Self.makeTarget(device: device) else {
-            return nil
-        }
-
-        self = directTarget
+        self.init(
+            transport: target.transport,
+            featureIndex: target.featureIndex,
+            supportedDPI: Self.readSupportedDPI(
+                transport: target.transport,
+                featureIndex: target.featureIndex
+            )
+        )
     }
 
     init(
@@ -128,62 +117,6 @@ struct LogitechHIDPPDeviceDPIController {
         }
 
         return supportedDPI.contains(dpi)
-    }
-
-    private static func makeTarget(device: VendorSpecificDeviceContext) -> Self? {
-        guard let transport = LogitechHIDPPTransport(device: device, deviceIndex: nil),
-              let featureIndex = transport.featureIndex(for: .adjustableDPI)
-        else {
-            return nil
-        }
-
-        let supportedDPI = readSupportedDPI(transport: transport, featureIndex: featureIndex)
-        return .init(
-            transport: transport,
-            featureIndex: featureIndex,
-            supportedDPI: supportedDPI
-        )
-    }
-
-    private static func makeReceiverTarget(
-        device: VendorSpecificDeviceContext,
-        provider: LogitechHIDPPDeviceMetadataProvider
-    ) -> Self? {
-        guard device.transport == PointerDeviceTransportName.usb,
-              let receiverChannel = provider.openReceiverChannel(for: device),
-              let slot = receiverSlot(for: device, using: receiverChannel, provider: provider),
-              let transport = LogitechHIDPPTransport(device: receiverChannel, deviceIndex: slot),
-              let featureIndex = transport.featureIndex(for: .adjustableDPI)
-        else {
-            return nil
-        }
-
-        let supportedDPI = readSupportedDPI(transport: transport, featureIndex: featureIndex)
-        return .init(
-            transport: transport,
-            featureIndex: featureIndex,
-            supportedDPI: supportedDPI
-        )
-    }
-
-    private static func receiverSlot(
-        for device: VendorSpecificDeviceContext,
-        using receiverChannel: LogitechReceiverChannel,
-        provider: LogitechHIDPPDeviceMetadataProvider
-    ) -> UInt8? {
-        switch LogitechHIDPPDeviceMetadataProvider.receiverProtocolFamily(
-            vendorID: device.vendorID,
-            productID: device.productID,
-            transport: device.transport
-        ) {
-        case .classic, .lightspeed:
-            return provider.receiverSlot(for: device, using: receiverChannel)
-        case .bolt:
-            let discovery = provider.receiverPointingDeviceDiscovery(for: device, using: receiverChannel)
-            return provider.receiverSlot(for: device, identities: discovery.identities)
-        case nil:
-            return provider.receiverSlot(for: device, using: receiverChannel)
-        }
     }
 
     private static func readSupportedDPI(transport: LogitechHIDPPTransport, featureIndex: UInt8) -> [Int] {

--- a/LinearMouse/Device/VendorSpecific/Logitech/LogitechHIDPPFeatureTargetResolver.swift
+++ b/LinearMouse/Device/VendorSpecific/Logitech/LogitechHIDPPFeatureTargetResolver.swift
@@ -1,0 +1,87 @@
+// MIT License
+// Copyright (c) 2021-2026 LinearMouse
+
+import PointerKit
+
+enum LogitechHIDPPFeatureTargetResolver {
+    struct Target {
+        let transport: LogitechHIDPPTransport
+        let featureIndex: UInt8
+    }
+
+    static func resolve(
+        _ featureID: LogitechHIDPPDeviceMetadataProvider.FeatureID,
+        for device: VendorSpecificDeviceContext
+    ) -> Target? {
+        guard device.vendorID == LogitechHIDPPDeviceMetadataProvider.Constants.vendorID,
+              [PointerDeviceTransportName.usb, PointerDeviceTransportName.bluetoothLowEnergy]
+              .contains(device.transport)
+        else {
+            return nil
+        }
+
+        let provider = LogitechHIDPPDeviceMetadataProvider()
+        if !LogitechHIDPPDeviceMetadataProvider.isKnownReceiver(
+            vendorID: device.vendorID,
+            productID: device.productID
+        ), let directTarget = directTarget(featureID, for: device) {
+            return directTarget
+        }
+
+        if let receiverTarget = receiverTarget(featureID, for: device, provider: provider) {
+            return receiverTarget
+        }
+
+        return directTarget(featureID, for: device)
+    }
+
+    private static func directTarget(
+        _ featureID: LogitechHIDPPDeviceMetadataProvider.FeatureID,
+        for device: VendorSpecificDeviceContext
+    ) -> Target? {
+        guard let transport = LogitechHIDPPTransport(device: device, deviceIndex: nil),
+              let featureIndex = transport.featureIndex(for: featureID)
+        else {
+            return nil
+        }
+
+        return .init(transport: transport, featureIndex: featureIndex)
+    }
+
+    private static func receiverTarget(
+        _ featureID: LogitechHIDPPDeviceMetadataProvider.FeatureID,
+        for device: VendorSpecificDeviceContext,
+        provider: LogitechHIDPPDeviceMetadataProvider
+    ) -> Target? {
+        guard device.transport == PointerDeviceTransportName.usb,
+              let receiverChannel = provider.openReceiverChannel(for: device),
+              let slot = receiverSlot(for: device, using: receiverChannel, provider: provider),
+              let transport = LogitechHIDPPTransport(device: receiverChannel, deviceIndex: slot),
+              let featureIndex = transport.featureIndex(for: featureID)
+        else {
+            return nil
+        }
+
+        return .init(transport: transport, featureIndex: featureIndex)
+    }
+
+    private static func receiverSlot(
+        for device: VendorSpecificDeviceContext,
+        using receiverChannel: LogitechReceiverChannel,
+        provider: LogitechHIDPPDeviceMetadataProvider
+    ) -> UInt8? {
+        switch LogitechHIDPPDeviceMetadataProvider.receiverProtocolFamily(
+            vendorID: device.vendorID,
+            productID: device.productID,
+            transport: device.transport
+        ) {
+        case .classic, .lightspeed:
+            return provider.receiverSlot(for: device, using: receiverChannel)
+        case .bolt:
+            let discovery = provider.receiverPointingDeviceDiscovery(for: device, using: receiverChannel)
+            return provider.receiverSlot(for: device, identities: discovery.identities)
+        case nil:
+            return provider.receiverSlot(for: device, using: receiverChannel)
+        }
+    }
+}

--- a/LinearMouse/Device/VendorSpecific/Logitech/LogitechHIDPPHighResolutionWheelController.swift
+++ b/LinearMouse/Device/VendorSpecific/Logitech/LogitechHIDPPHighResolutionWheelController.swift
@@ -2,7 +2,6 @@
 // Copyright (c) 2021-2026 LinearMouse
 
 import Foundation
-import PointerKit
 
 struct LogitechHIDPPHighResolutionWheelController {
     private enum Constants {
@@ -21,14 +20,15 @@ struct LogitechHIDPPHighResolutionWheelController {
     private let featureIndex: UInt8
 
     init?(device: VendorSpecificDeviceContext) {
-        guard device.vendorID == LogitechHIDPPDeviceMetadataProvider.Constants.vendorID,
-              device.transport == PointerDeviceTransportName.bluetoothLowEnergy,
-              let transport = LogitechHIDPPTransport(device: device, deviceIndex: nil),
-              let featureIndex = transport.featureIndex(for: .hiresWheel)
+        guard let target = LogitechHIDPPFeatureTargetResolver.resolve(.hiresWheel, for: device)
         else {
             return nil
         }
 
+        self.init(transport: target.transport, featureIndex: target.featureIndex)
+    }
+
+    init(transport: LogitechHIDPPTransport, featureIndex: UInt8) {
         self.transport = transport
         self.featureIndex = featureIndex
     }

--- a/LinearMouseUnitTests/Device/VendorSpecific/LogitechHIDPPHighResolutionWheelControllerTests.swift
+++ b/LinearMouseUnitTests/Device/VendorSpecific/LogitechHIDPPHighResolutionWheelControllerTests.swift
@@ -103,11 +103,66 @@ final class LogitechHIDPPHighResolutionWheelControllerTests: XCTestCase {
         XCTAssertNil(LogitechHIDPPHighResolutionWheelController(device: device))
     }
 
-    func testOnlySupportsBluetoothLowEnergyDevicesForNow() {
+    func testReadsAndWritesHighResolutionWheelModeThroughReceiverSlot() {
+        let device = MockVendorSpecificDeviceContext(
+            vendorID: 0x046D,
+            productID: 0xC548,
+            transport: PointerDeviceTransportName.usb,
+            maxInputReportSize: 20,
+            maxOutputReportSize: 20
+        )
+        device.responseProvider = { report in
+            let bytes = [UInt8](report)
+            guard bytes.count >= 4 else {
+                return nil
+            }
+
+            switch (bytes[2], bytes[3]) {
+            case (0x1E, 0x08):
+                return Self.hidppLongReply(
+                    deviceIndex: bytes[1],
+                    featureIndex: 0x1E,
+                    address: 0x08,
+                    payload: [0x08, 0x0C]
+                )
+            case (0x1E, 0x18):
+                return Self.hidppLongReply(
+                    deviceIndex: bytes[1],
+                    featureIndex: 0x1E,
+                    address: 0x18,
+                    payload: [0x04, 0x00]
+                )
+            case (0x1E, 0x28):
+                return Self.hidppLongReply(
+                    deviceIndex: bytes[1],
+                    featureIndex: 0x1E,
+                    address: 0x28,
+                    payload: []
+                )
+            default:
+                return nil
+            }
+        }
+
+        let transport = LogitechHIDPPTransport(device: device, deviceIndex: 2)
+        let controller = transport.map {
+            LogitechHIDPPHighResolutionWheelController(transport: $0, featureIndex: 0x1E)
+        }
+
+        XCTAssertEqual(controller?.capabilities(), .init(multiplier: 8, flags: 0x0C))
+        XCTAssertEqual(controller?.isHighResolutionWheelEnabled(), false)
+        XCTAssertEqual(controller?.setHighResolutionWheelEnabled(true), true)
+        XCTAssertEqual(
+            device.sentReports.last.map { Array($0.prefix(5)) },
+            Optional([0x11, 0x02, 0x1E, 0x28, 0x06] as [UInt8])
+        )
+    }
+
+    func testRejectsUnsupportedTransport() {
         let device = MockVendorSpecificDeviceContext(
             vendorID: 0x046D,
             productID: 0xB015,
-            transport: PointerDeviceTransportName.usb,
+            transport: "SPI",
             maxInputReportSize: 20,
             maxOutputReportSize: 20
         )
@@ -116,10 +171,15 @@ final class LogitechHIDPPHighResolutionWheelControllerTests: XCTestCase {
         XCTAssertEqual(device.outputReportRequestCount, 0)
     }
 
-    private static func hidppLongReply(featureIndex: UInt8, address: UInt8, payload: [UInt8]) -> Data {
+    private static func hidppLongReply(
+        deviceIndex: UInt8 = 0xFF,
+        featureIndex: UInt8,
+        address: UInt8,
+        payload: [UInt8]
+    ) -> Data {
         var bytes = [UInt8](repeating: 0, count: 20)
         bytes[0] = 0x11
-        bytes[1] = 0xFF
+        bytes[1] = deviceIndex
         bytes[2] = featureIndex
         bytes[3] = address
         for (index, byte) in payload.enumerated() where index + 4 < bytes.count {


### PR DESCRIPTION
## Summary

- enable high-resolution wheel control for Logitech devices connected through a Bolt receiver
- route the wheel feature to the paired Bolt device slot using the shared receiver feature target resolver
- preserve existing wheel mode flags while changing only the high-resolution bit
- add coverage for reading and writing wheel mode through a receiver-routed HID++ transport

## Testing

- ran the full test suite: 296 tests, 0 failures
- tested with an MX Master 3S connected through a Bolt receiver
- verified that the high-resolution wheel mode can be read, toggled, and restored to its original value
- ran SwiftFormat and SwiftLint on the changed files
