### PR TITLE
Fix Command shortcuts on non-Latin keyboard layouts

### DIFF
--- a/Modules/KeyKit/Sources/KeyKit/KeyCodeResolver.swift
+++ b/Modules/KeyKit/Sources/KeyKit/KeyCodeResolver.swift
@@ -1,19 +1,37 @@
 // MIT License
 // Copyright (c) 2021-2026 LinearMouse
 
-import AppKit
 import Carbon
 import Combine
+import CoreGraphics
 import Foundation
 
 /// Keyboard layout-independent key code resolver.
 public class KeyCodeResolver {
+    typealias CharacterMapping = [String: CGKeyCode]
+
     private var subscriptions = Set<AnyCancellable>()
+    private let characterMappingsProvider: (_ commandModified: Bool) -> [CharacterMapping]
     private let mappingLock = NSLock()
-    private var mapping: [String: CGKeyCode] = [:]
+    private var mapping: CharacterMapping = [:]
+    private var commandMapping: CharacterMapping = [:]
     private var reversedMapping: [CGKeyCode: Key] = [:]
 
     public init() {
+        characterMappingsProvider = { commandModified in
+            Self.currentCharacterMappings(commandModified: commandModified)
+        }
+
+        startObservingInputSourceChanges()
+        initializeMapping()
+    }
+
+    init(characterMappingsProvider: @escaping (_ commandModified: Bool) -> [CharacterMapping]) {
+        self.characterMappingsProvider = characterMappingsProvider
+        initializeMapping()
+    }
+
+    private func startObservingInputSourceChanges() {
         DistributedNotificationCenter.default
             .publisher(for: .init(kTISNotifyEnabledKeyboardInputSourcesChanged as String))
             .sink { [weak self] _ in
@@ -27,8 +45,10 @@ public class KeyCodeResolver {
                 self?.scheduleMappingUpdate(after: 0.1)
             }
             .store(in: &subscriptions)
+    }
 
-        // `NSEvent.characters` below asserts on the main thread.
+    private func initializeMapping() {
+        // Text Input Source Services is not thread-safe.
         if Thread.isMainThread {
             updateMapping()
         } else {
@@ -43,28 +63,9 @@ public class KeyCodeResolver {
     }
 
     private func updateMapping() {
-        var newMapping: [String: CGKeyCode] = [:]
+        var newMapping = Self.mergeCharacterMappings(characterMappingsProvider(false))
+        var newCommandMapping = Self.mergeCharacterMappings(characterMappingsProvider(true))
         var newReversedMapping: [CGKeyCode: Key] = [:]
-
-        for keyCode: CGKeyCode in 0 ..< 128 {
-            guard let cgEvent = CGEvent(keyboardEventSource: nil, virtualKey: keyCode, keyDown: true) else {
-                continue
-            }
-            cgEvent.flags = []
-            guard let nsEvent = NSEvent(cgEvent: cgEvent) else {
-                continue
-            }
-            guard nsEvent.type == .keyDown else {
-                continue
-            }
-            guard let characters = nsEvent.characters, characters.count == 1 else {
-                continue
-            }
-            guard newMapping[characters] == nil else {
-                continue
-            }
-            newMapping[characters] = keyCode
-        }
 
         newMapping[Key.enter.rawValue] = 0x24
         newMapping[Key.tab.rawValue] = 0x30
@@ -127,6 +128,11 @@ public class KeyCodeResolver {
         newMapping[Key.numpad7.rawValue] = 0x59
         newMapping[Key.numpad8.rawValue] = 0x5B
         newMapping[Key.numpad9.rawValue] = 0x5C
+
+        // Command-modified characters from the active layout take priority. The regular
+        // mapping fills layout-independent keys and any characters without a Command variant.
+        newCommandMapping = Self.mergeCharacterMappings([newCommandMapping, newMapping])
+
         for (keyString, keyCode) in newMapping {
             guard let key = Key(rawValue: keyString) else {
                 continue
@@ -136,12 +142,103 @@ public class KeyCodeResolver {
 
         mappingLock.withLock {
             mapping = newMapping
+            commandMapping = newCommandMapping
             reversedMapping = newReversedMapping
         }
     }
 
-    public func keyCode(for key: Key) -> CGKeyCode? {
-        mappingLock.withLock { mapping[key.rawValue] }
+    private static func currentCharacterMappings(commandModified: Bool) -> [CharacterMapping] {
+        guard let currentInputSource = TISCopyCurrentKeyboardLayoutInputSource()?.takeRetainedValue() else {
+            return []
+        }
+
+        let currentMapping = characterMapping(for: currentInputSource)
+        guard commandModified else {
+            return [currentMapping]
+        }
+
+        let commandModifierState = UInt32(cmdKey >> 8)
+        let currentCommandMapping = characterMapping(
+            for: currentInputSource,
+            modifierKeyState: commandModifierState
+        )
+        var mappings = [currentCommandMapping, currentMapping]
+
+        if let asciiInputSource = TISCopyCurrentASCIICapableKeyboardLayoutInputSource()?.takeRetainedValue() {
+            mappings.append(characterMapping(for: asciiInputSource))
+        }
+
+        return mappings
+    }
+
+    static func characterMapping(
+        for inputSource: TISInputSource,
+        modifierKeyState: UInt32 = 0
+    ) -> CharacterMapping {
+        guard let layoutDataPointer = TISGetInputSourceProperty(inputSource, kTISPropertyUnicodeKeyLayoutData) else {
+            return [:]
+        }
+
+        let layoutData = unsafeBitCast(layoutDataPointer, to: CFData.self)
+        guard let layoutBytes = CFDataGetBytePtr(layoutData) else {
+            return [:]
+        }
+
+        let keyboardType = UInt32(LMGetKbdType())
+        var mapping: CharacterMapping = [:]
+
+        for keyCode: CGKeyCode in 0 ..< 128 {
+            var deadKeyState: UInt32 = 0
+            var length = 0
+            var characters = [UniChar](repeating: 0, count: 4)
+
+            let status = layoutBytes.withMemoryRebound(to: UCKeyboardLayout.self, capacity: 1) { keyboardLayout in
+                UCKeyTranslate(
+                    keyboardLayout,
+                    keyCode,
+                    UInt16(kUCKeyActionDown),
+                    modifierKeyState,
+                    keyboardType,
+                    OptionBits(kUCKeyTranslateNoDeadKeysBit),
+                    &deadKeyState,
+                    characters.count,
+                    &length,
+                    &characters
+                )
+            }
+
+            guard status == noErr, length == 1 else {
+                continue
+            }
+
+            let character = String(utf16CodeUnits: characters, count: length)
+            if mapping[character] == nil {
+                mapping[character] = keyCode
+            }
+        }
+
+        return mapping
+    }
+
+    static func mergeCharacterMappings(_ mappings: [CharacterMapping]) -> CharacterMapping {
+        var result: CharacterMapping = [:]
+
+        for mapping in mappings {
+            for (character, keyCode) in mapping where result[character] == nil {
+                result[character] = keyCode
+            }
+        }
+
+        return result
+    }
+
+    public func keyCode(for key: Key, modifiers: CGEventFlags = []) -> CGKeyCode? {
+        mappingLock.withLock {
+            if modifiers.contains(.maskCommand) {
+                return commandMapping[key.rawValue]
+            }
+            return mapping[key.rawValue]
+        }
     }
 
     public func key(from keyCode: CGKeyCode) -> Key? {

--- a/Modules/KeyKit/Sources/KeyKit/KeySimulator.swift
+++ b/Modules/KeyKit/Sources/KeyKit/KeySimulator.swift
@@ -63,7 +63,7 @@ public class KeySimulator: KeySimulating {
             break
         }
 
-        guard let keyCode = keyCodeResolver.keyCode(for: key) else {
+        guard let keyCode = keyCodeResolver.keyCode(for: key, modifiers: flags) else {
             throw KeySimulatorError.unsupportedKey
         }
 

--- a/Modules/KeyKit/Tests/KeyKitTests/KeyKitTests.swift
+++ b/Modules/KeyKit/Tests/KeyKitTests/KeyKitTests.swift
@@ -1,10 +1,26 @@
 // MIT License
 // Copyright (c) 2021-2026 LinearMouse
 
+import Carbon
 @testable import KeyKit
 import XCTest
 
 final class KeyKitTests: XCTestCase {
+    private func characterMapping(
+        inputSourceID: String,
+        modifierKeyState: UInt32 = 0
+    ) throws -> KeyCodeResolver.CharacterMapping {
+        let filter = [kTISPropertyInputSourceID!: inputSourceID as CFString] as CFDictionary
+        let inputSources = try XCTUnwrap(
+            TISCreateInputSourceList(filter, true).takeRetainedValue() as? [TISInputSource]
+        )
+        let inputSource = try XCTUnwrap(inputSources.first)
+        return KeyCodeResolver.characterMapping(
+            for: inputSource,
+            modifierKeyState: modifierKeyState
+        )
+    }
+
     /// The tests below post real keyboard / system-defined events into the OS, which causes
     /// observable side effects (volume change, Mission Control space switch, stuck modifier
     /// state in WindowServer, etc.). Gate them behind an env var so day-to-day `swift test`
@@ -25,6 +41,45 @@ final class KeyKitTests: XCTestCase {
         }
 
         wait(for: [expectation], timeout: 5)
+    }
+
+    func testKeyCodeResolverUsesCommandLayerForRussianLayout() throws {
+        let russianMapping = try characterMapping(inputSourceID: "com.apple.keylayout.Russian")
+        let russianCommandMapping = try characterMapping(
+            inputSourceID: "com.apple.keylayout.Russian",
+            modifierKeyState: UInt32(cmdKey >> 8)
+        )
+
+        XCTAssertNil(russianMapping[Key.c.rawValue])
+        XCTAssertNil(russianMapping[Key.v.rawValue])
+        XCTAssertEqual(russianMapping["с"], 0x08)
+        XCTAssertEqual(russianMapping["м"], 0x09)
+        XCTAssertEqual(russianCommandMapping[Key.c.rawValue], 0x08)
+        XCTAssertEqual(russianCommandMapping[Key.v.rawValue], 0x09)
+
+        let resolver = KeyCodeResolver { commandModified in
+            commandModified ? [russianCommandMapping, russianMapping] : [russianMapping]
+        }
+
+        XCTAssertNil(resolver.keyCode(for: .c))
+        XCTAssertNil(resolver.keyCode(for: .v))
+        XCTAssertEqual(resolver.keyCode(for: .c, modifiers: .maskCommand), 0x08)
+        XCTAssertEqual(resolver.keyCode(for: .v, modifiers: .maskCommand), 0x09)
+    }
+
+    func testKeyCodeResolverDoesNotForceANSIPositionForDvorak() throws {
+        let dvorakMapping = try characterMapping(inputSourceID: "com.apple.keylayout.Dvorak")
+        let dvorakCommandMapping = try characterMapping(
+            inputSourceID: "com.apple.keylayout.Dvorak",
+            modifierKeyState: UInt32(cmdKey >> 8)
+        )
+        let ansiFallback = [Key.v.rawValue: CGKeyCode(kVK_ANSI_V)]
+        let resolver = KeyCodeResolver { commandModified in
+            commandModified ? [dvorakCommandMapping, dvorakMapping, ansiFallback] : [dvorakMapping]
+        }
+
+        XCTAssertEqual(resolver.keyCode(for: .v, modifiers: .maskCommand), 0x2F)
+        XCTAssertNotEqual(resolver.keyCode(for: .v, modifiers: .maskCommand), CGKeyCode(kVK_ANSI_V))
     }
 
     func testPressKey() throws {


### PR DESCRIPTION
## Summary

- resolve Command-modified keys through the active keyboard layout’s Command layer
- preserve the active layout’s semantics, with base and ASCII-capable mappings as fallbacks
- pass active modifiers into key-code resolution during simulated key presses
- add regression coverage using macOS’s built-in Russian and Dvorak layouts

## Testing

- `swift test` in `Modules/KeyKit`
- `xcodebuild test -project LinearMouse.xcodeproj -scheme LinearMouse`
- `make lint`

Fixes #1282