### PR TITLE
Support modifier shortcuts on non-Latin layouts

### DIFF
--- a/Modules/KeyKit/Sources/KeyKit/KeyCodeResolver.swift
+++ b/Modules/KeyKit/Sources/KeyKit/KeyCodeResolver.swift
@@ -63,8 +63,12 @@ public class KeyCodeResolver {
     }
 
     private func updateMapping() {
-        var newMapping = Self.mergeCharacterMappings(characterMappingsProvider(false))
-        var newCommandMapping = Self.mergeCharacterMappings(characterMappingsProvider(true))
+        var newMapping = Self.mergeCharacterMappings(
+            characterMappingsProvider(false) + [Self.ansiCharacterMapping]
+        )
+        var newCommandMapping = Self.mergeCharacterMappings(
+            characterMappingsProvider(true) + [Self.ansiCharacterMapping]
+        )
         var newReversedMapping: [CGKeyCode: Key] = [:]
 
         newMapping[Key.enter.rawValue] = 0x24
@@ -162,13 +166,7 @@ public class KeyCodeResolver {
             for: currentInputSource,
             modifierKeyState: commandModifierState
         )
-        var mappings = [currentCommandMapping, currentMapping]
-
-        if let asciiInputSource = TISCopyCurrentASCIICapableKeyboardLayoutInputSource()?.takeRetainedValue() {
-            mappings.append(characterMapping(for: asciiInputSource))
-        }
-
-        return mappings
+        return [currentCommandMapping, currentMapping]
     }
 
     static func characterMapping(
@@ -244,4 +242,58 @@ public class KeyCodeResolver {
     public func key(from keyCode: CGKeyCode) -> Key? {
         mappingLock.withLock { reversedMapping[keyCode] }
     }
+}
+
+extension KeyCodeResolver {
+    /// Keep Latin shortcuts usable when the active layout has no Latin representation.
+    /// Active-layout mappings are merged first so they always keep their own key positions.
+    static let ansiCharacterMapping: CharacterMapping = [
+        Key.a.rawValue: CGKeyCode(kVK_ANSI_A),
+        Key.b.rawValue: CGKeyCode(kVK_ANSI_B),
+        Key.c.rawValue: CGKeyCode(kVK_ANSI_C),
+        Key.d.rawValue: CGKeyCode(kVK_ANSI_D),
+        Key.e.rawValue: CGKeyCode(kVK_ANSI_E),
+        Key.f.rawValue: CGKeyCode(kVK_ANSI_F),
+        Key.g.rawValue: CGKeyCode(kVK_ANSI_G),
+        Key.h.rawValue: CGKeyCode(kVK_ANSI_H),
+        Key.i.rawValue: CGKeyCode(kVK_ANSI_I),
+        Key.j.rawValue: CGKeyCode(kVK_ANSI_J),
+        Key.k.rawValue: CGKeyCode(kVK_ANSI_K),
+        Key.l.rawValue: CGKeyCode(kVK_ANSI_L),
+        Key.m.rawValue: CGKeyCode(kVK_ANSI_M),
+        Key.n.rawValue: CGKeyCode(kVK_ANSI_N),
+        Key.o.rawValue: CGKeyCode(kVK_ANSI_O),
+        Key.p.rawValue: CGKeyCode(kVK_ANSI_P),
+        Key.q.rawValue: CGKeyCode(kVK_ANSI_Q),
+        Key.r.rawValue: CGKeyCode(kVK_ANSI_R),
+        Key.s.rawValue: CGKeyCode(kVK_ANSI_S),
+        Key.t.rawValue: CGKeyCode(kVK_ANSI_T),
+        Key.u.rawValue: CGKeyCode(kVK_ANSI_U),
+        Key.v.rawValue: CGKeyCode(kVK_ANSI_V),
+        Key.w.rawValue: CGKeyCode(kVK_ANSI_W),
+        Key.x.rawValue: CGKeyCode(kVK_ANSI_X),
+        Key.y.rawValue: CGKeyCode(kVK_ANSI_Y),
+        Key.z.rawValue: CGKeyCode(kVK_ANSI_Z),
+        Key.zero.rawValue: CGKeyCode(kVK_ANSI_0),
+        Key.one.rawValue: CGKeyCode(kVK_ANSI_1),
+        Key.two.rawValue: CGKeyCode(kVK_ANSI_2),
+        Key.three.rawValue: CGKeyCode(kVK_ANSI_3),
+        Key.four.rawValue: CGKeyCode(kVK_ANSI_4),
+        Key.five.rawValue: CGKeyCode(kVK_ANSI_5),
+        Key.six.rawValue: CGKeyCode(kVK_ANSI_6),
+        Key.seven.rawValue: CGKeyCode(kVK_ANSI_7),
+        Key.eight.rawValue: CGKeyCode(kVK_ANSI_8),
+        Key.nine.rawValue: CGKeyCode(kVK_ANSI_9),
+        Key.equal.rawValue: CGKeyCode(kVK_ANSI_Equal),
+        Key.minus.rawValue: CGKeyCode(kVK_ANSI_Minus),
+        Key.semicolon.rawValue: CGKeyCode(kVK_ANSI_Semicolon),
+        Key.quote.rawValue: CGKeyCode(kVK_ANSI_Quote),
+        Key.comma.rawValue: CGKeyCode(kVK_ANSI_Comma),
+        Key.period.rawValue: CGKeyCode(kVK_ANSI_Period),
+        Key.slash.rawValue: CGKeyCode(kVK_ANSI_Slash),
+        Key.backslash.rawValue: CGKeyCode(kVK_ANSI_Backslash),
+        Key.backquote.rawValue: CGKeyCode(kVK_ANSI_Grave),
+        Key.backetLeft.rawValue: CGKeyCode(kVK_ANSI_LeftBracket),
+        Key.backetRight.rawValue: CGKeyCode(kVK_ANSI_RightBracket)
+    ]
 }

--- a/Modules/KeyKit/Tests/KeyKitTests/KeyKitTests.swift
+++ b/Modules/KeyKit/Tests/KeyKitTests/KeyKitTests.swift
@@ -6,6 +6,35 @@ import Carbon
 import XCTest
 
 final class KeyKitTests: XCTestCase {
+    private static let commonShortcutKeys: [(Key, CGKeyCode)] = [
+        (.a, CGKeyCode(kVK_ANSI_A)),
+        (.c, CGKeyCode(kVK_ANSI_C)),
+        (.e, CGKeyCode(kVK_ANSI_E)),
+        (.k, CGKeyCode(kVK_ANSI_K)),
+        (.u, CGKeyCode(kVK_ANSI_U)),
+        (.v, CGKeyCode(kVK_ANSI_V)),
+        (.w, CGKeyCode(kVK_ANSI_W)),
+        (.x, CGKeyCode(kVK_ANSI_X)),
+        (.z, CGKeyCode(kVK_ANSI_Z))
+    ]
+
+    private static let nonCommandModifierSets: [CGEventFlags] = [
+        .maskShift,
+        .maskAlternate,
+        .maskControl,
+        [.maskControl, .maskShift],
+        [.maskAlternate, .maskShift],
+        [.maskControl, .maskAlternate]
+    ]
+
+    private static let commandModifierSets: [CGEventFlags] = [
+        .maskCommand,
+        [.maskCommand, .maskShift],
+        [.maskCommand, .maskAlternate],
+        [.maskCommand, .maskControl],
+        [.maskCommand, .maskShift, .maskAlternate, .maskControl]
+    ]
+
     private func characterMapping(
         inputSourceID: String,
         modifierKeyState: UInt32 = 0
@@ -43,11 +72,15 @@ final class KeyKitTests: XCTestCase {
         wait(for: [expectation], timeout: 5)
     }
 
-    func testKeyCodeResolverUsesCommandLayerForRussianLayout() throws {
+    func testKeyCodeResolverSupportsCommonModifierShortcutsInRussianLayout() throws {
         let russianMapping = try characterMapping(inputSourceID: "com.apple.keylayout.Russian")
         let russianCommandMapping = try characterMapping(
             inputSourceID: "com.apple.keylayout.Russian",
             modifierKeyState: UInt32(cmdKey >> 8)
+        )
+        let russianControlMapping = try characterMapping(
+            inputSourceID: "com.apple.keylayout.Russian",
+            modifierKeyState: UInt32(controlKey >> 8)
         )
 
         XCTAssertNil(russianMapping[Key.c.rawValue])
@@ -61,10 +94,29 @@ final class KeyKitTests: XCTestCase {
             commandModified ? [russianCommandMapping, russianMapping] : [russianMapping]
         }
 
-        XCTAssertNil(resolver.keyCode(for: .c))
-        XCTAssertNil(resolver.keyCode(for: .v))
-        XCTAssertEqual(resolver.keyCode(for: .c, modifiers: .maskCommand), 0x08)
-        XCTAssertEqual(resolver.keyCode(for: .v, modifiers: .maskCommand), 0x09)
+        for (key, ansiKeyCode) in Self.commonShortcutKeys {
+            XCTAssertEqual(resolver.key(from: ansiKeyCode), key)
+
+            for modifiers in Self.nonCommandModifierSets {
+                XCTAssertEqual(resolver.keyCode(for: key, modifiers: modifiers), ansiKeyCode)
+            }
+            for modifiers in Self.commandModifierSets {
+                XCTAssertEqual(resolver.keyCode(for: key, modifiers: modifiers), ansiKeyCode)
+            }
+
+            let asciiValue = try XCTUnwrap(key.rawValue.utf8.first)
+            let controlCharacter = String(UnicodeScalar(asciiValue & 0x1F))
+            XCTAssertEqual(russianControlMapping[controlCharacter], ansiKeyCode)
+        }
+    }
+
+    func testANSICharacterMappingMatchesBuiltInUSLayout() throws {
+        let usMapping = try characterMapping(inputSourceID: "com.apple.keylayout.US")
+
+        XCTAssertEqual(KeyCodeResolver.ansiCharacterMapping.count, 47)
+        for (character, keyCode) in KeyCodeResolver.ansiCharacterMapping {
+            XCTAssertEqual(usMapping[character], keyCode)
+        }
     }
 
     func testKeyCodeResolverDoesNotForceANSIPositionForDvorak() throws {
@@ -73,13 +125,25 @@ final class KeyKitTests: XCTestCase {
             inputSourceID: "com.apple.keylayout.Dvorak",
             modifierKeyState: UInt32(cmdKey >> 8)
         )
-        let ansiFallback = [Key.v.rawValue: CGKeyCode(kVK_ANSI_V)]
         let resolver = KeyCodeResolver { commandModified in
-            commandModified ? [dvorakCommandMapping, dvorakMapping, ansiFallback] : [dvorakMapping]
+            commandModified ? [dvorakCommandMapping, dvorakMapping] : [dvorakMapping]
         }
 
-        XCTAssertEqual(resolver.keyCode(for: .v, modifiers: .maskCommand), 0x2F)
-        XCTAssertNotEqual(resolver.keyCode(for: .v, modifiers: .maskCommand), CGKeyCode(kVK_ANSI_V))
+        let modifierSets: [CGEventFlags] = [
+            .maskShift,
+            .maskAlternate,
+            .maskControl,
+            .maskCommand,
+            [.maskCommand, .maskShift],
+            [.maskCommand, .maskAlternate],
+            [.maskCommand, .maskControl]
+        ]
+
+        for modifiers in modifierSets {
+            XCTAssertEqual(resolver.keyCode(for: .v, modifiers: modifiers), 0x2F)
+            XCTAssertNotEqual(resolver.keyCode(for: .v, modifiers: modifiers), CGKeyCode(kVK_ANSI_V))
+        }
+        XCTAssertEqual(resolver.key(from: 0x2F), .v)
     }
 
     func testPressKey() throws {


### PR DESCRIPTION
## Summary

- keep active keyboard-layout mappings first for layout-aware shortcuts
- fall back to standard ANSI positions when the active layout has no Latin key
- cover Shift, Option, Control, Command, and combined modifier shortcuts
- verify common Control shortcuts against Russian control characters
- verify Dvorak positions are not overridden and ANSI constants match the built-in U.S. layout

## Testing

- swift test in Modules/KeyKit
- xcodebuild test -project LinearMouse.xcodeproj -scheme LinearMouse
- make lint

Follow-up to #1287.