### PR TITLE
Fix Logitech startup QoS inversions

### DIFF
--- a/LinearMouse/Device/Device+HardwareDPI.swift
+++ b/LinearMouse/Device/Device+HardwareDPI.swift
@@ -6,7 +6,7 @@ import Foundation
 extension Device {
     private static let hardwareDPIQueue = DispatchQueue(
         label: "app.linearmouse.hardware-dpi",
-        qos: .userInitiated
+        qos: .default
     )
 
     struct HardwareDPIInfo: Equatable {

--- a/LinearMouse/Device/Device+HighResolutionWheel.swift
+++ b/LinearMouse/Device/Device+HighResolutionWheel.swift
@@ -11,7 +11,7 @@ extension Device {
 
     private static let highResolutionWheelQueue = DispatchQueue(
         label: "app.linearmouse.high-resolution-wheel",
-        qos: .userInitiated
+        qos: .default
     )
 
     struct HighResolutionWheelInfo: Equatable {

--- a/LinearMouse/Device/VendorSpecific/Logitech/LogitechHIDPPDeviceMetadataProvider.swift
+++ b/LinearMouse/Device/VendorSpecific/Logitech/LogitechHIDPPDeviceMetadataProvider.swift
@@ -1154,7 +1154,8 @@ final class LogitechReceiverChannel: VendorSpecificDeviceContext {
         maxOutputReportSize = Self.getProperty("MaxOutputReportSize", from: device)
         maxFeatureReportSize = Self.getProperty("MaxFeatureReportSize", from: device)
         ioQueue = DispatchQueue(
-            label: "com.lujjjh.dev.LinearMouse.LogitechReceiverChannel.\(locationID ?? 0)"
+            label: "app.linearmouse.logitech-receiver.\(locationID ?? 0)",
+            qos: .default
         )
         inputReportBufferLength = max(
             maxInputReportSize ?? LogitechHIDPPDeviceMetadataProvider.Constants.longReportLength,


### PR DESCRIPTION
## Summary

- run Logitech hardware DPI, high-resolution wheel, and receiver callback work at the same default QoS
- avoid user-initiated configuration queues synchronously waiting on lower-priority HID callbacks
- replace the development-specific receiver queue label with a neutral app label

## Testing

- Xcode Thread Performance Checker with a Bolt receiver and MX Master: 6 startup diagnostics before, 0 after
- verified receiver discovery and app shutdown with 0 Thread Performance Checker diagnostics
- xcodebuild test -project LinearMouse.xcodeproj -scheme LinearMouse -destination platform=macOS
- make lint