### PR TITLE
Prevent stale process metadata after PID reuse

### DIFF
--- a/LinearMouse/EventTransformer/EventTransformerManager.swift
+++ b/LinearMouse/EventTransformer/EventTransformerManager.swift
@@ -19,7 +19,7 @@ class EventTransformerManager {
 
     struct CacheKey: Hashable {
         var deviceMatcher: DeviceMatcher?
-        var pid: pid_t?
+        var process: ProcessIdentity?
         var screen: String?
     }
 
@@ -133,34 +133,48 @@ class EventTransformerManager {
         }
 
         let pid = mouseLocationPid ?? targetPid
+        let process = pid?.processIdentity
         let device = DeviceManager.shared.deviceFromCGEvent(cgEvent)
 
         return .init(
-            transformer: get(withDevice: device, withPid: pid, withDisplay: display, updateActiveCacheKey: true),
+            transformer: get(
+                withDevice: device,
+                withProcess: process,
+                withDisplay: display,
+                updateActiveCacheKey: true
+            ),
             context: .init(device: device)
         )
     }
 
     func get(withDevice device: Device?, withPid pid: pid_t?, withDisplay display: String?) -> EventTransformer {
+        get(withDevice: device, withProcess: pid?.processIdentity, withDisplay: display)
+    }
+
+    func get(
+        withDevice device: Device?,
+        withProcess process: ProcessIdentity?,
+        withDisplay display: String?
+    ) -> EventTransformer {
         if EventThread.shared.isCurrent {
-            return getOnCurrentThread(withDevice: device, withPid: pid, withDisplay: display)
+            return getOnCurrentThread(withDevice: device, withProcess: process, withDisplay: display)
         }
 
         if let transformer = EventThread.shared.performAndWait({
-            self.getOnCurrentThread(withDevice: device, withPid: pid, withDisplay: display)
+            self.getOnCurrentThread(withDevice: device, withProcess: process, withDisplay: display)
         }) {
             return transformer
         }
 
-        return getOnCurrentThread(withDevice: device, withPid: pid, withDisplay: display)
+        return getOnCurrentThread(withDevice: device, withProcess: process, withDisplay: display)
     }
 
     private func getOnCurrentThread(
         withDevice device: Device?,
-        withPid pid: pid_t?,
+        withProcess process: ProcessIdentity?,
         withDisplay display: String?
     ) -> EventTransformer {
-        get(withDevice: device, withPid: pid, withDisplay: display, updateActiveCacheKey: false)
+        get(withDevice: device, withProcess: process, withDisplay: display, updateActiveCacheKey: false)
     }
 
     func handleLogitechControlEvent(_ context: LogitechEventContext) -> LogitechControlEventHandlingResult {
@@ -187,7 +201,7 @@ class EventTransformerManager {
 
     private func get(
         withDevice device: Device?,
-        withPid pid: pid_t?,
+        withProcess process: ProcessIdentity?,
         withDisplay display: String?,
         updateActiveCacheKey: Bool
     ) -> EventTransformer {
@@ -208,7 +222,7 @@ class EventTransformerManager {
 
         let cacheKey = CacheKey(
             deviceMatcher: device.map { DeviceMatcher(of: $0) },
-            pid: pid,
+            process: process,
             screen: display
         )
         if updateActiveCacheKey {
@@ -220,7 +234,7 @@ class EventTransformerManager {
 
         let scheme = ConfigurationState.shared.configuration.matchScheme(
             withDevice: device,
-            withPid: pid,
+            withProcess: process,
             withDisplay: display
         )
 
@@ -232,7 +246,7 @@ class EventTransformerManager {
             type: .info,
             String(describing: scheme),
             String(describing: device),
-            String(describing: pid),
+            String(describing: process?.pid),
             String(describing: display)
         )
 

--- a/LinearMouse/Model/Configuration/Configuration.swift
+++ b/LinearMouse/Model/Configuration/Configuration.swift
@@ -175,12 +175,24 @@ extension Configuration {
     ) -> Scheme {
         matchScheme(
             withDevice: device,
-            withApp: pid?.bundleIdentifier,
-            withParentApp: pid?.parent?.bundleIdentifier,
-            withGroupApp: pid?.group?.bundleIdentifier,
+            withProcess: pid?.processIdentity,
+            withDisplay: display
+        )
+    }
+
+    func matchScheme(
+        withDevice device: Device? = nil,
+        withProcess process: ProcessIdentity? = nil,
+        withDisplay display: String? = nil
+    ) -> Scheme {
+        matchScheme(
+            withDevice: device,
+            withApp: process?.bundleIdentifier,
+            withParentApp: process?.parent?.bundleIdentifier,
+            withGroupApp: process?.group?.bundleIdentifier,
             withDisplay: display,
-            withProcessName: pid?.processName,
-            withProcessPath: pid?.processPath
+            withProcessName: process?.processName,
+            withProcessPath: process?.processPath
         )
     }
 }

--- a/LinearMouse/Utilities/Extensions.swift
+++ b/LinearMouse/Utilities/Extensions.swift
@@ -80,43 +80,70 @@ func formattedPercent<Value: BinaryInteger>(_ value: Value) -> String {
         ?? "\(value)%"
 }
 
-extension pid_t {
-    private static var bundleIdentifierCache = LRUCache<Self, String>(countLimit: 16)
-    private static var processPathCache = LRUCache<Self, String>(countLimit: 16)
-    private static var processNameCache = LRUCache<Self, String>(countLimit: 16)
+struct ProcessCacheKey: Hashable {
+    let pid: pid_t
+    let startTimeSeconds: UInt64
+    let startTimeMicroseconds: UInt64
+}
 
-    var bundleIdentifier: String? {
-        guard let bundleIdentifier = Self.bundleIdentifierCache.value(forKey: self)
-            ?? NSRunningApplication(processIdentifier: self)?.bundleIdentifier
-        else {
+final class ProcessMetadataCache<Value> {
+    private let cache: LRUCache<ProcessCacheKey, Value>
+
+    init(countLimit: Int) {
+        cache = LRUCache(countLimit: countLimit)
+    }
+
+    func value(for key: ProcessCacheKey?, load: () -> Value?) -> Value? {
+        if let key, let cached = cache.value(forKey: key) {
+            return cached
+        }
+
+        guard let value = load() else {
             return nil
         }
 
-        Self.bundleIdentifierCache.setValue(bundleIdentifier, forKey: self)
+        if let key {
+            cache.setValue(value, forKey: key)
+        }
 
-        return bundleIdentifier
+        return value
+    }
+}
+
+extension pid_t {
+    private static let bundleIdentifierCache = ProcessMetadataCache<String>(countLimit: 16)
+    private static let processPathCache = ProcessMetadataCache<String>(countLimit: 16)
+    private static let processNameCache = ProcessMetadataCache<String>(countLimit: 16)
+
+    private var cacheKey: ProcessCacheKey? {
+        let info = getProcessInfo(self)
+        guard info.startTimeSeconds > 0 else {
+            return nil
+        }
+
+        return ProcessCacheKey(
+            pid: self,
+            startTimeSeconds: info.startTimeSeconds,
+            startTimeMicroseconds: info.startTimeMicroseconds
+        )
+    }
+
+    var bundleIdentifier: String? {
+        Self.bundleIdentifierCache.value(for: cacheKey) {
+            NSRunningApplication(processIdentifier: self)?.bundleIdentifier
+        }
     }
 
     var processPath: String? {
-        if let cached = Self.processPathCache.value(forKey: self) {
-            return cached
+        Self.processPathCache.value(for: cacheKey) {
+            NSRunningApplication(processIdentifier: self)?.executableURL?.path
         }
-        guard let path = NSRunningApplication(processIdentifier: self)?.executableURL?.path else {
-            return nil
-        }
-        Self.processPathCache.setValue(path, forKey: self)
-        return path
     }
 
     var processName: String? {
-        if let cached = Self.processNameCache.value(forKey: self) {
-            return cached
+        Self.processNameCache.value(for: cacheKey) {
+            NSRunningApplication(processIdentifier: self)?.executableURL?.lastPathComponent
         }
-        guard let name = NSRunningApplication(processIdentifier: self)?.executableURL?.lastPathComponent else {
-            return nil
-        }
-        Self.processNameCache.setValue(name, forKey: self)
-        return name
     }
 
     var parent: pid_t? {

--- a/LinearMouse/Utilities/Extensions.swift
+++ b/LinearMouse/Utilities/Extensions.swift
@@ -80,20 +80,59 @@ func formattedPercent<Value: BinaryInteger>(_ value: Value) -> String {
         ?? "\(value)%"
 }
 
-struct ProcessCacheKey: Hashable {
+struct ProcessIdentity: Hashable {
     let pid: pid_t
     let startTimeSeconds: UInt64
     let startTimeMicroseconds: UInt64
+
+    init(pid: pid_t, startTimeSeconds: UInt64, startTimeMicroseconds: UInt64) {
+        self.pid = pid
+        self.startTimeSeconds = startTimeSeconds
+        self.startTimeMicroseconds = startTimeMicroseconds
+    }
+
+    init?(pid: pid_t) {
+        let info = getProcessInfo(pid)
+        guard info.startTimeSeconds > 0 else {
+            return nil
+        }
+
+        self.init(
+            pid: pid,
+            startTimeSeconds: info.startTimeSeconds,
+            startTimeMicroseconds: info.startTimeMicroseconds
+        )
+    }
+
+    var bundleIdentifier: String? {
+        pid.bundleIdentifier(for: self)
+    }
+
+    var processPath: String? {
+        pid.processPath(for: self)
+    }
+
+    var processName: String? {
+        pid.processName(for: self)
+    }
+
+    var parent: Self? {
+        pid.parent.flatMap { Self(pid: $0) }
+    }
+
+    var group: Self? {
+        pid.group.flatMap { Self(pid: $0) }
+    }
 }
 
 final class ProcessMetadataCache<Value> {
-    private let cache: LRUCache<ProcessCacheKey, Value>
+    private let cache: LRUCache<ProcessIdentity, Value>
 
     init(countLimit: Int) {
         cache = LRUCache(countLimit: countLimit)
     }
 
-    func value(for key: ProcessCacheKey?, load: () -> Value?) -> Value? {
+    func value(for key: ProcessIdentity?, load: () -> Value?) -> Value? {
         if let key, let cached = cache.value(forKey: key) {
             return cached
         }
@@ -115,33 +154,36 @@ extension pid_t {
     private static let processPathCache = ProcessMetadataCache<String>(countLimit: 16)
     private static let processNameCache = ProcessMetadataCache<String>(countLimit: 16)
 
-    private var cacheKey: ProcessCacheKey? {
-        let info = getProcessInfo(self)
-        guard info.startTimeSeconds > 0 else {
-            return nil
-        }
-
-        return ProcessCacheKey(
-            pid: self,
-            startTimeSeconds: info.startTimeSeconds,
-            startTimeMicroseconds: info.startTimeMicroseconds
-        )
+    var processIdentity: ProcessIdentity? {
+        ProcessIdentity(pid: self)
     }
 
     var bundleIdentifier: String? {
-        Self.bundleIdentifierCache.value(for: cacheKey) {
+        bundleIdentifier(for: processIdentity)
+    }
+
+    fileprivate func bundleIdentifier(for processIdentity: ProcessIdentity?) -> String? {
+        Self.bundleIdentifierCache.value(for: processIdentity) {
             NSRunningApplication(processIdentifier: self)?.bundleIdentifier
         }
     }
 
     var processPath: String? {
-        Self.processPathCache.value(for: cacheKey) {
+        processPath(for: processIdentity)
+    }
+
+    fileprivate func processPath(for processIdentity: ProcessIdentity?) -> String? {
+        Self.processPathCache.value(for: processIdentity) {
             NSRunningApplication(processIdentifier: self)?.executableURL?.path
         }
     }
 
     var processName: String? {
-        Self.processNameCache.value(for: cacheKey) {
+        processName(for: processIdentity)
+    }
+
+    fileprivate func processName(for processIdentity: ProcessIdentity?) -> String? {
+        Self.processNameCache.value(for: processIdentity) {
             NSRunningApplication(processIdentifier: self)?.executableURL?.lastPathComponent
         }
     }

--- a/LinearMouse/Utilities/Process.h
+++ b/LinearMouse/Utilities/Process.h
@@ -6,6 +6,8 @@
 typedef struct ProcessInfo {
     pid_t ppid;
     pid_t pgid;
+    uint64_t startTimeSeconds;
+    uint64_t startTimeMicroseconds;
 } ProcessInfo;
 
 ProcessInfo getProcessInfo(pid_t pid);

--- a/LinearMouse/Utilities/Process.m
+++ b/LinearMouse/Utilities/Process.m
@@ -11,6 +11,8 @@ ProcessInfo getProcessInfo(pid_t pid) {
 
     pi.ppid = info.kp_eproc.e_ppid;
     pi.pgid = info.kp_eproc.e_pgid;
+    pi.startTimeSeconds = info.kp_proc.p_starttime.tv_sec;
+    pi.startTimeMicroseconds = info.kp_proc.p_starttime.tv_usec;
 
     return pi;
 }

--- a/LinearMouseUnitTests/EventTransformer/EventTransformerManagerTests.swift
+++ b/LinearMouseUnitTests/EventTransformer/EventTransformerManagerTests.swift
@@ -17,16 +17,51 @@ final class EventTransformerManagerTests: XCTestCase {
         let matcher = DeviceMatcher(category: .mouse)
         let firstKey = EventTransformerManager.CacheKey(
             deviceMatcher: matcher,
-            pid: nil,
+            process: nil,
             screen: nil
         )
         let secondKey = EventTransformerManager.CacheKey(
             deviceMatcher: matcher,
-            pid: nil,
+            process: nil,
             screen: nil
         )
 
         XCTAssertEqual(firstKey, secondKey)
+    }
+
+    func testTransformerCacheDoesNotReuseValueForNewProcess() throws {
+        ConfigurationState.shared.configuration = .init(schemes: [
+            Scheme(scrolling: .init(reverse: .init(vertical: true)))
+        ])
+        let firstProcess = ProcessIdentity(pid: 42, startTimeSeconds: 100, startTimeMicroseconds: 1)
+        let secondProcess = ProcessIdentity(pid: 42, startTimeSeconds: 200, startTimeMicroseconds: 2)
+        let firstTransformer = EventTransformerManager.shared.get(
+            withDevice: nil,
+            withProcess: firstProcess,
+            withDisplay: nil
+        )
+        let cachedFirstTransformer = EventTransformerManager.shared.get(
+            withDevice: nil,
+            withProcess: firstProcess,
+            withDisplay: nil
+        )
+        let secondTransformer = EventTransformerManager.shared.get(
+            withDevice: nil,
+            withProcess: secondProcess,
+            withDisplay: nil
+        )
+        let firstReverseTransformer = try XCTUnwrap((firstTransformer as? [EventTransformer])?
+            .compactMap { $0 as? ReverseScrollingTransformer }
+            .first)
+        let cachedFirstReverseTransformer = try XCTUnwrap((cachedFirstTransformer as? [EventTransformer])?
+            .compactMap { $0 as? ReverseScrollingTransformer }
+            .first)
+        let secondReverseTransformer = try XCTUnwrap((secondTransformer as? [EventTransformer])?
+            .compactMap { $0 as? ReverseScrollingTransformer }
+            .first)
+
+        XCTAssertIdentical(firstReverseTransformer, cachedFirstReverseTransformer)
+        XCTAssertNotIdentical(firstReverseTransformer, secondReverseTransformer)
     }
 
     func testSyntheticSmoothedEventStillGetsModifierActions() throws {

--- a/LinearMouseUnitTests/Utilities/ProcessEnvironmentTests.swift
+++ b/LinearMouseUnitTests/Utilities/ProcessEnvironmentTests.swift
@@ -8,4 +8,13 @@ final class ProcessEnvironmentTests: XCTestCase {
     func testUnitTestHostIsDetectedAsRunningTest() {
         XCTAssertTrue(ProcessEnvironment.isRunningTest)
     }
+
+    func testProcessMetadataCacheDoesNotReuseValueForNewProcess() {
+        let cache = ProcessMetadataCache<String>(countLimit: 16)
+        let firstProcess = ProcessCacheKey(pid: 42, startTimeSeconds: 100, startTimeMicroseconds: 1)
+        let secondProcess = ProcessCacheKey(pid: 42, startTimeSeconds: 200, startTimeMicroseconds: 2)
+
+        XCTAssertEqual(cache.value(for: firstProcess) { "First" }, "First")
+        XCTAssertEqual(cache.value(for: secondProcess) { "Second" }, "Second")
+    }
 }

--- a/LinearMouseUnitTests/Utilities/ProcessEnvironmentTests.swift
+++ b/LinearMouseUnitTests/Utilities/ProcessEnvironmentTests.swift
@@ -11,8 +11,8 @@ final class ProcessEnvironmentTests: XCTestCase {
 
     func testProcessMetadataCacheDoesNotReuseValueForNewProcess() {
         let cache = ProcessMetadataCache<String>(countLimit: 16)
-        let firstProcess = ProcessCacheKey(pid: 42, startTimeSeconds: 100, startTimeMicroseconds: 1)
-        let secondProcess = ProcessCacheKey(pid: 42, startTimeSeconds: 200, startTimeMicroseconds: 2)
+        let firstProcess = ProcessIdentity(pid: 42, startTimeSeconds: 100, startTimeMicroseconds: 1)
+        let secondProcess = ProcessIdentity(pid: 42, startTimeSeconds: 200, startTimeMicroseconds: 2)
 
         XCTAssertEqual(cache.value(for: firstProcess) { "First" }, "First")
         XCTAssertEqual(cache.value(for: secondProcess) { "Second" }, "Second")


### PR DESCRIPTION
Process metadata and event transformers were cached only by PID. When macOS reuses a PID, LinearMouse can read the previous process metadata or return its transformer before matching the new process.

Resolve one process identity containing the PID and start time, then use it for metadata lookup, scheme matching, and transformer cache keys. Repeated events from the same process still reuse their cached values.

Test: DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild test -quiet -project LinearMouse.xcodeproj -scheme LinearMouse -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO (305 passed)