### PR TITLE
docs: fix Title Case headings and singular noun in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,10 +1,10 @@
-# Contributing guide
+# Contributing Guide
 
 Thank you for investing your time in contributing to LinearMouse!
 
 Read our [Code of Conduct](CODE_OF_CONDUCT.md) to keep our community approachable and respectable.
 
-## Build instructions
+## Build Instructions
 
 Instructions for building LinearMouse on macOS.
 
@@ -46,7 +46,7 @@ $ make configure
 
 If there are no available code signing certificates in your Keychain, it will generate a configuration that uses ad-hoc certificates to sign the app.
 
-By using ad-hoc certificates, you'll have to [grant accessibility permissions](https://github.com/linearmouse/linearmouse#accessibility-permission) for each builds.
+By using ad-hoc certificates, you'll have to [grant accessibility permissions](https://github.com/linearmouse/linearmouse#accessibility-permission) for each build.
 In that case, using Apple Development certificates is recommended.
 You can create an Apple Development certificate [in Xcode](https://help.apple.com/xcode/mac/current/#/dev154b28f09), which is totally free.
 


### PR DESCRIPTION
## Description
This PR fixes section heading Title Case and grammar in `CONTRIBUTING.md`.

## Details
1. Capitalized headings (`# Contributing guide` -> `# Contributing Guide`, `## Build instructions` -> `## Build Instructions`).
2. Fixed plural/singular noun agreement (`for each builds` -> `for each build`).