### PR TITLE
Support ELECOM HUGE TrackBall Fn buttons

### DIFF
--- a/LinearMouse/Device/InputReportHandler.swift
+++ b/LinearMouse/Device/InputReportHandler.swift
@@ -59,7 +59,8 @@ extension InputReportHandler {
 enum InputReportHandlerRegistry {
     static let handlers: [InputReportHandler] = [
         GenericSideButtonHandler(),
-        KensingtonSlimbladeHandler()
+        KensingtonSlimbladeHandler(),
+        ElecomTrackballHandler()
     ]
 
     static func handlers(for vendorID: Int, productID: Int) -> [InputReportHandler] {

--- a/LinearMouse/Device/InputReportHandlers/ElecomTrackballHandler.swift
+++ b/LinearMouse/Device/InputReportHandlers/ElecomTrackballHandler.swift
@@ -1,0 +1,83 @@
+// MIT License
+// Copyright (c) 2021-2026 LinearMouse
+
+import Foundation
+
+/// Handles the extra Fn buttons of ELECOM trackballs.
+///
+/// The HID report descriptor of these devices declares only 5 buttons in its mouse
+/// collection, which are taken up by left, right, middle and the two thumb buttons.
+/// The remaining Fn buttons are still reported in the same input report, but in the
+/// three bits that the descriptor declares as padding, so macOS discards them and no
+/// `otherMouseDown` event is ever generated.
+///
+/// This handler reads those undeclared bits out of the raw input report and simulates
+/// the corresponding button events.
+///
+/// Other ELECOM trackballs share this report layout, so they can be supported by adding
+/// their product IDs below once the layout has been confirmed on the device.
+///
+/// Supported devices:
+/// - ELECOM HUGE TrackBall (0x056E:0x010C)
+struct ElecomTrackballHandler: InputReportHandler {
+    private struct Product: Hashable {
+        let vendorID: Int
+        let productID: Int
+    }
+
+    private static let supportedProducts: Set<Product> = [
+        .init(vendorID: 0x056E, productID: 0x010C) // ELECOM HUGE TrackBall
+    ]
+
+    /// Report format: | Button 0 (1 bit) | ... | Button 4 (1 bit) | Fn buttons (3 bits) |
+    ///
+    /// Buttons 0 to 4 are declared in the report descriptor and handled by macOS, so only
+    /// the upper three bits are of interest here.
+    private static let fnButtonsMask: UInt8 = 0xE0
+
+    /// Bit 5 to 7 are mapped to button 5 to 7, the first button numbers not already used by
+    /// the buttons macOS recognizes.
+    private static let fnButtonBits = 5 ... 7
+
+    private let emit: MouseButtonEmitter
+
+    init(emit: @escaping MouseButtonEmitter = SyntheticMouseButtonEventEmitter.post) {
+        self.emit = emit
+    }
+
+    func matches(vendorID: Int, productID: Int) -> Bool {
+        Self.supportedProducts.contains(.init(vendorID: vendorID, productID: productID))
+    }
+
+    func alwaysNeedsReportObservation() -> Bool {
+        // The device reports 5 buttons, so the button count heuristic would not enable
+        // report observation on its own.
+        true
+    }
+
+    func handleReport(_ context: InputReportContext, next: (InputReportContext) -> Void) {
+        defer { next(context) }
+
+        // Byte 0 is the report ID, byte 1 holds the button states.
+        guard context.report.count >= 2, context.report[0] == 0x01 else {
+            return
+        }
+
+        let buttonStates = context.report[1] & Self.fnButtonsMask
+        let toggled = context.lastButtonStates ^ buttonStates
+
+        guard toggled != 0 else {
+            return
+        }
+
+        for button in Self.fnButtonBits {
+            guard toggled & (1 << button) != 0 else {
+                continue
+            }
+            let down = buttonStates & (1 << button) != 0
+            emit(button, down)
+        }
+
+        context.lastButtonStates = buttonStates
+    }
+}

--- a/LinearMouseUnitTests/Device/InputReportHandlerTests.swift
+++ b/LinearMouseUnitTests/Device/InputReportHandlerTests.swift
@@ -268,6 +268,135 @@ final class InputReportHandlerTests: XCTestCase {
         XCTAssertEqual(recorder.events.map(\.down), [true, true])
     }
 
+    // MARK: - ElecomTrackballHandler Tests
+
+    /// Builds a report in the format observed from an ELECOM HUGE TrackBall:
+    /// byte 0 is the report ID, byte 1 holds the button states.
+    private func elecomReport(buttons: UInt8) -> Data {
+        Data([0x01, buttons, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00])
+    }
+
+    func testElecomHandlerMatchesHugeTrackball() {
+        let handler = ElecomTrackballHandler()
+
+        XCTAssertTrue(handler.matches(vendorID: 0x056E, productID: 0x010C))
+    }
+
+    func testElecomHandlerDoesNotMatchOtherDevice() {
+        let handler = ElecomTrackballHandler()
+
+        XCTAssertFalse(handler.matches(vendorID: 0x1234, productID: 0x5678))
+    }
+
+    func testElecomHandlerAlwaysNeedsReportObservation() {
+        let handler = ElecomTrackballHandler()
+
+        XCTAssertTrue(handler.alwaysNeedsReportObservation())
+    }
+
+    func testElecomHandlerCallsNext() {
+        let handler = ElecomTrackballHandler { _, _ in }
+        let context = InputReportContext(report: elecomReport(buttons: 0x00), lastButtonStates: 0x00)
+
+        var nextCalled = false
+        handler.handleReport(context) { _ in
+            nextCalled = true
+        }
+
+        XCTAssertTrue(nextCalled)
+    }
+
+    func testElecomHandlerCallsNextEvenWithShortReport() {
+        let handler = ElecomTrackballHandler { _, _ in }
+        let context = InputReportContext(report: Data([0x01]), lastButtonStates: 0x00)
+
+        var nextCalled = false
+        handler.handleReport(context) { _ in
+            nextCalled = true
+        }
+
+        XCTAssertTrue(nextCalled)
+    }
+
+    func testElecomHandlerDetectsFnButtons() {
+        // Bit 5, 6 and 7 are the three buttons the report descriptor declares as padding.
+        for (mask, button) in [(UInt8(0x20), 5), (UInt8(0x40), 6), (UInt8(0x80), 7)] {
+            let recorder = EmissionRecorder()
+            let handler = ElecomTrackballHandler(emit: recorder.emit)
+            let context = InputReportContext(report: elecomReport(buttons: mask), lastButtonStates: 0x00)
+
+            handler.handleReport(context) { _ in }
+
+            XCTAssertEqual(recorder.events.count, 1)
+            XCTAssertEqual(recorder.events.first?.button, button)
+            XCTAssertEqual(recorder.events.first?.down, true)
+            XCTAssertEqual(context.lastButtonStates, mask)
+        }
+    }
+
+    func testElecomHandlerEmitsReleaseOnUp() {
+        let recorder = EmissionRecorder()
+        let handler = ElecomTrackballHandler(emit: recorder.emit)
+        let context = InputReportContext(report: elecomReport(buttons: 0x00), lastButtonStates: 0x20)
+
+        handler.handleReport(context) { _ in }
+
+        XCTAssertEqual(recorder.events.count, 1)
+        XCTAssertEqual(recorder.events.first?.button, 5)
+        XCTAssertEqual(recorder.events.first?.down, false)
+        XCTAssertEqual(context.lastButtonStates, 0x00)
+    }
+
+    func testElecomHandlerDetectsMultipleFnButtonsAtOnce() {
+        let recorder = EmissionRecorder()
+        let handler = ElecomTrackballHandler(emit: recorder.emit)
+        let context = InputReportContext(report: elecomReport(buttons: 0xA0), lastButtonStates: 0x00)
+
+        handler.handleReport(context) { _ in }
+
+        XCTAssertEqual(recorder.events.count, 2)
+        XCTAssertEqual(recorder.events.map(\.button), [5, 7])
+        XCTAssertTrue(recorder.events.allSatisfy(\.down))
+        XCTAssertEqual(context.lastButtonStates, 0xA0)
+    }
+
+    /// Buttons 1 to 5 are declared in the report descriptor and already handled by macOS,
+    /// so the handler must not emit duplicate events for them.
+    func testElecomHandlerIgnoresDeclaredButtons() {
+        let recorder = EmissionRecorder()
+        let handler = ElecomTrackballHandler(emit: recorder.emit)
+        let context = InputReportContext(report: elecomReport(buttons: 0x1F), lastButtonStates: 0x00)
+
+        handler.handleReport(context) { _ in }
+
+        XCTAssertTrue(recorder.events.isEmpty)
+        XCTAssertEqual(context.lastButtonStates, 0x00)
+    }
+
+    func testElecomHandlerEmitsNothingWhenStateUnchanged() {
+        let recorder = EmissionRecorder()
+        let handler = ElecomTrackballHandler(emit: recorder.emit)
+        let context = InputReportContext(report: elecomReport(buttons: 0x20), lastButtonStates: 0x20)
+
+        handler.handleReport(context) { _ in }
+
+        XCTAssertTrue(recorder.events.isEmpty)
+        XCTAssertEqual(context.lastButtonStates, 0x20)
+    }
+
+    /// Only the mouse input report carries button states; the device also sends consumer and
+    /// vendor defined reports that must not be parsed as buttons.
+    func testElecomHandlerIgnoresOtherReportIDs() {
+        let recorder = EmissionRecorder()
+        let handler = ElecomTrackballHandler(emit: recorder.emit)
+        let context = InputReportContext(report: Data([0x05, 0xE0, 0x00]), lastButtonStates: 0x00)
+
+        handler.handleReport(context) { _ in }
+
+        XCTAssertTrue(recorder.events.isEmpty)
+        XCTAssertEqual(context.lastButtonStates, 0x00)
+    }
+
     // MARK: - InputReportHandlerRegistry Tests
 
     func testRegistryFindsMiMouseHandler() {
@@ -282,6 +411,13 @@ final class InputReportHandlerTests: XCTestCase {
 
         XCTAssertEqual(handlers.count, 1)
         XCTAssertTrue(handlers.first is KensingtonSlimbladeHandler)
+    }
+
+    func testRegistryFindsElecomHandler() {
+        let handlers = InputReportHandlerRegistry.handlers(for: 0x056E, productID: 0x010C)
+
+        XCTAssertEqual(handlers.count, 1)
+        XCTAssertTrue(handlers.first is ElecomTrackballHandler)
     }
 
     func testRegistryReturnsEmptyForUnknownDevice() {


### PR DESCRIPTION
## Summary

The ELECOM HUGE TrackBall has 8 buttons, but only 5 of them can be recorded or mapped in LinearMouse today. The remaining three (the Fn buttons) produce no event at all.

The cause is in the device's report descriptor. Its mouse collection declares only 5 buttons:

| Report ID | Contents |
| --- | --- |
| 1 | Button usages 1–5, X, Y, Wheel, AC Pan |
| 3 | System Power Down / Sleep / Wake |
| 4 | Vendor page `0xFEBC`, array of 47 usages |
| 5 | Consumer page, array of 573 usages |

Left, right, middle and the two thumb buttons take up all five declared buttons, so the Fn buttons cannot be buttons 6–8 in this layout. They are nevertheless reported in the *same* input report, in the three bits the descriptor declares as padding:

```
01 20 00 00 00 00 00 00     Fn button, byte 1 bit 5
01 00 00 00 00 00 00 00     released
01 40 00 00 00 00 00 00     Fn button, byte 1 bit 6
01 00 00 00 00 00 00 00     released
01 80 00 00 00 00 00 00     Fn button, byte 1 bit 7
01 00 00 00 00 00 00 00     released
```

macOS honours the descriptor and drops those bits, so no `otherMouseDown` is ever generated and there is nothing for the event tap to see. This is also why SteerMouse and USB Overdrive detect these buttons on a physically connected device — they read raw HID reports rather than CGEvents.

This PR adds an `InputReportHandler` that reads the three undeclared bits out of the raw input report and simulates button 5 to 7. It follows the same approach as the existing `KensingtonSlimbladeHandler`, which solves the same class of problem for the Slimblade's top buttons.

Two details worth noting for review:

- `alwaysNeedsReportObservation()` returns `true`. The device reports 5 buttons, so the existing `buttonCount == 3` heuristic in `Device` would never enable report observation for it.
- The handler only parses reports whose ID is `0x01`. The device also emits consumer and vendor-defined reports, whose second byte would otherwise be misread as button states.

## On making this more general

This deliberately stays device-scoped, because a general fix is a larger change than it first appears.

The mechanism itself — *buttons hidden in bits the descriptor declares as padding* — is not vendor specific, and it is exactly what `GenericSideButtonHandler` and `KensingtonSlimbladeHandler` already work around one device at a time. Handling it automatically for any device would mean parsing `kIOHIDReportDescriptorKey` to locate the button field and its trailing padding bits, then treating those bits as extra buttons. Because events are only emitted on a bit *toggle*, genuine padding that stays zero would produce nothing, so that approach is safer than it sounds.

The blocker is not the parsing but the observation cost: it would require enabling raw input report observation for every connected mouse, which the current architecture deliberately gates per device. That trade-off felt like it deserves its own PR and a maintainer's opinion rather than being bundled into a device fix, so I'm happy to follow up on #708 if you think the cost is acceptable.

There is also a reason to keep raw report handling as a *supplement* rather than a direction of travel. It only works for devices physically attached to the Mac running LinearMouse. Input forwarded from another Mac by Universal Control arrives as a virtual device — `V-HUGE TrackBall`, same VID/PID, in my case — and HID-level detection cannot reach it. That is reportedly why HID-only utilities do not work with continuity-forwarded devices at all, while LinearMouse's CGEvent-level transforms (reverse scrolling and so on) work fine on the receiving Mac. Whatever shape a general fix for #708 takes, the CGEvent pipeline should stay the primary path, with report parsing filling in only the buttons macOS discards.

In the meantime the product ID table in the handler makes other ELECOM trackballs a one-line addition once their layout is confirmed on hardware. I only own the HUGE, so I have not added models I cannot verify.

## Known limitation: forwarded input

The buttons this recovers exist only in the raw reports of a physically connected device, so they are only available on the Mac the trackball is attached to. In my testing, an Fn button mapped to middle click did not fire on a second Mac over Universal Control. I did not isolate whether Universal Control relays middle clicks at all, so I would not put that forward as a confirmed limitation of this change — but it should not be expected to work. Mapping the Fn buttons to keystrokes is the workaround, since keyboard input is forwarded.

## Testing

- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild test -project LinearMouse.xcodeproj -scheme LinearMouse -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO` — 315 passed. The 2 failures in `StatusItemBatteryIndicatorTests` are pre-existing and locale dependent (`"100 %"` vs `"100%"`, non-breaking space); they reproduce on an unmodified `main` in the same environment.
- `swiftformat --lint` and `swiftlint lint` clean on the changed files.
- 10 new unit tests covering each Fn bit, release on button up, simultaneous presses, unchanged state, the declared buttons 1–5 being left alone, and other report IDs being ignored.
- Verified on hardware with an ELECOM HUGE TrackBall (`0x056E:0x010C`, USB): all three Fn buttons are now recordable in Settings → Buttons as Button #5, #6 and #7, and mapped actions fire correctly.

Closes #1250

Refs #708 — this covers the button half of that report. The mouse wheel tilt detection also mentioned there is not addressed; the device reports tilt as AC Pan in report 1, which is a separate concern.
