### PR TITLE
fix(modifier): default Shift key to alterOrientation for horizontal scroll compatibility

### DIFF
--- a/LinearMouse/EventTransformer/ModifierActionsTransformer.swift
+++ b/LinearMouse/EventTransformer/ModifierActionsTransformer.swift
@@ -52,8 +52,9 @@ extension ModifierActionsTransformer: EventTransformer {
         ]
         var event = event
         for case let (flag, action) in actions where event.flags.contains(flag) {
-            if let action, action != .auto {
-                guard let handledEvent = handleModifierKeyAction(for: event, action: action) else {
+            let resolvedAction = (flag == .maskShift && (action == nil || action == .auto)) ? Action.alterOrientation : action
+            if let resolvedAction, resolvedAction != .auto {
+                guard let handledEvent = handleModifierKeyAction(for: event, action: resolvedAction) else {
                     return nil
                 }
                 event = handledEvent


### PR DESCRIPTION
## Description
This PR resolves issue #1301 by defaulting the Shift modifier to `alterOrientation` when no explicit action is defined (the `auto` / `nil` state).

## Details
- On macOS, holding Shift while scrolling natively changes vertical scroll into horizontal scroll.
- When LinearMouse handles scroll events (especially continuous/smoothed ones), the native macOS translation does not fire, causing Shift-scroll to stop working for many mice (like the MX Master 3S).
- By mapping Shift to `alterOrientation` as its default action, we preserve the native macOS Shift-scroll behavior out-of-the-box without requiring users to manually change configurations in the UI.