### PR TITLE
fix(autoscroll): treat AXTab accessibility elements as pressable to preserve native middle-click

### DIFF
--- a/LinearMouse/Accessibility/AutoScrollAccessibilityActivationClassifier.swift
+++ b/LinearMouse/Accessibility/AutoScrollAccessibilityActivationClassifier.swift
@@ -16,6 +16,7 @@ struct AutoScrollAccessibilityActivationClassifier {
         "AXMenuButton",
         "AXPopUpButton",
         "AXTabGroup",
+        "AXTab",
         "AXToolbar"
     ]
     private static let excludedSubroles: Set<String> = [
@@ -36,7 +37,8 @@ struct AutoScrollAccessibilityActivationClassifier {
         "AXMenuButton",
         "AXComboBox",
         "AXDisclosureTriangle",
-        "AXSwitch"
+        "AXSwitch",
+        "AXTab"
     ]
 
     private let elementQuery: AccessibilityElementQuerying


### PR DESCRIPTION
## Description
This PR resolves part of issue #1237 by adding `AXTab` to the pressable and excluded accessibility roles in `AutoScrollAccessibilityActivationClassifier.swift`.

## Details
- Previously, `AXTab` was missing from `pressableRoles` and `excludedRoles`. As a result, middle-clicking browser tabs (e.g. in Safari, Chrome, Firefox) often triggered the AutoScroll wheel overlay instead of closing or opening tabs natively.
- Adding `AXTab` ensures tab UI elements are classified as pressable and preserve native middle-click handling.