### PR TITLE
fix(smoothed-scrolling): establish minimum velocity floor for slow wheel ticks

### DIFF
--- a/LinearMouse/EventTransformer/SmoothedScrollingEngine.swift
+++ b/LinearMouse/EventTransformer/SmoothedScrollingEngine.swift
@@ -86,7 +86,9 @@ final class SmoothedScrollingEngine {
             let magnitude = baseMagnitude * curvedMagnitude
             let speedBoost = 0.85 + speed * 0.4
             let accelerationBoost = 1 + acceleration * profile.accelerationGain
-            let velocity = magnitude * profile.velocityScale * speedBoost * accelerationBoost
+            let calculatedVelocity = magnitude * profile.velocityScale * speedBoost * accelerationBoost
+            let minVelocity = baseMagnitude * 2.0 * speedBoost
+            let velocity = max(calculatedVelocity, minVelocity)
 
             return input.sign == .minus ? -velocity : velocity
         }


### PR DESCRIPTION
## Description
This PR resolves issue #1270 by establishing a minimum velocity floor in `SmoothedScrollingEngine.swift` for low-magnitude wheel inputs.

## Details
- Previously, `desiredVelocity` applied polynomial compression (`pow(normalizedMagnitude, inputExponent)`) to low-magnitude inputs. Single-notch wheel clicks resulted in near-zero velocity where the page failed to move.
- This PR introduces a minimum velocity floor based on input magnitude and speed boost (`max(calculatedVelocity, baseMagnitude * 2.0 * speedBoost)`), ensuring slow or discrete wheel clicks produce responsive scrolling.