### PR TITLE
fix(zoom): reset KeySimulator after simulated zoom keypresses to prevent modifier state leaks

### DIFF
--- a/LinearMouse/EventTransformer/ModifierActionsTransformer.swift
+++ b/LinearMouse/EventTransformer/ModifierActionsTransformer.swift
@@ -90,6 +90,7 @@ extension ModifierActionsTransformer: EventTransformer {
             } else {
                 try? Self.keySimulator.press(.command, .numpadMinus, tap: .cgSessionEventTap)
             }
+            Self.keySimulator.reset()
             return nil
         case .pinchZoom:
             pinchZoomReversed = false


### PR DESCRIPTION
## Description
This PR resolves issue #1210 by calling `Self.keySimulator.reset()` after synthesizing zoom keypresses in `ModifierActionsTransformer.swift`.

## Details
- Previously, repeated scroll events during modifier+scroll zoom accumulated synthetic keypress state in `KeySimulator`.
- Calling `Self.keySimulator.reset()` ensures key state is cleared after each zoom event, preventing accidental modifier/spacebar leakage.