### PR TITLE
fix(modifier): call keySimulator.reset() on transformer deactivate

### DIFF
--- a/LinearMouse/EventTransformer/ModifierActionsTransformer.swift
+++ b/LinearMouse/EventTransformer/ModifierActionsTransformer.swift
@@ -133,6 +133,7 @@ extension ModifierActionsTransformer: EventTransformer {
 
 extension ModifierActionsTransformer: Deactivatable {
     func deactivate() {
+        Self.keySimulator.reset()
         if pinchZoomBegan {
             pinchZoomBegan = false
             pinchZoomReversed = false


### PR DESCRIPTION
## Description
This PR resolves issue #1210 by calling `Self.keySimulator.reset()` in `deactivate()` inside `ModifierActionsTransformer.swift`.

## Details
- Resets key simulator state when the transformer is deactivated or when modifier keys release, preventing lingering simulated key events from interfering with hotkey triggers like Cmd+Space.