### PR TITLE
perf(device): use debug log level for property change observation in DeviceManager

### DIFF
--- a/LinearMouse/Device/DeviceManager.swift
+++ b/LinearMouse/Device/DeviceManager.swift
@@ -49,7 +49,7 @@ class DeviceManager: ObservableObject {
             "HIDUseLinearScalingMouseAcceleration"
         ] {
             manager.observePropertyChanged(property: property) { [self] _ in
-                os_log("Property %{public}@ changed", log: Self.log, type: .info, property)
+                os_log("Property %{public}@ changed", log: Self.log, type: .debug, property)
                 updatePointerSpeed()
             }.tieToLifetime(of: self)
         }


### PR DESCRIPTION
## Description
This PR resolves issue #1168 by changing the log level of HID property change notifications from `.info` to `.debug` in `DeviceManager.swift`.

## Details
- Prevents high-frequency HID property notifications (such as mouse acceleration or resolution updates) from filling system log buffers when idle or in motion.