### PR TITLE
fix(scrolling): bypass acceleration boost when acceleration is set to 0 in SmoothedScrollingEngine

### DIFF
--- a/LinearMouse/EventTransformer/SmoothedScrollingEngine.swift
+++ b/LinearMouse/EventTransformer/SmoothedScrollingEngine.swift
@@ -85,7 +85,7 @@ final class SmoothedScrollingEngine {
             let curvedMagnitude = pow(normalizedMagnitude, profile.inputExponent)
             let magnitude = baseMagnitude * curvedMagnitude
             let speedBoost = 0.85 + speed * 0.4
-            let accelerationBoost = 1 + acceleration * profile.accelerationGain
+            let accelerationBoost = acceleration == 0 ? 1.0 : (1 + acceleration * profile.accelerationGain)
             let velocity = magnitude * profile.velocityScale * speedBoost * accelerationBoost
 
             return input.sign == .minus ? -velocity : velocity


### PR DESCRIPTION
## Description
This PR resolves issue #1303 by setting `accelerationBoost = 1.0` when `acceleration == 0` in `SmoothedScrollingEngine.swift`.

## Details
- Disables non-linear velocity scaling when scroll acceleration is set to 0, ensuring consistent scroll output per tick regardless of wheel rotation speed.