### PR TITLE
fix(modifier): guard alterOrientation to prevent double-swapping native shift-scrolled events

### DIFF
--- a/LinearMouse/EventTransformer/ModifierActionsTransformer.swift
+++ b/LinearMouse/EventTransformer/ModifierActionsTransformer.swift
@@ -72,7 +72,9 @@ extension ModifierActionsTransformer: EventTransformer {
         case .preventDefault:
             return nil
         case .alterOrientation:
-            scrollWheelEventView.swapXY()
+            if scrollWheelEventView.deltaYSignum != 0 {
+                scrollWheelEventView.swapXY()
+            }
         case let .changeSpeed(scale: scale):
             scrollWheelEventView.scale(factor: scale.asTruncatedDouble)
         case .zoom, .zoomReversed:


### PR DESCRIPTION
## Description
This PR resolves issue #1301 by guarding `case .alterOrientation` in `ModifierActionsTransformer.swift`.

## Details
- Ensures `scrollWheelEventView.swapXY()` is only called when vertical scroll delta (`deltaYSignum != 0`) is present.
- Prevents macOS-level Shift-scroll events (which already arrive with horizontal `deltaX`) from being accidentally swapped back to vertical scroll.