### PR TITLE
fix(debouncing): suppress mouseUp when mouseDown is debounced to prevent orphaned click-drag events

### DIFF
--- a/LinearMouse/EventTransformer/ClickDebouncingTransformer.swift
+++ b/LinearMouse/EventTransformer/ClickDebouncingTransformer.swift
@@ -26,6 +26,7 @@ class ClickDebouncingTransformer: EventTransformer {
     }
 
     private var lastClickedAtInNanoseconds: UInt64 = 0
+    private var isDebouncingCurrentClick = false
 
     func transform(_ event: CGEvent, in _: EventTransformerContext) -> CGEvent? {
         guard [mouseDownEventType, mouseUpEventType].contains(event.type) else {
@@ -41,6 +42,7 @@ class ClickDebouncingTransformer: EventTransformer {
             let intervalSinceLastClick = intervalSinceLastClick
             touchLastClickedAt()
             if intervalSinceLastClick <= timeout {
+                isDebouncingCurrentClick = true
                 os_log(
                     "Mouse down ignored because interval since last click %{public}f <= %{public}f",
                     log: Self.log,
@@ -50,8 +52,13 @@ class ClickDebouncingTransformer: EventTransformer {
                 )
                 return nil
             }
+            isDebouncingCurrentClick = false
             return event
         case mouseUpEventType:
+            if isDebouncingCurrentClick {
+                isDebouncingCurrentClick = false
+                return nil
+            }
             if resetTimerOnMouseUp {
                 touchLastClickedAt()
             }


### PR DESCRIPTION
## Description
This PR resolves issue #1300 by suppressing paired `mouseUp` events when a `mouseDown` event is debounced in `ClickDebouncingTransformer.swift`.

## Details
- Tracks `isDebouncingCurrentClick` state during click debouncing.
- Ensures both `mouseDown` and `mouseUp` are suppressed for debounced clicks, preventing orphaned mouse events during multi-line text selection.