### PR TITLE
fix(autoscroll): preserve native middle-click in window title bars

### DIFF
--- a/LinearMouse/Accessibility/AccessibilityBypassRule.swift
+++ b/LinearMouse/Accessibility/AccessibilityBypassRule.swift
@@ -11,6 +11,24 @@ struct AccessibilityBypassRule {
 extension AccessibilityBypassRule {
     static let autoScrollRules: [AccessibilityBypassRule] = [
         AccessibilityBypassRule(
+            name: "standardWindowTitleBar",
+            conditions: [
+                .role("AXWindow"),
+                .pointInStandardWindowTopRows(1)
+            ]
+        ),
+        // Some custom-rendered apps expose only the window itself during AX hit testing.
+        // Preserve the row immediately below the title bar, where these apps commonly put tabs.
+        AccessibilityBypassRule(
+            name: "windowOnlyTopRows",
+            conditions: [
+                .depth(0),
+                .role("AXWindow"),
+                .subrole("AXStandardWindow"),
+                .pointInStandardWindowTopRows(2)
+            ]
+        ),
+        AccessibilityBypassRule(
             name: "chromiumFullWindowGroupHitTestHole",
             conditions: [
                 .depth(0),
@@ -45,6 +63,7 @@ enum AccessibilityBypassCondition {
     case frameMatchesParent
     case domClassListContains(String)
     case domClassListContainsSuffix(String)
+    case pointInStandardWindowTopRows(Int)
 }
 
 struct AccessibilityBypassRuleContext {
@@ -63,6 +82,7 @@ struct AccessibilityBypassElementSnapshot {
     let hasVerticalScrollBar: Bool
     let hasHorizontalScrollBar: Bool
     let domClassList: [String]
+    let standardWindowButtonFrames: [CGRect]
 
     init(
         depth: Int,
@@ -75,7 +95,8 @@ struct AccessibilityBypassElementSnapshot {
         children: [AccessibilityBypassChildSnapshot] = [],
         hasVerticalScrollBar: Bool = false,
         hasHorizontalScrollBar: Bool = false,
-        domClassList: [String] = []
+        domClassList: [String] = [],
+        standardWindowButtonFrames: [CGRect] = []
     ) {
         self.depth = depth
         self.role = role
@@ -88,6 +109,7 @@ struct AccessibilityBypassElementSnapshot {
         self.hasVerticalScrollBar = hasVerticalScrollBar
         self.hasHorizontalScrollBar = hasHorizontalScrollBar
         self.domClassList = domClassList
+        self.standardWindowButtonFrames = standardWindowButtonFrames
     }
 }
 
@@ -157,7 +179,54 @@ struct AccessibilityBypassRuleMatcher {
             return element.domClassList.contains(expectedClass)
         case let .domClassListContainsSuffix(expectedSuffix):
             return element.domClassList.contains { $0.hasSuffix(expectedSuffix) }
+        case let .pointInStandardWindowTopRows(rowCount):
+            return pointIsInStandardWindowTopRows(rowCount, at: context.point, of: element)
         }
+    }
+
+    private func pointIsInStandardWindowTopRows(
+        _ rowCount: Int,
+        at point: CGPoint,
+        of element: AccessibilityBypassElementSnapshot
+    ) -> Bool {
+        guard rowCount > 0,
+              let windowFrame = element.frame else {
+            return false
+        }
+
+        let buttonCenterYs = element.standardWindowButtonFrames.compactMap { buttonFrame -> CGFloat? in
+            guard buttonFrame.width > 0,
+                  buttonFrame.height > 0,
+                  windowFrame.contains(CGPoint(x: buttonFrame.midX, y: buttonFrame.midY)) else {
+                return nil
+            }
+
+            return buttonFrame.midY
+        }
+
+        guard !buttonCenterYs.isEmpty else {
+            return false
+        }
+
+        let titleBarCenterY = buttonCenterYs.reduce(0, +) / CGFloat(buttonCenterYs.count)
+        let titleBarHeight = 2 * (titleBarCenterY - windowFrame.minY)
+        guard titleBarHeight > 0,
+              titleBarHeight <= windowFrame.height else {
+            return false
+        }
+
+        let topRegionHeight = titleBarHeight * CGFloat(rowCount)
+        guard topRegionHeight <= windowFrame.height else {
+            return false
+        }
+
+        let topRegionFrame = CGRect(
+            x: windowFrame.minX,
+            y: windowFrame.minY,
+            width: windowFrame.width,
+            height: topRegionHeight
+        )
+        return topRegionFrame.contains(point)
     }
 
     private func hasScrollabilitySignal(_ element: AccessibilityBypassElementSnapshot) -> Bool {

--- a/LinearMouse/Accessibility/AccessibilityBypassRule.swift
+++ b/LinearMouse/Accessibility/AccessibilityBypassRule.swift
@@ -14,18 +14,7 @@ extension AccessibilityBypassRule {
             name: "standardWindowTitleBar",
             conditions: [
                 .role("AXWindow"),
-                .pointInStandardWindowTopRows(1)
-            ]
-        ),
-        // Some custom-rendered apps expose only the window itself during AX hit testing.
-        // Preserve the row immediately below the title bar, where these apps commonly put tabs.
-        AccessibilityBypassRule(
-            name: "windowOnlyTopRows",
-            conditions: [
-                .depth(0),
-                .role("AXWindow"),
-                .subrole("AXStandardWindow"),
-                .pointInStandardWindowTopRows(2)
+                .pointInStandardWindowTitleBar
             ]
         ),
         AccessibilityBypassRule(
@@ -63,7 +52,7 @@ enum AccessibilityBypassCondition {
     case frameMatchesParent
     case domClassListContains(String)
     case domClassListContainsSuffix(String)
-    case pointInStandardWindowTopRows(Int)
+    case pointInStandardWindowTitleBar
 }
 
 struct AccessibilityBypassRuleContext {
@@ -179,18 +168,16 @@ struct AccessibilityBypassRuleMatcher {
             return element.domClassList.contains(expectedClass)
         case let .domClassListContainsSuffix(expectedSuffix):
             return element.domClassList.contains { $0.hasSuffix(expectedSuffix) }
-        case let .pointInStandardWindowTopRows(rowCount):
-            return pointIsInStandardWindowTopRows(rowCount, at: context.point, of: element)
+        case .pointInStandardWindowTitleBar:
+            return pointIsInStandardWindowTitleBar(at: context.point, of: element)
         }
     }
 
-    private func pointIsInStandardWindowTopRows(
-        _ rowCount: Int,
+    private func pointIsInStandardWindowTitleBar(
         at point: CGPoint,
         of element: AccessibilityBypassElementSnapshot
     ) -> Bool {
-        guard rowCount > 0,
-              let windowFrame = element.frame else {
+        guard let windowFrame = element.frame else {
             return false
         }
 
@@ -215,18 +202,13 @@ struct AccessibilityBypassRuleMatcher {
             return false
         }
 
-        let topRegionHeight = titleBarHeight * CGFloat(rowCount)
-        guard topRegionHeight <= windowFrame.height else {
-            return false
-        }
-
-        let topRegionFrame = CGRect(
+        let titleBarFrame = CGRect(
             x: windowFrame.minX,
             y: windowFrame.minY,
             width: windowFrame.width,
-            height: topRegionHeight
+            height: titleBarHeight
         )
-        return topRegionFrame.contains(point)
+        return titleBarFrame.contains(point)
     }
 
     private func hasScrollabilitySignal(_ element: AccessibilityBypassElementSnapshot) -> Bool {

--- a/LinearMouse/Accessibility/AutoScrollAccessibilityActivationClassifier.swift
+++ b/LinearMouse/Accessibility/AutoScrollAccessibilityActivationClassifier.swift
@@ -8,6 +8,12 @@ struct AutoScrollAccessibilityActivationClassifier {
     private static let domClassListAttribute = "AXDOMClassList" as CFString
     private static let maxParentDepth = 20
     private static let probeRadius: CGFloat = 4
+    private static let standardWindowButtonAttributes = [
+        kAXCloseButtonAttribute as CFString,
+        kAXMinimizeButtonAttribute as CFString,
+        kAXZoomButtonAttribute as CFString,
+        kAXFullScreenButtonAttribute as CFString
+    ]
     private static let excludedRoles: Set<String> = [
         "AXMenuBar",
         "AXMenuBarItem",
@@ -248,8 +254,26 @@ struct AutoScrollAccessibilityActivationClassifier {
             children: immediateChildren(of: element).map(childSnapshot),
             hasVerticalScrollBar: hasAttributeValue(kAXVerticalScrollBarAttribute as CFString, on: element),
             hasHorizontalScrollBar: hasAttributeValue(kAXHorizontalScrollBarAttribute as CFString, on: element),
-            domClassList: domClassList(of: element)
+            domClassList: domClassList(of: element),
+            standardWindowButtonFrames: role == "AXWindow" ? standardWindowButtonFrames(of: element) : []
         )
+    }
+
+    private func standardWindowButtonFrames(of window: AXUIElement) -> [CGRect] {
+        for attribute in Self.standardWindowButtonAttributes {
+            guard case let .success(button?) = elementQuery.optionalElementValue(
+                of: attribute,
+                on: window
+            ) else {
+                continue
+            }
+
+            if let frame = frame(of: button) {
+                return [frame]
+            }
+        }
+
+        return []
     }
 
     private func domClassList(of element: AXUIElement) -> [String] {

--- a/LinearMouseUnitTests/Accessibility/AccessibilityBypassRuleTests.swift
+++ b/LinearMouseUnitTests/Accessibility/AccessibilityBypassRuleTests.swift
@@ -11,6 +11,120 @@ final class AccessibilityBypassRuleTests: XCTestCase {
         scrollableRoles: ["AXWebArea", "AXScrollArea"]
     )
 
+    func testStandardWindowTitleBarRuleMatchesZoteroTabStrip() {
+        let rule = matcher.firstMatchingRule(
+            for: zoteroWindowSnapshot(),
+            in: AccessibilityBypassRuleContext(point: CGPoint(x: 150, y: 48))
+        )
+
+        XCTAssertEqual(rule?.name, "standardWindowTitleBar")
+    }
+
+    func testStandardWindowTitleBarRuleMatchesChromeTabStrip() {
+        let rule = matcher.firstMatchingRule(
+            for: standardWindowSnapshot(
+                depth: 6,
+                standardWindowButtonFrames: [
+                    CGRect(x: 12, y: 42.5, width: 16, height: 16),
+                    CGRect(x: 35, y: 42.5, width: 16, height: 16),
+                    CGRect(x: 58, y: 42.5, width: 16, height: 16)
+                ]
+            ),
+            in: AccessibilityBypassRuleContext(point: CGPoint(x: 200, y: 50))
+        )
+
+        XCTAssertEqual(rule?.name, "standardWindowTitleBar")
+    }
+
+    func testStandardWindowTitleBarRuleMatchesFirefoxTabStrip() {
+        let rule = matcher.firstMatchingRule(
+            for: standardWindowSnapshot(
+                depth: 6,
+                standardWindowButtonFrames: [
+                    CGRect(x: 11, y: 44, width: 16, height: 16),
+                    CGRect(x: 34, y: 44, width: 16, height: 16),
+                    CGRect(x: 57, y: 44, width: 16, height: 16)
+                ]
+            ),
+            in: AccessibilityBypassRuleContext(point: CGPoint(x: 500, y: 52))
+        )
+
+        XCTAssertEqual(rule?.name, "standardWindowTitleBar")
+    }
+
+    func testStandardWindowTitleBarRuleDoesNotMatchToolbarBelowTitleBar() {
+        let rule = matcher.firstMatchingRule(
+            for: zoteroWindowSnapshot(),
+            in: AccessibilityBypassRuleContext(point: CGPoint(x: 500, y: 80))
+        )
+
+        XCTAssertNil(rule)
+    }
+
+    func testStandardWindowTitleBarRuleRequiresStandardWindowButtonGeometry() {
+        let rule = matcher.firstMatchingRule(
+            for: zoteroWindowSnapshot(standardWindowButtonFrames: []),
+            in: AccessibilityBypassRuleContext(point: CGPoint(x: 150, y: 48))
+        )
+
+        XCTAssertNil(rule)
+    }
+
+    func testStandardWindowTitleBarRuleNeedsOnlyOneWindowButton() {
+        let rule = matcher.firstMatchingRule(
+            for: zoteroWindowSnapshot(
+                standardWindowButtonFrames: [
+                    CGRect(x: 13, y: 41, width: 12, height: 14)
+                ]
+            ),
+            in: AccessibilityBypassRuleContext(point: CGPoint(x: 150, y: 48))
+        )
+
+        XCTAssertEqual(rule?.name, "standardWindowTitleBar")
+    }
+
+    func testStandardWindowTitleBarRuleRejectsPointOutsideWindow() {
+        let rule = matcher.firstMatchingRule(
+            for: zoteroWindowSnapshot(),
+            in: AccessibilityBypassRuleContext(point: CGPoint(x: 1920, y: 48))
+        )
+
+        XCTAssertNil(rule)
+    }
+
+    func testWindowOnlyTopRowsRuleMatchesZedTabStrip() {
+        let rule = matcher.firstMatchingRule(
+            for: zedWindowSnapshot(),
+            in: AccessibilityBypassRuleContext(point: CGPoint(x: 500, y: 80))
+        )
+
+        XCTAssertEqual(rule?.name, "windowOnlyTopRows")
+    }
+
+    func testWindowOnlyTopRowsRuleDoesNotMatchZedEditor() {
+        let rule = matcher.firstMatchingRule(
+            for: zedWindowSnapshot(),
+            in: AccessibilityBypassRuleContext(point: CGPoint(x: 500, y: 120))
+        )
+
+        XCTAssertNil(rule)
+    }
+
+    func testWindowOnlyTopRowsRuleRequiresStandardWindow() {
+        let rule = matcher.firstMatchingRule(
+            for: standardWindowSnapshot(
+                depth: 0,
+                subrole: "AXDialog",
+                standardWindowButtonFrames: [
+                    CGRect(x: 10, y: 40, width: 12, height: 14)
+                ]
+            ),
+            in: AccessibilityBypassRuleContext(point: CGPoint(x: 500, y: 80))
+        )
+
+        XCTAssertNil(rule)
+    }
+
     func testChromiumFullWindowGroupRuleMatchesChromeHitTestHole() {
         let rule = matcher.firstMatchingRule(
             for: chromiumFullWindowGroupSnapshot(),
@@ -188,6 +302,46 @@ final class AccessibilityBypassRuleTests: XCTestCase {
             parentFrame: CGRect(x: 166, y: 52, width: 494, height: 41),
             children: [],
             domClassList: domClassList
+        )
+    }
+
+    private func zoteroWindowSnapshot(
+        standardWindowButtonFrames: [CGRect] = [
+            CGRect(x: 13, y: 41, width: 12, height: 14),
+            CGRect(x: 33, y: 41, width: 12, height: 14),
+            CGRect(x: 53, y: 41, width: 12, height: 14)
+        ]
+    ) -> AccessibilityBypassElementSnapshot {
+        standardWindowSnapshot(
+            depth: 6,
+            standardWindowButtonFrames: standardWindowButtonFrames
+        )
+    }
+
+    private func zedWindowSnapshot() -> AccessibilityBypassElementSnapshot {
+        standardWindowSnapshot(
+            depth: 0,
+            standardWindowButtonFrames: [
+                CGRect(x: 10, y: 40, width: 12, height: 14),
+                CGRect(x: 30, y: 40, width: 12, height: 14),
+                CGRect(x: 50, y: 40, width: 12, height: 14)
+            ]
+        )
+    }
+
+    private func standardWindowSnapshot(
+        depth: Int,
+        subrole: String = "AXStandardWindow",
+        standardWindowButtonFrames: [CGRect]
+    ) -> AccessibilityBypassElementSnapshot {
+        AccessibilityBypassElementSnapshot(
+            depth: depth,
+            role: "AXWindow",
+            subrole: subrole,
+            actions: ["AXRaise"],
+            frame: CGRect(x: 0, y: 30, width: 1920, height: 971),
+            children: [],
+            standardWindowButtonFrames: standardWindowButtonFrames
         )
     }
 }

--- a/LinearMouseUnitTests/Accessibility/AccessibilityBypassRuleTests.swift
+++ b/LinearMouseUnitTests/Accessibility/AccessibilityBypassRuleTests.swift
@@ -92,29 +92,10 @@ final class AccessibilityBypassRuleTests: XCTestCase {
         XCTAssertNil(rule)
     }
 
-    func testWindowOnlyTopRowsRuleMatchesZedTabStrip() {
-        let rule = matcher.firstMatchingRule(
-            for: zedWindowSnapshot(),
-            in: AccessibilityBypassRuleContext(point: CGPoint(x: 500, y: 80))
-        )
-
-        XCTAssertEqual(rule?.name, "windowOnlyTopRows")
-    }
-
-    func testWindowOnlyTopRowsRuleDoesNotMatchZedEditor() {
-        let rule = matcher.firstMatchingRule(
-            for: zedWindowSnapshot(),
-            in: AccessibilityBypassRuleContext(point: CGPoint(x: 500, y: 120))
-        )
-
-        XCTAssertNil(rule)
-    }
-
-    func testWindowOnlyTopRowsRuleRequiresStandardWindow() {
+    func testStandardWindowTitleBarRuleDoesNotExpandWhenHitTestReturnsWindow() {
         let rule = matcher.firstMatchingRule(
             for: standardWindowSnapshot(
                 depth: 0,
-                subrole: "AXDialog",
                 standardWindowButtonFrames: [
                     CGRect(x: 10, y: 40, width: 12, height: 14)
                 ]
@@ -315,17 +296,6 @@ final class AccessibilityBypassRuleTests: XCTestCase {
         standardWindowSnapshot(
             depth: 6,
             standardWindowButtonFrames: standardWindowButtonFrames
-        )
-    }
-
-    private func zedWindowSnapshot() -> AccessibilityBypassElementSnapshot {
-        standardWindowSnapshot(
-            depth: 0,
-            standardWindowButtonFrames: [
-                CGRect(x: 10, y: 40, width: 12, height: 14),
-                CGRect(x: 30, y: 40, width: 12, height: 14),
-                CGRect(x: 50, y: 40, width: 12, height: 14)
-            ]
         )
     }
 


### PR DESCRIPTION
## Summary

Middle clicks in title bars and tab strips should remain available to the target application instead of activating autoscroll.

This change:

- infers standard macOS title-bar bounds from the accessibility geometry of native window controls
- bypasses autoscroll activation only within that title-bar region, preserving native middle-click behavior in apps such as Zotero, Chrome, and Firefox
- retains the existing Chromium-specific fallbacks for Chromium accessibility hit-test holes
- stops querying window controls after the first valid frame is found

The title-bar detection is intentionally generic and does not rely on application bundle identifiers or per-app rules. It is deliberately limited to one inferred title-bar height; applications that do not expose their tab strips through accessibility are not given a broader fallback region.

## Testing

- Added coverage based on observed title-bar geometry in Zotero, Chrome, and Firefox
- Verified points below the title bar are not bypassed, including when accessibility hit testing returns only the window
- Verified malformed or missing window-control geometry does not trigger the rule
- All 325 unit tests pass
- SwiftFormat and SwiftLint pass

Fixes #1315