### PR TITLE
Preserve held modifier keys when scrolling to zoom

### DIFF
--- a/LinearMouse/EventTransformer/ModifierActionsTransformer.swift
+++ b/LinearMouse/EventTransformer/ModifierActionsTransformer.swift
@@ -89,16 +89,19 @@ extension ModifierActionsTransformer: EventTransformer {
             if deltaSignum == 0 {
                 return event
             }
+            let restoringModifierFlags = ModifierState.normalize(event.flags)
             if deltaSignum > 0 {
                 try? keySimulator.press(
                     keys: [.numpadPlus],
                     modifierFlags: .maskCommand,
+                    restoringModifierFlags: restoringModifierFlags,
                     tap: .cgSessionEventTap
                 )
             } else {
                 try? keySimulator.press(
                     keys: [.numpadMinus],
                     modifierFlags: .maskCommand,
+                    restoringModifierFlags: restoringModifierFlags,
                     tap: .cgSessionEventTap
                 )
             }

--- a/LinearMouse/EventTransformer/ModifierActionsTransformer.swift
+++ b/LinearMouse/EventTransformer/ModifierActionsTransformer.swift
@@ -12,18 +12,22 @@ class ModifierActionsTransformer {
         category: "ModifierActionsTransformer"
     )
 
-    private static let keySimulator = KeySimulator()
+    private static let defaultKeySimulator = KeySimulator(
+        eventSourceUserData: CGEvent.linearMouseSyntheticEventUserData
+    )
 
     typealias Modifiers = Scheme.Scrolling.Bidirectional<Scheme.Scrolling.Modifiers>
     typealias Action = Scheme.Scrolling.Modifiers.Action
 
     private let modifiers: Modifiers
+    private let keySimulator: KeySimulating
 
     private var pinchZoomBegan = false
     private var pinchZoomReversed = false
 
-    init(modifiers: Modifiers) {
+    init(modifiers: Modifiers, keySimulator: KeySimulating? = nil) {
         self.modifiers = modifiers
+        self.keySimulator = keySimulator ?? Self.defaultKeySimulator
     }
 }
 
@@ -86,9 +90,17 @@ extension ModifierActionsTransformer: EventTransformer {
                 return event
             }
             if deltaSignum > 0 {
-                try? Self.keySimulator.press(.command, .numpadPlus, tap: .cgSessionEventTap)
+                try? keySimulator.press(
+                    keys: [.numpadPlus],
+                    modifierFlags: .maskCommand,
+                    tap: .cgSessionEventTap
+                )
             } else {
-                try? Self.keySimulator.press(.command, .numpadMinus, tap: .cgSessionEventTap)
+                try? keySimulator.press(
+                    keys: [.numpadMinus],
+                    modifierFlags: .maskCommand,
+                    tap: .cgSessionEventTap
+                )
             }
             return nil
         case .pinchZoom:

--- a/LinearMouse/Utilities/CGEvent+LinearMouseSynthetic.swift
+++ b/LinearMouse/Utilities/CGEvent+LinearMouseSynthetic.swift
@@ -123,7 +123,7 @@ extension LogitechControlIdentity {
 }
 
 extension CGEvent {
-    private static let linearMouseSyntheticEventUserData: Int64 = 0x534D_4F4F_5448
+    static let linearMouseSyntheticEventUserData: Int64 = 0x534D_4F4F_5448
     private static let gestureCleanupReleaseUserData: Int64 = 0x4745_5354_5552
 
     var isLinearMouseSyntheticEvent: Bool {

--- a/LinearMouseUnitTests/EventTransformer/ButtonActionsTransformerTests.swift
+++ b/LinearMouseUnitTests/EventTransformer/ButtonActionsTransformerTests.swift
@@ -38,6 +38,15 @@ private final class RecordingKeySimulator: KeySimulating {
         events.append(.pressWithModifierFlags(keys, modifierFlags))
     }
 
+    func press(
+        keys: [Key],
+        modifierFlags: CGEventFlags,
+        restoringModifierFlags _: CGEventFlags,
+        tap _: CGEventTapLocation?
+    ) throws {
+        events.append(.pressWithModifierFlags(keys, modifierFlags))
+    }
+
     func reset() {
         events.append(.reset)
     }

--- a/LinearMouseUnitTests/EventTransformer/ButtonActionsTransformerTests.swift
+++ b/LinearMouseUnitTests/EventTransformer/ButtonActionsTransformerTests.swift
@@ -12,6 +12,7 @@ private final class RecordingKeySimulator: KeySimulating {
         case down([Key])
         case up([Key])
         case press([Key])
+        case pressWithModifierFlags([Key], CGEventFlags)
         case reset
     }
 
@@ -27,6 +28,14 @@ private final class RecordingKeySimulator: KeySimulating {
 
     func press(keys: [Key], tap _: CGEventTapLocation?) throws {
         events.append(.press(keys))
+    }
+
+    func press(
+        keys: [Key],
+        modifierFlags: CGEventFlags,
+        tap _: CGEventTapLocation?
+    ) throws {
+        events.append(.pressWithModifierFlags(keys, modifierFlags))
     }
 
     func reset() {

--- a/LinearMouseUnitTests/EventTransformer/ModifierActionsTransformerTests.swift
+++ b/LinearMouseUnitTests/EventTransformer/ModifierActionsTransformerTests.swift
@@ -9,6 +9,7 @@ private final class RecordingModifierKeySimulator: KeySimulating {
     struct ModifiedPress: Equatable {
         let keys: [Key]
         let modifierFlags: CGEventFlags
+        let restoringModifierFlags: CGEventFlags?
     }
 
     private(set) var unmodifiedPresses: [[Key]] = []
@@ -26,7 +27,24 @@ private final class RecordingModifierKeySimulator: KeySimulating {
         modifierFlags: CGEventFlags,
         tap _: CGEventTapLocation?
     ) throws {
-        modifiedPresses.append(.init(keys: keys, modifierFlags: modifierFlags))
+        modifiedPresses.append(.init(
+            keys: keys,
+            modifierFlags: modifierFlags,
+            restoringModifierFlags: nil
+        ))
+    }
+
+    func press(
+        keys: [Key],
+        modifierFlags: CGEventFlags,
+        restoringModifierFlags: CGEventFlags,
+        tap _: CGEventTapLocation?
+    ) throws {
+        modifiedPresses.append(.init(
+            keys: keys,
+            modifierFlags: modifierFlags,
+            restoringModifierFlags: restoringModifierFlags
+        ))
     }
 
     func reset() {}
@@ -106,8 +124,47 @@ final class ModifierActionsTransformerTests: XCTestCase {
         XCTAssertEqual(
             keySimulator.modifiedPresses,
             [
-                .init(keys: [.numpadPlus], modifierFlags: .maskCommand),
-                .init(keys: [.numpadMinus], modifierFlags: .maskCommand)
+                .init(
+                    keys: [.numpadPlus],
+                    modifierFlags: .maskCommand,
+                    restoringModifierFlags: .maskCommand
+                ),
+                .init(
+                    keys: [.numpadMinus],
+                    modifierFlags: .maskCommand,
+                    restoringModifierFlags: .maskCommand
+                )
+            ]
+        )
+    }
+
+    func testZoomRestoresNonCommandTriggerModifier() throws {
+        let keySimulator = RecordingModifierKeySimulator()
+        let modifiers = Scheme.Scrolling.Modifiers(option: .zoom)
+        let transformer = ModifierActionsTransformer(
+            modifiers: .init(vertical: modifiers, horizontal: modifiers),
+            keySimulator: keySimulator
+        )
+        let event = try XCTUnwrap(CGEvent(
+            scrollWheelEvent2Source: nil,
+            units: .line,
+            wheelCount: 1,
+            wheel1: 1,
+            wheel2: 0,
+            wheel3: 0
+        ))
+        let leftOptionFlag = CGEventFlags(rawValue: UInt64(NX_DEVICELALTKEYMASK))
+        event.flags = [.maskAlternate, leftOptionFlag]
+
+        XCTAssertNil(transformer.transform(event, in: EventTransformerContext(device: nil)))
+        XCTAssertEqual(
+            keySimulator.modifiedPresses,
+            [
+                .init(
+                    keys: [.numpadPlus],
+                    modifierFlags: .maskCommand,
+                    restoringModifierFlags: [.maskAlternate, leftOptionFlag]
+                )
             ]
         )
     }

--- a/LinearMouseUnitTests/EventTransformer/ModifierActionsTransformerTests.swift
+++ b/LinearMouseUnitTests/EventTransformer/ModifierActionsTransformerTests.swift
@@ -1,8 +1,40 @@
 // MIT License
 // Copyright (c) 2021-2026 LinearMouse
 
+import KeyKit
 @testable import LinearMouse
 import XCTest
+
+private final class RecordingModifierKeySimulator: KeySimulating {
+    struct ModifiedPress: Equatable {
+        let keys: [Key]
+        let modifierFlags: CGEventFlags
+    }
+
+    private(set) var unmodifiedPresses: [[Key]] = []
+    private(set) var modifiedPresses: [ModifiedPress] = []
+
+    func down(keys _: [Key], tap _: CGEventTapLocation?) throws {}
+    func up(keys _: [Key], tap _: CGEventTapLocation?) throws {}
+
+    func press(keys: [Key], tap _: CGEventTapLocation?) throws {
+        unmodifiedPresses.append(keys)
+    }
+
+    func press(
+        keys: [Key],
+        modifierFlags: CGEventFlags,
+        tap _: CGEventTapLocation?
+    ) throws {
+        modifiedPresses.append(.init(keys: keys, modifierFlags: modifierFlags))
+    }
+
+    func reset() {}
+
+    func modifiedCGEventFlags(of _: CGEvent) -> CGEventFlags? {
+        nil
+    }
+}
 
 final class ModifierActionsTransformerTests: XCTestCase {
     func testModifierActions() throws {
@@ -45,5 +77,38 @@ final class ModifierActionsTransformerTests: XCTestCase {
         view = ScrollWheelEventView(event)
         XCTAssertEqual(view.deltaX, 2)
         XCTAssertEqual(view.deltaY, 4)
+    }
+
+    func testZoomAttachesCommandWithoutPressingCommandKey() throws {
+        let keySimulator = RecordingModifierKeySimulator()
+        let modifiers = Scheme.Scrolling.Modifiers(command: .zoom)
+        let transformer = ModifierActionsTransformer(
+            modifiers: .init(vertical: modifiers, horizontal: modifiers),
+            keySimulator: keySimulator
+        )
+        let event = try XCTUnwrap(CGEvent(
+            scrollWheelEvent2Source: nil,
+            units: .line,
+            wheelCount: 1,
+            wheel1: 1,
+            wheel2: 0,
+            wheel3: 0
+        ))
+        event.flags = .maskCommand
+
+        XCTAssertNil(transformer.transform(event, in: EventTransformerContext(device: nil)))
+        event.setIntegerValueField(.scrollWheelEventDeltaAxis1, value: -1)
+        event.setDoubleValueField(.scrollWheelEventFixedPtDeltaAxis1, value: -1)
+        event.setDoubleValueField(.scrollWheelEventPointDeltaAxis1, value: -10)
+        XCTAssertNil(transformer.transform(event, in: EventTransformerContext(device: nil)))
+
+        XCTAssertTrue(keySimulator.unmodifiedPresses.isEmpty)
+        XCTAssertEqual(
+            keySimulator.modifiedPresses,
+            [
+                .init(keys: [.numpadPlus], modifierFlags: .maskCommand),
+                .init(keys: [.numpadMinus], modifierFlags: .maskCommand)
+            ]
+        )
     }
 }

--- a/Modules/KeyKit/Sources/KeyKit/KeySimulator.swift
+++ b/Modules/KeyKit/Sources/KeyKit/KeySimulator.swift
@@ -15,6 +15,12 @@ public protocol KeySimulating: AnyObject {
     func up(keys: [Key], tap: CGEventTapLocation?) throws
     func press(keys: [Key], tap: CGEventTapLocation?) throws
     func press(keys: [Key], modifierFlags: CGEventFlags, tap: CGEventTapLocation?) throws
+    func press(
+        keys: [Key],
+        modifierFlags: CGEventFlags,
+        restoringModifierFlags: CGEventFlags,
+        tap: CGEventTapLocation?
+    ) throws
     func reset()
     func modifiedCGEventFlags(of event: CGEvent) -> CGEventFlags?
 }
@@ -22,6 +28,24 @@ public protocol KeySimulating: AnyObject {
 /// Simulate key presses.
 public class KeySimulator: KeySimulating {
     typealias EventPoster = (_ event: CGEvent, _ tap: CGEventTapLocation?) -> Void
+
+    private static let genericModifierFlags: CGEventFlags = [
+        .maskCommand,
+        .maskShift,
+        .maskAlternate,
+        .maskControl
+    ]
+    private static let deviceSpecificModifierFlags = CGEventFlags(rawValue: UInt64(
+        NX_DEVICELCTLKEYMASK |
+            NX_DEVICERCTLKEYMASK |
+            NX_DEVICELSHIFTKEYMASK |
+            NX_DEVICERSHIFTKEYMASK |
+            NX_DEVICELALTKEYMASK |
+            NX_DEVICERALTKEYMASK |
+            NX_DEVICELCMDKEYMASK |
+            NX_DEVICERCMDKEYMASK
+    ))
+    private static let keyboardModifierFlags = genericModifierFlags.union(deviceSpecificModifierFlags)
 
     private let keyCodeResolver = KeyCodeResolver()
     private let eventSourceUserData: Int64?
@@ -94,9 +118,7 @@ public class KeySimulator: KeySimulating {
             return
         }
 
-        event.flags = event.flags
-            .subtracting([.maskCommand, .maskShift, .maskAlternate, .maskControl])
-            .union(eventFlags)
+        event.flags = Self.replacingKeyboardModifierFlags(in: event.flags, with: eventFlags)
 
         if !flagsToToggle.isEmpty {
             event.type = .flagsChanged
@@ -109,9 +131,19 @@ public class KeySimulator: KeySimulating {
         eventPoster(event, tap)
     }
 
+    static func replacingKeyboardModifierFlags(
+        in inheritedFlags: CGEventFlags,
+        with simulatedFlags: CGEventFlags
+    ) -> CGEventFlags {
+        inheritedFlags
+            .subtracting(keyboardModifierFlags)
+            .union(simulatedFlags)
+    }
+
     private func pressLocked(
         keys: [Key],
         modifierFlags: CGEventFlags = [],
+        restoringModifierFlags: CGEventFlags? = nil,
         tap: CGEventTapLocation?
     ) {
         for key in keys {
@@ -138,6 +170,80 @@ public class KeySimulator: KeySimulating {
                 os_log(.error, "KeySimulator: keyUp failed for %{public}@: %{public}@", "\(key)", "\(error)")
             }
         }
+
+        if let restoringModifierFlags {
+            do {
+                try restoreModifierFlagsLocked(
+                    restoringModifierFlags,
+                    afterUsing: modifierFlags,
+                    tap: tap
+                )
+            } catch {
+                os_log(.error, "KeySimulator: restoring modifier flags failed: %{public}@", "\(error)")
+            }
+        }
+    }
+
+    private func restoreModifierFlagsLocked(
+        _ restoringModifierFlags: CGEventFlags,
+        afterUsing simulatedModifierFlags: CGEventFlags,
+        tap: CGEventTapLocation?
+    ) throws {
+        let restoringGenericFlags = restoringModifierFlags.intersection(Self.genericModifierFlags)
+        let simulatedGenericFlags = simulatedModifierFlags.intersection(Self.genericModifierFlags)
+        let genericFlagsToRestore = restoringGenericFlags.subtracting(simulatedGenericFlags)
+
+        guard !genericFlagsToRestore.isEmpty,
+              let key = Self.modifierKey(
+                  in: restoringModifierFlags,
+                  matching: genericFlagsToRestore
+              ),
+              let keyCode = keyCodeResolver.keyCode(for: key) else {
+            return
+        }
+
+        guard let event = CGEvent(keyboardEventSource: nil, virtualKey: keyCode, keyDown: true) else {
+            return
+        }
+
+        event.type = .flagsChanged
+        event.flags = Self.replacingKeyboardModifierFlags(
+            in: event.flags,
+            with: restoringModifierFlags
+        )
+
+        if let eventSourceUserData {
+            event.setIntegerValueField(.eventSourceUserData, value: eventSourceUserData)
+        }
+
+        eventPoster(event, tap)
+    }
+
+    private static func modifierKey(
+        in modifierFlags: CGEventFlags,
+        matching genericFlags: CGEventFlags
+    ) -> Key? {
+        if genericFlags.contains(.maskShift) {
+            return modifierFlags.contains(.init(rawValue: UInt64(NX_DEVICERSHIFTKEYMASK)))
+                ? .shiftRight
+                : .shift
+        }
+        if genericFlags.contains(.maskAlternate) {
+            return modifierFlags.contains(.init(rawValue: UInt64(NX_DEVICERALTKEYMASK)))
+                ? .optionRight
+                : .option
+        }
+        if genericFlags.contains(.maskControl) {
+            return modifierFlags.contains(.init(rawValue: UInt64(NX_DEVICERCTLKEYMASK)))
+                ? .controlRight
+                : .control
+        }
+        if genericFlags.contains(.maskCommand) {
+            return modifierFlags.contains(.init(rawValue: UInt64(NX_DEVICERCMDKEYMASK)))
+                ? .commandRight
+                : .command
+        }
+        return nil
     }
 }
 
@@ -200,6 +306,24 @@ public extension KeySimulator {
         tap: CGEventTapLocation? = nil
     ) throws {
         try press(keys: keys, modifierFlags: modifierFlags, tap: tap)
+    }
+
+    /// Presses keys with transient modifier flags, then restores the modifier state that was
+    /// active before the generated key events were posted.
+    func press(
+        keys: [Key],
+        modifierFlags: CGEventFlags,
+        restoringModifierFlags: CGEventFlags,
+        tap: CGEventTapLocation? = nil
+    ) throws {
+        lock.withLock {
+            pressLocked(
+                keys: keys,
+                modifierFlags: modifierFlags,
+                restoringModifierFlags: restoringModifierFlags,
+                tap: tap
+            )
+        }
     }
 
     func modifiedCGEventFlags(of event: CGEvent) -> CGEventFlags? {

--- a/Modules/KeyKit/Sources/KeyKit/KeySimulator.swift
+++ b/Modules/KeyKit/Sources/KeyKit/KeySimulator.swift
@@ -14,20 +14,42 @@ public protocol KeySimulating: AnyObject {
     func down(keys: [Key], tap: CGEventTapLocation?) throws
     func up(keys: [Key], tap: CGEventTapLocation?) throws
     func press(keys: [Key], tap: CGEventTapLocation?) throws
+    func press(keys: [Key], modifierFlags: CGEventFlags, tap: CGEventTapLocation?) throws
     func reset()
     func modifiedCGEventFlags(of event: CGEvent) -> CGEventFlags?
 }
 
 /// Simulate key presses.
 public class KeySimulator: KeySimulating {
+    typealias EventPoster = (_ event: CGEvent, _ tap: CGEventTapLocation?) -> Void
+
     private let keyCodeResolver = KeyCodeResolver()
+    private let eventSourceUserData: Int64?
+    private let eventPoster: EventPoster
     private let lock = NSLock()
 
     private var flags = CGEventFlags()
 
-    public init() {}
+    public convenience init(eventSourceUserData: Int64? = nil) {
+        self.init(eventSourceUserData: eventSourceUserData) { event, tap in
+            event.post(tap: tap ?? .cghidEventTap)
+        }
+    }
 
-    private func postKeyLocked(_ key: Key, keyDown: Bool, tap: CGEventTapLocation? = nil) throws {
+    init(
+        eventSourceUserData: Int64? = nil,
+        eventPoster: @escaping EventPoster
+    ) {
+        self.eventSourceUserData = eventSourceUserData
+        self.eventPoster = eventPoster
+    }
+
+    private func postKeyLocked(
+        _ key: Key,
+        keyDown: Bool,
+        modifierFlags: CGEventFlags = [],
+        tap: CGEventTapLocation? = nil
+    ) throws {
         var flagsToToggle = CGEventFlags()
         switch key {
         case .command, .commandRight:
@@ -63,7 +85,8 @@ public class KeySimulator: KeySimulating {
             break
         }
 
-        guard let keyCode = keyCodeResolver.keyCode(for: key, modifiers: flags) else {
+        let eventFlags = flags.union(modifierFlags)
+        guard let keyCode = keyCodeResolver.keyCode(for: key, modifiers: eventFlags) else {
             throw KeySimulatorError.unsupportedKey
         }
 
@@ -73,13 +96,48 @@ public class KeySimulator: KeySimulating {
 
         event.flags = event.flags
             .subtracting([.maskCommand, .maskShift, .maskAlternate, .maskControl])
-            .union(flags)
+            .union(eventFlags)
 
         if !flagsToToggle.isEmpty {
             event.type = .flagsChanged
         }
 
-        event.post(tap: tap ?? .cghidEventTap)
+        if let eventSourceUserData {
+            event.setIntegerValueField(.eventSourceUserData, value: eventSourceUserData)
+        }
+
+        eventPoster(event, tap)
+    }
+
+    private func pressLocked(
+        keys: [Key],
+        modifierFlags: CGEventFlags = [],
+        tap: CGEventTapLocation?
+    ) {
+        for key in keys {
+            do {
+                try postKeyLocked(
+                    key,
+                    keyDown: true,
+                    modifierFlags: modifierFlags,
+                    tap: tap
+                )
+            } catch {
+                os_log(.error, "KeySimulator: keyDown failed for %{public}@: %{public}@", "\(key)", "\(error)")
+            }
+        }
+        for key in keys.reversed() {
+            do {
+                try postKeyLocked(
+                    key,
+                    keyDown: false,
+                    modifierFlags: modifierFlags,
+                    tap: tap
+                )
+            } catch {
+                os_log(.error, "KeySimulator: keyUp failed for %{public}@: %{public}@", "\(key)", "\(error)")
+            }
+        }
     }
 }
 
@@ -115,26 +173,33 @@ public extension KeySimulator {
     }
 
     func press(keys: [Key], tap: CGEventTapLocation? = nil) throws {
-        try lock.withLock {
-            for key in keys {
-                do {
-                    try postKeyLocked(key, keyDown: true, tap: tap)
-                } catch {
-                    os_log(.error, "KeySimulator: keyDown failed for %{public}@: %{public}@", "\(key)", "\(error)")
-                }
-            }
-            for key in keys.reversed() {
-                do {
-                    try postKeyLocked(key, keyDown: false, tap: tap)
-                } catch {
-                    os_log(.error, "KeySimulator: keyUp failed for %{public}@: %{public}@", "\(key)", "\(error)")
-                }
-            }
+        lock.withLock {
+            pressLocked(keys: keys, tap: tap)
         }
     }
 
     func press(_ keys: Key..., tap: CGEventTapLocation? = nil) throws {
         try press(keys: keys, tap: tap)
+    }
+
+    /// Presses keys with modifier flags attached to each generated event without synthesizing
+    /// modifier key transitions.
+    func press(
+        keys: [Key],
+        modifierFlags: CGEventFlags,
+        tap: CGEventTapLocation? = nil
+    ) throws {
+        lock.withLock {
+            pressLocked(keys: keys, modifierFlags: modifierFlags, tap: tap)
+        }
+    }
+
+    func press(
+        _ keys: Key...,
+        modifierFlags: CGEventFlags,
+        tap: CGEventTapLocation? = nil
+    ) throws {
+        try press(keys: keys, modifierFlags: modifierFlags, tap: tap)
     }
 
     func modifiedCGEventFlags(of event: CGEvent) -> CGEventFlags? {

--- a/Modules/KeyKit/Tests/KeyKitTests/KeyKitTests.swift
+++ b/Modules/KeyKit/Tests/KeyKitTests/KeyKitTests.swift
@@ -72,6 +72,37 @@ final class KeyKitTests: XCTestCase {
         wait(for: [expectation], timeout: 5)
     }
 
+    func testPressWithModifierFlagsDoesNotPostModifierTransitionsOrPersistFlags() throws {
+        var postedEvents: [CGEvent] = []
+        let eventSourceUserData: Int64 = 0x1234
+        let keySimulator = KeySimulator(eventSourceUserData: eventSourceUserData) { event, _ in
+            postedEvents.append(event)
+        }
+
+        try keySimulator.press(
+            keys: [.numpadPlus],
+            modifierFlags: .maskCommand,
+            tap: .cgSessionEventTap
+        )
+        try keySimulator.press(keys: [.home], tap: .cgSessionEventTap)
+
+        XCTAssertEqual(postedEvents.map(\.type), [.keyDown, .keyUp, .keyDown, .keyUp])
+        XCTAssertEqual(
+            postedEvents.map { $0.getIntegerValueField(.keyboardEventKeycode) },
+            [
+                Int64(kVK_ANSI_KeypadPlus),
+                Int64(kVK_ANSI_KeypadPlus),
+                Int64(kVK_Home),
+                Int64(kVK_Home)
+            ]
+        )
+        XCTAssertTrue(postedEvents.prefix(2).allSatisfy { $0.flags.contains(.maskCommand) })
+        XCTAssertTrue(postedEvents.suffix(2).allSatisfy { !$0.flags.contains(.maskCommand) })
+        XCTAssertTrue(postedEvents.allSatisfy {
+            $0.getIntegerValueField(.eventSourceUserData) == eventSourceUserData
+        })
+    }
+
     func testKeyCodeResolverSupportsCommonModifierShortcutsInRussianLayout() throws {
         let russianMapping = try characterMapping(inputSourceID: "com.apple.keylayout.Russian")
         let russianCommandMapping = try characterMapping(

--- a/Modules/KeyKit/Tests/KeyKitTests/KeyKitTests.swift
+++ b/Modules/KeyKit/Tests/KeyKitTests/KeyKitTests.swift
@@ -103,6 +103,85 @@ final class KeyKitTests: XCTestCase {
         })
     }
 
+    func testReplacingKeyboardModifierFlagsRemovesInheritedSideSpecificModifiers() {
+        let inheritedFlags: CGEventFlags = [
+            .maskAlternate,
+            .maskShift,
+            .maskNumericPad,
+            .init(rawValue: UInt64(NX_DEVICELALTKEYMASK)),
+            .init(rawValue: UInt64(NX_DEVICERSHIFTKEYMASK))
+        ]
+
+        let eventFlags = KeySimulator.replacingKeyboardModifierFlags(
+            in: inheritedFlags,
+            with: .maskCommand
+        )
+
+        XCTAssertEqual(
+            eventFlags.intersection([
+                .maskCommand,
+                .maskShift,
+                .maskAlternate,
+                .maskControl
+            ]),
+            .maskCommand
+        )
+        XCTAssertFalse(eventFlags.contains(.init(rawValue: UInt64(NX_DEVICELALTKEYMASK))))
+        XCTAssertFalse(eventFlags.contains(.init(rawValue: UInt64(NX_DEVICERSHIFTKEYMASK))))
+        XCTAssertTrue(eventFlags.contains(.maskNumericPad))
+    }
+
+    func testPressWithModifierFlagsRestoresDifferentPhysicalModifierState() throws {
+        var postedEvents: [CGEvent] = []
+        let eventSourceUserData: Int64 = 0x1234
+        let keySimulator = KeySimulator(eventSourceUserData: eventSourceUserData) { event, _ in
+            postedEvents.append(event)
+        }
+        let leftOptionFlag = CGEventFlags(rawValue: UInt64(NX_DEVICELALTKEYMASK))
+
+        try keySimulator.press(
+            keys: [.numpadPlus],
+            modifierFlags: .maskCommand,
+            restoringModifierFlags: [.maskAlternate, leftOptionFlag],
+            tap: .cgSessionEventTap
+        )
+
+        XCTAssertEqual(postedEvents.map(\.type), [.keyDown, .keyUp, .flagsChanged])
+        XCTAssertTrue(postedEvents.prefix(2).allSatisfy {
+            $0.flags.contains(.maskCommand) &&
+                !$0.flags.contains(.maskAlternate) &&
+                !$0.flags.contains(leftOptionFlag)
+        })
+        let restorationEvent = try XCTUnwrap(postedEvents.last)
+        XCTAssertEqual(
+            restorationEvent.getIntegerValueField(.keyboardEventKeycode),
+            Int64(kVK_Option)
+        )
+        XCTAssertTrue(restorationEvent.flags.contains(.maskAlternate))
+        XCTAssertTrue(restorationEvent.flags.contains(leftOptionFlag))
+        XCTAssertFalse(restorationEvent.flags.contains(.maskCommand))
+        XCTAssertTrue(postedEvents.allSatisfy {
+            $0.getIntegerValueField(.eventSourceUserData) == eventSourceUserData
+        })
+    }
+
+    func testPressWithModifierFlagsDoesNotRestoreMatchingGenericModifierState() throws {
+        var postedEvents: [CGEvent] = []
+        let keySimulator = KeySimulator { event, _ in
+            postedEvents.append(event)
+        }
+        let leftCommandFlag = CGEventFlags(rawValue: UInt64(NX_DEVICELCMDKEYMASK))
+
+        try keySimulator.press(
+            keys: [.numpadPlus],
+            modifierFlags: .maskCommand,
+            restoringModifierFlags: [.maskCommand, leftCommandFlag],
+            tap: .cgSessionEventTap
+        )
+
+        XCTAssertEqual(postedEvents.map(\.type), [.keyDown, .keyUp])
+    }
+
     func testKeyCodeResolverSupportsCommonModifierShortcutsInRussianLayout() throws {
         let russianMapping = try characterMapping(inputSourceID: "com.apple.keylayout.Russian")
         let russianCommandMapping = try characterMapping(


### PR DESCRIPTION
## Summary

Zoom previously simulated Command key transitions around each numpad `+` or `-` press. Synthetic modifier transitions and temporary key-event flags can replace the combined modifier state used by other input utilities, causing subsequent generated scroll events to lose the physically held modifier and resume normal scrolling.

This change:

- attaches the Command flag directly to the generated `+` and `-` key events without posting Command transitions
- removes inherited generic and side-specific modifier flags from the generated shortcut
- restores the modifier state captured from the original scroll event after the shortcut when it differs from Command
- marks generated events as LinearMouse synthetic so they do not affect physical modifier-state tracking
- adds test coverage for transient flags, modifier restoration, and matching Command state

## Known limitation

With Logi Options+ running, assigning Zoom to the Shift modifier still does not activate zoom. This PR does not address that conflict.

## Testing

- `xcodebuild test -project LinearMouse.xcodeproj -scheme LinearMouse -destination "platform=macOS" CODE_SIGNING_ALLOWED=NO` (327 tests passed)
- `swift test --package-path Modules/KeyKit` (8 passed; 3 opt-in integration tests skipped)
- SwiftFormat and SwiftLint pass on the changed files
- Manually verified with Logi Options+ running that Command and Option continue zooming while the modifier remains held

Closes #1314