### PR TITLE
Support ELECOM HUGE Trackball (0x011C)

### DIFF
--- a/LinearMouse/Device/InputReportHandlers/ElecomTrackballHandler.swift
+++ b/LinearMouse/Device/InputReportHandlers/ElecomTrackballHandler.swift
@@ -3,22 +3,23 @@
 
 import Foundation
 
-/// Handles the extra Fn buttons of ELECOM trackballs.
+/// Handles undeclared button bits of supported ELECOM trackballs.
 ///
-/// The HID report descriptor of these devices declares only 5 buttons in its mouse
-/// collection, which are taken up by left, right, middle and the two thumb buttons.
-/// The remaining Fn buttons are still reported in the same input report, but in the
-/// three bits that the descriptor declares as padding, so macOS discards them and no
-/// `otherMouseDown` event is ever generated.
+/// The 0x010C layout was verified in #1302. Passive on-device capture for 0x011C verified
+/// 8-byte reports with report ID 0x01 in byte 0: Fn1 is `01 20 00 00 00 00 00 00`, Fn2 is
+/// `01 40 00 00 00 00 00 00`, and Fn3 is `01 80 00 00 00 00 00 00`; release clears
+/// the corresponding bit. Its descriptor declares only Button usages 1 through 5 (bits 0
+/// through 4) for report ID 0x01, so these upper masks are undeclared and macOS drops
+/// their events.
 ///
-/// This handler reads those undeclared bits out of the raw input report and simulates
-/// the corresponding button events.
+/// This handler synthesizes logical buttons 5, 6, and 7 for those masks so it does not
+/// duplicate the declared button usages that macOS already handles.
 ///
-/// Other ELECOM trackballs share this report layout, so they can be supported by adding
-/// their product IDs below once the layout has been confirmed on the device.
+/// Add other product IDs only after confirming their report layout on-device.
 ///
 /// Supported devices:
 /// - ELECOM HUGE TrackBall (0x056E:0x010C)
+/// - ELECOM trackball (0x056E:0x011C)
 struct ElecomTrackballHandler: InputReportHandler {
     private struct Product: Hashable {
         let vendorID: Int
@@ -26,13 +27,14 @@ struct ElecomTrackballHandler: InputReportHandler {
     }
 
     private static let supportedProducts: Set<Product> = [
-        .init(vendorID: 0x056E, productID: 0x010C) // ELECOM HUGE TrackBall
+        .init(vendorID: 0x056E, productID: 0x010C), // ELECOM HUGE TrackBall
+        .init(vendorID: 0x056E, productID: 0x011C) // ELECOM trackball
     ]
 
-    /// Report format: | Button 0 (1 bit) | ... | Button 4 (1 bit) | Fn buttons (3 bits) |
+    /// Report format: | Bits 0-4 (HID Button usages 1-5) | Undeclared masks (3 bits) |
     ///
-    /// Buttons 0 to 4 are declared in the report descriptor and handled by macOS, so only
-    /// the upper three bits are of interest here.
+    /// Bits 0 to 4 are declared in the report descriptor and handled by macOS, so only the
+    /// upper three bits are of interest here.
     private static let fnButtonsMask: UInt8 = 0xE0
 
     /// Bit 5 to 7 are mapped to button 5 to 7, the first button numbers not already used by
@@ -50,8 +52,8 @@ struct ElecomTrackballHandler: InputReportHandler {
     }
 
     func alwaysNeedsReportObservation() -> Bool {
-        // The device reports 5 buttons, so the button count heuristic would not enable
-        // report observation on its own.
+        // Both supported IDs declare five native buttons and require raw-report observation
+        // to synthesize their undeclared button masks.
         true
     }
 

--- a/LinearMouse/Device/InputReportHandlers/ElecomTrackballHandler.swift
+++ b/LinearMouse/Device/InputReportHandlers/ElecomTrackballHandler.swift
@@ -5,21 +5,19 @@ import Foundation
 
 /// Handles undeclared button bits of supported ELECOM trackballs.
 ///
-/// The 0x010C layout was verified in #1302. Passive on-device capture for 0x011C verified
-/// 8-byte reports with report ID 0x01 in byte 0: Fn1 is `01 20 00 00 00 00 00 00`, Fn2 is
-/// `01 40 00 00 00 00 00 00`, and Fn3 is `01 80 00 00 00 00 00 00`; release clears
-/// the corresponding bit. Its descriptor declares only Button usages 1 through 5 (bits 0
-/// through 4) for report ID 0x01, so these upper masks are undeclared and macOS drops
-/// their events.
+/// These trackballs declare only five HID button usages (1 through 5) in their mouse
+/// collection. Their additional Fn buttons are transmitted in the same input report in the
+/// three upper bits that the descriptor leaves undeclared. macOS discards those bits and does
+/// not emit button events.
 ///
-/// This handler synthesizes logical buttons 5, 6, and 7 for those masks so it does not
-/// duplicate the declared button usages that macOS already handles.
+/// This handler reads those bits from the raw input report and synthesizes buttons 5 through
+/// 7, leaving the declared buttons to macOS.
 ///
 /// Add other product IDs only after confirming their report layout on-device.
 ///
 /// Supported devices:
 /// - ELECOM HUGE TrackBall (0x056E:0x010C)
-/// - ELECOM trackball (0x056E:0x011C)
+/// - ELECOM HUGE Trackball (Wireless) (0x056E:0x011C)
 struct ElecomTrackballHandler: InputReportHandler {
     private struct Product: Hashable {
         let vendorID: Int
@@ -28,7 +26,7 @@ struct ElecomTrackballHandler: InputReportHandler {
 
     private static let supportedProducts: Set<Product> = [
         .init(vendorID: 0x056E, productID: 0x010C), // ELECOM HUGE TrackBall
-        .init(vendorID: 0x056E, productID: 0x011C) // ELECOM trackball
+        .init(vendorID: 0x056E, productID: 0x011C) // ELECOM HUGE Trackball (Wireless)
     ]
 
     /// Report format: | Bits 0-4 (HID Button usages 1-5) | Undeclared masks (3 bits) |

--- a/LinearMouseUnitTests/Device/InputReportHandlerTests.swift
+++ b/LinearMouseUnitTests/Device/InputReportHandlerTests.swift
@@ -282,7 +282,7 @@ final class InputReportHandlerTests: XCTestCase {
         XCTAssertTrue(handler.matches(vendorID: 0x056E, productID: 0x010C))
     }
 
-    func testElecomHandlerMatchesElecomTrackball011C() {
+    func testElecomHandlerMatchesHugeTrackballWireless011C() {
         let handler = ElecomTrackballHandler()
 
         XCTAssertTrue(handler.matches(vendorID: 0x056E, productID: 0x011C))
@@ -444,7 +444,7 @@ final class InputReportHandlerTests: XCTestCase {
         XCTAssertTrue(handlers.first is ElecomTrackballHandler)
     }
 
-    func testRegistryFindsElecomHandlerForElecomTrackball011C() {
+    func testRegistryFindsElecomHandlerForHugeTrackballWireless011C() {
         let handlers = InputReportHandlerRegistry.handlers(for: 0x056E, productID: 0x011C)
 
         XCTAssertEqual(handlers.count, 1)

--- a/LinearMouseUnitTests/Device/InputReportHandlerTests.swift
+++ b/LinearMouseUnitTests/Device/InputReportHandlerTests.swift
@@ -270,22 +270,34 @@ final class InputReportHandlerTests: XCTestCase {
 
     // MARK: - ElecomTrackballHandler Tests
 
-    /// Builds a report in the format observed from an ELECOM HUGE TrackBall:
+    /// Builds a synthetic 8-byte report used by both supported product IDs:
     /// byte 0 is the report ID, byte 1 holds the button states.
     private func elecomReport(buttons: UInt8) -> Data {
         Data([0x01, buttons, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00])
     }
 
-    func testElecomHandlerMatchesHugeTrackball() {
+    func testElecomHandlerMatchesHugeTrackball010C() {
         let handler = ElecomTrackballHandler()
 
         XCTAssertTrue(handler.matches(vendorID: 0x056E, productID: 0x010C))
+    }
+
+    func testElecomHandlerMatchesElecomTrackball011C() {
+        let handler = ElecomTrackballHandler()
+
+        XCTAssertTrue(handler.matches(vendorID: 0x056E, productID: 0x011C))
     }
 
     func testElecomHandlerDoesNotMatchOtherDevice() {
         let handler = ElecomTrackballHandler()
 
         XCTAssertFalse(handler.matches(vendorID: 0x1234, productID: 0x5678))
+    }
+
+    func testElecomHandlerDoesNotMatchUnsupportedElecomDevice() {
+        let handler = ElecomTrackballHandler()
+
+        XCTAssertFalse(handler.matches(vendorID: 0x056E, productID: 0xFFFF))
     }
 
     func testElecomHandlerAlwaysNeedsReportObservation() {
@@ -319,7 +331,7 @@ final class InputReportHandlerTests: XCTestCase {
     }
 
     func testElecomHandlerDetectsFnButtons() {
-        // Bit 5, 6 and 7 are the three buttons the report descriptor declares as padding.
+        // Bits 5, 6, and 7 are undeclared upper button masks.
         for (mask, button) in [(UInt8(0x20), 5), (UInt8(0x40), 6), (UInt8(0x80), 7)] {
             let recorder = EmissionRecorder()
             let handler = ElecomTrackballHandler(emit: recorder.emit)
@@ -360,8 +372,20 @@ final class InputReportHandlerTests: XCTestCase {
         XCTAssertEqual(context.lastButtonStates, 0xA0)
     }
 
-    /// Buttons 1 to 5 are declared in the report descriptor and already handled by macOS,
-    /// so the handler must not emit duplicate events for them.
+    func testElecomHandlerIgnoresDeclaredBitsInMixedReport() {
+        let recorder = EmissionRecorder()
+        let handler = ElecomTrackballHandler(emit: recorder.emit)
+        let context = InputReportContext(report: elecomReport(buttons: 0xFF), lastButtonStates: 0x00)
+
+        handler.handleReport(context) { _ in }
+
+        XCTAssertEqual(recorder.events.map(\.button), [5, 6, 7])
+        XCTAssertTrue(recorder.events.allSatisfy(\.down))
+        XCTAssertEqual(context.lastButtonStates, 0xE0)
+    }
+
+    /// Bits 0 through 4 (HID Button usages 1 through 5) are already handled by macOS, so
+    /// the handler must not emit duplicate events for them.
     func testElecomHandlerIgnoresDeclaredButtons() {
         let recorder = EmissionRecorder()
         let handler = ElecomTrackballHandler(emit: recorder.emit)
@@ -413,11 +437,24 @@ final class InputReportHandlerTests: XCTestCase {
         XCTAssertTrue(handlers.first is KensingtonSlimbladeHandler)
     }
 
-    func testRegistryFindsElecomHandler() {
+    func testRegistryFindsElecomHandlerForHugeTrackball010C() {
         let handlers = InputReportHandlerRegistry.handlers(for: 0x056E, productID: 0x010C)
 
         XCTAssertEqual(handlers.count, 1)
         XCTAssertTrue(handlers.first is ElecomTrackballHandler)
+    }
+
+    func testRegistryFindsElecomHandlerForElecomTrackball011C() {
+        let handlers = InputReportHandlerRegistry.handlers(for: 0x056E, productID: 0x011C)
+
+        XCTAssertEqual(handlers.count, 1)
+        XCTAssertTrue(handlers.first is ElecomTrackballHandler)
+    }
+
+    func testRegistryReturnsEmptyForUnsupportedElecomDevice() {
+        let handlers = InputReportHandlerRegistry.handlers(for: 0x056E, productID: 0xFFFF)
+
+        XCTAssertTrue(handlers.isEmpty)
     }
 
     func testRegistryReturnsEmptyForUnknownDevice() {


### PR DESCRIPTION
## Summary

The wireless ELECOM HUGE TrackBall (`0x056E:0x011C`) reports its Fn1,
Fn2, and Fn3 buttons in bits that its HID descriptor leaves undeclared,
so macOS drops them and the buttons cannot be mapped to anything.

The wired model (`0x056E:0x010C`) has been supported since #1302 and uses
the same report layout, but the wireless variant was never added to the
handler's allowlist.

## Verification

Confirmed on-device with a passive `IOHIDManager` input report capture.
Reports are 8 bytes with report ID `0x01` in byte 0:

| Button  | Report                    |
| ------- | ------------------------- |
| Fn1     | `01 20 00 ...`            |
| Fn2     | `01 40 00 ...`            |
| Fn3     | `01 80 00 ...`            |
| Release | corresponding bit cleared |

Repeated press/release cycles produced the same mapping. The descriptor
declares Button usages 1 through 5 only, so masks `0x20`, `0x40`, and
`0x80` have no native usage, meaning synthesizing buttons 5 through 7
cannot duplicate events macOS already delivers.

## Tests

`make test`: 332 tests, 0 failures. `make lint` clean.

Also verified manually on the device: Fn1, Fn2, and Fn3 are recorded as
buttons 5, 6, and 7 in the button mapping recorder and the assigned
actions fire as expected.
