### PR TITLE
Add experimental libinput click debouncing mode

### DIFF
--- a/Documentation/Configuration.d.ts
+++ b/Documentation/Configuration.d.ts
@@ -1014,7 +1014,13 @@ declare namespace Scheme {
 
     type ClickDebouncing = {
       /**
-       * @description The time period in which rapid clicks are ignored.
+       * @description Select the existing click filter or the experimental libinput-inspired state machine.
+       * @default legacy
+       */
+      mode?: ClickDebouncing.Mode;
+
+      /**
+       * @description Enables click debouncing when greater than zero. The value is the debounce window in milliseconds for legacy mode; libinput mode uses fixed 25 ms and 12 ms windows.
        */
       timeout?: Int;
 
@@ -1024,10 +1030,24 @@ declare namespace Scheme {
       resetTimerOnMouseUp?: boolean;
 
       /**
-       * @description Buttons to debounce.
+       * @description Buttons to debounce in legacy mode. Libinput mode applies to all standard mouse buttons.
        */
       buttons?: PhysicalButton[];
     };
+
+    namespace ClickDebouncing {
+      /**
+       * @description Use LinearMouse's existing press-only click filter.
+       */
+      type Legacy = "legacy";
+
+      /**
+       * @description Use the experimental libinput press-and-release state machine with its fixed 25 ms bounce and 12 ms spurious-release windows.
+       */
+      type Libinput = "libinput";
+
+      type Mode = Legacy | Libinput;
+    }
 
     type Gesture = {
       /**

--- a/Documentation/Configuration.json
+++ b/Documentation/Configuration.json
@@ -236,11 +236,16 @@
       "additionalProperties": false,
       "properties": {
         "buttons": {
-          "description": "Buttons to debounce.",
+          "description": "Buttons to debounce in legacy mode. Libinput mode applies to all standard mouse buttons.",
           "items": {
             "$ref": "#/definitions/PhysicalButton"
           },
           "type": "array"
+        },
+        "mode": {
+          "$ref": "#/definitions/Scheme.Buttons.ClickDebouncing.Mode",
+          "default": "legacy",
+          "description": "Select the existing click filter or the experimental libinput-inspired state machine."
         },
         "resetTimerOnMouseUp": {
           "description": "If the value is true, the timer will be reset on mouse up.",
@@ -248,10 +253,30 @@
         },
         "timeout": {
           "$ref": "#/definitions/Int",
-          "description": "The time period in which rapid clicks are ignored."
+          "description": "Enables click debouncing when greater than zero. The value is the debounce window in milliseconds for legacy mode; libinput mode uses fixed 25 ms and 12 ms windows."
         }
       },
       "type": "object"
+    },
+    "Scheme.Buttons.ClickDebouncing.Legacy": {
+      "const": "legacy",
+      "description": "Use LinearMouse's existing press-only click filter.",
+      "type": "string"
+    },
+    "Scheme.Buttons.ClickDebouncing.Libinput": {
+      "const": "libinput",
+      "description": "Use the experimental libinput press-and-release state machine with its fixed 25 ms bounce and 12 ms spurious-release windows.",
+      "type": "string"
+    },
+    "Scheme.Buttons.ClickDebouncing.Mode": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/Scheme.Buttons.ClickDebouncing.Legacy"
+        },
+        {
+          "$ref": "#/definitions/Scheme.Buttons.ClickDebouncing.Libinput"
+        }
+      ]
     },
     "Scheme.Buttons.Gesture": {
       "additionalProperties": false,

--- a/Documentation/Configuration.md
+++ b/Documentation/Configuration.md
@@ -120,6 +120,40 @@ For example, to use a smoother scrolling profile for a mouse:
 If you want different tuning for each direction, provide `vertical` and `horizontal` values under
 `smoothed`.
 
+## Click debouncing
+
+`buttons.clickDebouncing` filters electrical chatter from worn or noisy mouse switches. Existing
+configurations continue to use the `legacy` mode when `mode` is omitted.
+
+The experimental `libinput` mode tracks press and release pairs with a state machine. Like
+libinput, it uses a fixed 25 ms bounce window and a fixed 12 ms spurious-release window. It may
+delay a suspicious release briefly, but it preserves the final release so applications do not
+remain in a stuck dragging or resizing state.
+
+```json
+{
+  "schemes": [
+    {
+      "if": {
+        "device": {
+          "category": "mouse"
+        }
+      },
+      "buttons": {
+        "clickDebouncing": {
+          "mode": "libinput",
+          "timeout": 25
+        }
+      }
+    }
+  ]
+}
+```
+
+`timeout` must be greater than zero to enable the feature. Its numeric value and
+`resetTimerOnMouseUp` apply only to `legacy` mode. The `buttons` list also applies only to
+`legacy` mode; `libinput` mode always uses its fixed windows and covers all standard mouse buttons.
+
 ## Device matching
 
 Vendor ID and product ID can be provided to match a specific device.

--- a/LinearMouse/EventTransformer/ClickDebouncingTransformer.swift
+++ b/LinearMouse/EventTransformer/ClickDebouncingTransformer.swift
@@ -10,11 +10,18 @@ class ClickDebouncingTransformer: EventTransformer {
     private let button: CGMouseButton
     private let timeout: TimeInterval
     private let resetTimerOnMouseUp: Bool
+    private let nowInNanoseconds: () -> UInt64
 
-    init(for button: CGMouseButton, timeout: TimeInterval, resetTimerOnMouseUp: Bool) {
+    init(
+        for button: CGMouseButton,
+        timeout: TimeInterval,
+        resetTimerOnMouseUp: Bool,
+        nowInNanoseconds: @escaping () -> UInt64 = { DispatchTime.now().uptimeNanoseconds }
+    ) {
         self.button = button
         self.timeout = timeout
         self.resetTimerOnMouseUp = resetTimerOnMouseUp
+        self.nowInNanoseconds = nowInNanoseconds
     }
 
     private var mouseDownEventType: CGEventType {
@@ -64,11 +71,11 @@ class ClickDebouncingTransformer: EventTransformer {
     }
 
     private func touchLastClickedAt() {
-        lastClickedAtInNanoseconds = DispatchTime.now().uptimeNanoseconds
+        lastClickedAtInNanoseconds = nowInNanoseconds()
     }
 
     private var intervalSinceLastClick: TimeInterval {
         let nanosecondsPerSecond = 1e9
-        return Double(DispatchTime.now().uptimeNanoseconds - lastClickedAtInNanoseconds) / nanosecondsPerSecond
+        return Double(nowInNanoseconds() - lastClickedAtInNanoseconds) / nanosecondsPerSecond
     }
 }

--- a/LinearMouse/EventTransformer/EventTransformer.swift
+++ b/LinearMouse/EventTransformer/EventTransformer.swift
@@ -7,6 +7,12 @@ import os.log
 
 struct EventTransformerContext {
     var device: Device?
+    var deferredEventSink: ((CGEvent) -> Void)?
+
+    init(device: Device?, deferredEventSink: ((CGEvent) -> Void)? = nil) {
+        self.device = device
+        self.deferredEventSink = deferredEventSink
+    }
 }
 
 struct EventTransformerResolution {
@@ -14,13 +20,21 @@ struct EventTransformerResolution {
     var context: EventTransformerContext
 
     func transform(_ event: CGEvent) -> CGEvent? {
-        transformer.transform(event, in: context)
+        var context = context
+        context.deferredEventSink = { $0.post(tap: .cgSessionEventTap) }
+        return transformer.transform(event, in: context)
     }
 }
 
 protocol EventTransformer {
     func transform(_ event: CGEvent, in context: EventTransformerContext) -> CGEvent?
 }
+
+/// Adopted by transformers that can emit an event after `transform` returns.
+///
+/// The array transformer provides those events with a continuation through the
+/// remaining transformers before they are posted back to the session.
+protocol DeferredEventTransformer {}
 
 enum LogitechControlEventHandlingResult {
     case notHandled
@@ -41,8 +55,25 @@ extension [EventTransformer]: EventTransformer {
     func transform(_ event: CGEvent, in context: EventTransformerContext) -> CGEvent? {
         var event: CGEvent? = event
 
-        for eventTransformer in self {
-            event = event.flatMap { eventTransformer.transform($0, in: context) }
+        for (index, eventTransformer) in enumerated() {
+            event = event.flatMap {
+                var transformerContext = context
+
+                if eventTransformer is DeferredEventTransformer,
+                   let finalSink = context.deferredEventSink {
+                    // Capture only the tail. A deferred transformer may retain this
+                    // continuation while a timer is active, so capturing the full
+                    // array here would create a temporary retain cycle.
+                    let remainingTransformers = Array(dropFirst(index + 1))
+                    transformerContext.deferredEventSink = { deferredEvent in
+                        if let transformedEvent = remainingTransformers.transform(deferredEvent, in: context) {
+                            finalSink(transformedEvent)
+                        }
+                    }
+                }
+
+                return eventTransformer.transform($0, in: transformerContext)
+            }
         }
 
         return event

--- a/LinearMouse/EventTransformer/EventTransformerManager.swift
+++ b/LinearMouse/EventTransformer/EventTransformerManager.swift
@@ -351,15 +351,26 @@ class EventTransformerManager {
                 ))
         }
 
-        if let timeout = scheme.buttons.clickDebouncing.timeout, timeout > 0,
-           let buttons = scheme.buttons.clickDebouncing.buttons {
+        if let timeout = scheme.buttons.clickDebouncing.timeout, timeout > 0 {
+            let mode = scheme.buttons.clickDebouncing.mode ?? .legacy
             let resetTimerOnMouseUp = scheme.buttons.clickDebouncing.resetTimerOnMouseUp ?? false
+            let buttons = mode == .libinput
+                ? Scheme.Buttons.ClickDebouncing.standardButtons
+                : scheme.buttons.clickDebouncing.buttons ?? []
+
             for button in buttons {
-                eventTransformer.append(ClickDebouncingTransformer(
-                    for: button,
-                    timeout: TimeInterval(timeout) / 1000,
-                    resetTimerOnMouseUp: resetTimerOnMouseUp
-                ))
+                switch mode {
+                case .legacy:
+                    eventTransformer.append(ClickDebouncingTransformer(
+                        for: button,
+                        timeout: TimeInterval(timeout) / 1000,
+                        resetTimerOnMouseUp: resetTimerOnMouseUp
+                    ))
+                case .libinput:
+                    eventTransformer.append(LibinputClickDebouncingTransformer(
+                        for: button
+                    ))
+                }
             }
         }
 
@@ -478,7 +489,9 @@ class EventTransformerManager {
     }
 
     private func resetState() {
+        let activeEventTransformer = activeCacheKey.flatMap { eventTransformerCache.value(forKey: $0) }
         let oldAutoScroll = sharedAutoScrollTransformer
+        deactivate(activeEventTransformer, excluding: oldAutoScroll)
         sharedAutoScrollTransformer = nil
         activeCacheKey = nil
         eventTransformerCache.removeAllValues()

--- a/LinearMouse/EventTransformer/LibinputClickDebouncingEngine.swift
+++ b/LinearMouse/EventTransformer/LibinputClickDebouncingEngine.swift
@@ -1,0 +1,186 @@
+// MIT License
+// Copyright (c) 2021-2026 LinearMouse
+
+import Foundation
+
+/// State transitions are adapted from libinput's button debouncer.
+/// See ThirdPartyNotices/libinput.txt for source and license details.
+struct LibinputClickDebouncingEngine {
+    enum ButtonState: Equatable {
+        case pressed
+        case released
+    }
+
+    enum Input: Equatable {
+        case press
+        case release
+        case bounceTimeout
+        case spuriousTimeout
+        case otherButton
+    }
+
+    enum Effect: Equatable {
+        case emit(ButtonState)
+        case setBounceTimer
+        case setSpuriousTimer
+        case cancelBounceTimer
+        case cancelSpuriousTimer
+        case spuriousDebouncingEnabled
+    }
+
+    enum State: Equatable {
+        case isUp
+        case isDown
+        case isDownWaiting
+        case isUpDelaying
+        case isUpDelayingSpurious
+        case isUpDetectingSpurious
+        case isDownDetectingSpurious
+        case isUpWaiting
+        case isDownDelaying
+    }
+
+    private(set) var state: State = .isUp
+    private(set) var spuriousDebouncingEnabled = false
+
+    mutating func handle(_ input: Input) -> [Effect] {
+        var effects = [Effect]()
+
+        if input == .otherButton {
+            effects.append(.cancelBounceTimer)
+            effects.append(.cancelSpuriousTimer)
+        }
+
+        switch state {
+        case .isUp:
+            switch input {
+            case .press:
+                state = .isDownWaiting
+                effects.append(.setBounceTimer)
+                effects.append(.emit(.pressed))
+            case .release:
+                // LinearMouse can switch configuration while a button is held.
+                // Passing an unmatched release through is safer than risking a
+                // stuck button in the receiving application.
+                effects.append(.emit(.released))
+            case .otherButton, .bounceTimeout, .spuriousTimeout:
+                break
+            }
+
+        case .isDown:
+            switch input {
+            case .press:
+                // A duplicated press does not change the logical button state.
+                break
+            case .release:
+                effects.append(.setBounceTimer)
+                effects.append(.setSpuriousTimer)
+                if spuriousDebouncingEnabled {
+                    state = .isUpDelayingSpurious
+                } else {
+                    state = .isUpDetectingSpurious
+                    effects.append(.emit(.released))
+                }
+            case .otherButton, .bounceTimeout, .spuriousTimeout:
+                break
+            }
+
+        case .isDownWaiting:
+            switch input {
+            case .release:
+                state = .isUpDelaying
+                effects.append(.setBounceTimer)
+            case .bounceTimeout, .otherButton:
+                state = .isDown
+            case .press, .spuriousTimeout:
+                break
+            }
+
+        case .isUpDelaying:
+            switch input {
+            case .press:
+                state = .isDownWaiting
+                effects.append(.setBounceTimer)
+            case .bounceTimeout, .otherButton:
+                state = .isUp
+                effects.append(.emit(.released))
+            case .release, .spuriousTimeout:
+                break
+            }
+
+        case .isUpDelayingSpurious:
+            switch input {
+            case .press:
+                state = .isDown
+                effects.append(.cancelBounceTimer)
+                effects.append(.cancelSpuriousTimer)
+            case .spuriousTimeout:
+                state = .isUpWaiting
+                effects.append(.emit(.released))
+            case .otherButton:
+                state = .isUp
+                effects.append(.emit(.released))
+            case .release, .bounceTimeout:
+                break
+            }
+
+        case .isUpDetectingSpurious:
+            switch input {
+            case .press:
+                state = .isDownDetectingSpurious
+                effects.append(.setBounceTimer)
+                effects.append(.setSpuriousTimer)
+            case .bounceTimeout, .otherButton:
+                state = .isUp
+            case .spuriousTimeout:
+                state = .isUpWaiting
+            case .release:
+                break
+            }
+
+        case .isDownDetectingSpurious:
+            switch input {
+            case .release:
+                state = .isUpDetectingSpurious
+                effects.append(.setBounceTimer)
+                effects.append(.setSpuriousTimer)
+            case .spuriousTimeout:
+                state = .isDown
+                spuriousDebouncingEnabled = true
+                effects.append(.cancelBounceTimer)
+                effects.append(.spuriousDebouncingEnabled)
+                effects.append(.emit(.pressed))
+            case .bounceTimeout, .otherButton:
+                state = .isDown
+                effects.append(.emit(.pressed))
+            case .press:
+                break
+            }
+
+        case .isUpWaiting:
+            switch input {
+            case .press:
+                state = .isDownDelaying
+                effects.append(.setBounceTimer)
+            case .bounceTimeout, .otherButton:
+                state = .isUp
+            case .release, .spuriousTimeout:
+                break
+            }
+
+        case .isDownDelaying:
+            switch input {
+            case .release:
+                state = .isUpWaiting
+                effects.append(.setBounceTimer)
+            case .bounceTimeout, .otherButton:
+                state = .isDown
+                effects.append(.emit(.pressed))
+            case .press, .spuriousTimeout:
+                break
+            }
+        }
+
+        return effects
+    }
+}

--- a/LinearMouse/EventTransformer/LibinputClickDebouncingTransformer.swift
+++ b/LinearMouse/EventTransformer/LibinputClickDebouncingTransformer.swift
@@ -1,0 +1,368 @@
+// MIT License
+// Copyright (c) 2021-2026 LinearMouse
+
+import Foundation
+import os.log
+
+final class LibinputClickDebouncingTransformer: EventTransformer, DeferredEventTransformer, Deactivatable {
+    static let bounceTimeout: TimeInterval = 0.025
+    static let spuriousTimeout: TimeInterval = 0.012
+    private static let bounceTimeoutNanoseconds: UInt64 = 25_000_000
+    private static let spuriousTimeoutNanoseconds: UInt64 = 12_000_000
+
+    final class TimerToken {
+        private var invalidateHandler: (() -> Void)?
+
+        init(invalidate: @escaping () -> Void) {
+            invalidateHandler = invalidate
+        }
+
+        deinit {
+            invalidate()
+        }
+
+        func invalidate() {
+            invalidateHandler?()
+            invalidateHandler = nil
+        }
+    }
+
+    typealias TimerScheduler = (TimeInterval, @escaping () -> Void) -> TimerToken?
+    typealias MonotonicClock = () -> UInt64
+
+    private struct DeferredEvent {
+        var event: CGEvent
+        var sink: (CGEvent) -> Void
+    }
+
+    private static let log = OSLog(
+        subsystem: Bundle.main.bundleIdentifier!,
+        category: "LibinputClickDebouncing"
+    )
+
+    private let button: CGMouseButton
+    private let scheduleTimer: TimerScheduler
+    private let monotonicClock: MonotonicClock
+    private let fallbackEventSink: (CGEvent) -> Void
+
+    private var engine = LibinputClickDebouncingEngine()
+    private var bounceTimer: TimerToken?
+    private var spuriousTimer: TimerToken?
+    // RunLoop timers are wakeups only. These monotonic deadlines define the
+    // actual state-machine boundary when a wakeup is delayed.
+    private var bounceDeadline: UInt64?
+    private var spuriousDeadline: UInt64?
+    private var bounceTimerGeneration: UInt64 = 0
+    private var spuriousTimerGeneration: UInt64 = 0
+    private var pendingPress: DeferredEvent?
+    private var pendingRelease: DeferredEvent?
+
+    init(
+        for button: CGMouseButton,
+        scheduleTimer: @escaping TimerScheduler = LibinputClickDebouncingTransformer.scheduleEventThreadTimer,
+        monotonicClock: @escaping MonotonicClock = { DispatchTime.now().uptimeNanoseconds },
+        eventSink: @escaping (CGEvent) -> Void = { $0.post(tap: .cgSessionEventTap) }
+    ) {
+        self.button = button
+        self.scheduleTimer = scheduleTimer
+        self.monotonicClock = monotonicClock
+        fallbackEventSink = eventSink
+    }
+
+    func transform(_ event: CGEvent, in context: EventTransformerContext) -> CGEvent? {
+        guard let inputState = buttonState(of: event),
+              let eventButton = MouseEventView(event).mouseButton else {
+            return event
+        }
+
+        expireElapsedTimers(at: monotonicClock())
+
+        guard eventButton == button else {
+            _ = process(.otherButton)
+            return event
+        }
+
+        let deferredEvent = DeferredEvent(
+            event: event.copy() ?? event,
+            sink: context.deferredEventSink ?? fallbackEventSink
+        )
+        switch inputState {
+        case .pressed:
+            pendingPress = deferredEvent
+        case .released:
+            pendingRelease = deferredEvent
+        }
+
+        let forwardsCurrentEvent = process(
+            inputState == .pressed ? .press : .release,
+            currentEventState: inputState
+        )
+        return forwardsCurrentEvent ? event : nil
+    }
+
+    func deactivate() {
+        // Flushing through OTHERBUTTON mirrors libinput's neutral-state
+        // guarantee and balances any press or release held by a timer.
+        _ = process(.otherButton)
+        cancelBounceTimer()
+        cancelSpuriousTimer()
+        engine = LibinputClickDebouncingEngine()
+        pendingPress = nil
+        pendingRelease = nil
+    }
+
+    private static func scheduleEventThreadTimer(
+        interval: TimeInterval,
+        handler: @escaping () -> Void
+    ) -> TimerToken? {
+        guard let timer = EventThread.shared.scheduleTimer(
+            interval: interval,
+            repeats: false,
+            handler: handler
+        ) else {
+            return nil
+        }
+
+        return TimerToken {
+            timer.invalidate()
+        }
+    }
+
+    private func buttonState(of event: CGEvent) -> LibinputClickDebouncingEngine.ButtonState? {
+        switch event.type {
+        case .leftMouseDown, .rightMouseDown, .otherMouseDown:
+            return .pressed
+        case .leftMouseUp, .rightMouseUp, .otherMouseUp:
+            return .released
+        default:
+            return nil
+        }
+    }
+
+    @discardableResult
+    private func process(
+        _ input: LibinputClickDebouncingEngine.Input,
+        currentEventState: LibinputClickDebouncingEngine.ButtonState? = nil
+    ) -> Bool {
+        let previousState = engine.state
+        let effects = engine.handle(input)
+        var forwardsCurrentEvent = false
+
+        for effect in effects {
+            switch effect {
+            case let .emit(buttonState):
+                if buttonState == currentEventState {
+                    forwardsCurrentEvent = true
+                } else {
+                    emitPendingEvent(for: buttonState)
+                }
+                clearPendingEvent(for: buttonState)
+            case .setBounceTimer:
+                setBounceTimer()
+            case .setSpuriousTimer:
+                setSpuriousTimer()
+            case .cancelBounceTimer:
+                cancelBounceTimer()
+            case .cancelSpuriousTimer:
+                cancelSpuriousTimer()
+            case .spuriousDebouncingEnabled:
+                os_log(
+                    "Enabled short release debouncing for button %{public}u",
+                    log: Self.log,
+                    type: .info,
+                    button.rawValue
+                )
+            }
+        }
+
+        discardUnusedPendingEvents()
+
+        os_log(
+            "Button %{public}u: %{public}@ -> %{public}@ -> %{public}@",
+            log: Self.log,
+            type: .debug,
+            button.rawValue,
+            String(describing: previousState),
+            String(describing: input),
+            String(describing: engine.state)
+        )
+
+        return forwardsCurrentEvent
+    }
+
+    private func emitPendingEvent(for state: LibinputClickDebouncingEngine.ButtonState) {
+        let deferredEvent: DeferredEvent?
+        switch state {
+        case .pressed:
+            deferredEvent = pendingPress
+        case .released:
+            deferredEvent = pendingRelease
+        }
+
+        guard let deferredEvent else {
+            os_log(
+                "Cannot emit %{public}@ for button %{public}u: no pending event",
+                log: Self.log,
+                type: .error,
+                String(describing: state),
+                button.rawValue
+            )
+            return
+        }
+        deferredEvent.sink(deferredEvent.event)
+    }
+
+    private func clearPendingEvent(for state: LibinputClickDebouncingEngine.ButtonState) {
+        switch state {
+        case .pressed:
+            pendingPress = nil
+        case .released:
+            pendingRelease = nil
+        }
+    }
+
+    private func discardUnusedPendingEvents() {
+        switch engine.state {
+        case .isUpDelaying, .isUpDelayingSpurious:
+            pendingPress = nil
+        case .isDownDetectingSpurious, .isDownDelaying:
+            pendingRelease = nil
+        case .isUp, .isDown, .isDownWaiting, .isUpDetectingSpurious, .isUpWaiting:
+            pendingPress = nil
+            pendingRelease = nil
+        }
+    }
+
+    private func setBounceTimer() {
+        cancelBounceTimer()
+        bounceTimerGeneration &+= 1
+        let generation = bounceTimerGeneration
+        let deadline = monotonicClock() &+ Self.bounceTimeoutNanoseconds
+        bounceDeadline = deadline
+        scheduleBounceTimer(deadline: deadline, generation: generation)
+    }
+
+    private func scheduleBounceTimer(deadline: UInt64, generation: UInt64) {
+        let interval = interval(until: deadline)
+        bounceTimer = scheduleTimer(interval) { [weak self] in
+            guard let self else {
+                return
+            }
+            handleBounceTimer(generation: generation)
+        }
+
+        if bounceTimer == nil {
+            fireBounceTimeout()
+        }
+    }
+
+    private func setSpuriousTimer() {
+        cancelSpuriousTimer()
+        spuriousTimerGeneration &+= 1
+        let generation = spuriousTimerGeneration
+        let deadline = monotonicClock() &+ Self.spuriousTimeoutNanoseconds
+        spuriousDeadline = deadline
+        scheduleSpuriousTimer(deadline: deadline, generation: generation)
+    }
+
+    private func scheduleSpuriousTimer(deadline: UInt64, generation: UInt64) {
+        let interval = interval(until: deadline)
+        spuriousTimer = scheduleTimer(interval) { [weak self] in
+            guard let self else {
+                return
+            }
+            handleSpuriousTimer(generation: generation)
+        }
+
+        if spuriousTimer == nil {
+            fireSpuriousTimeout()
+        }
+    }
+
+    private func cancelBounceTimer() {
+        bounceTimerGeneration &+= 1
+        bounceTimer?.invalidate()
+        bounceTimer = nil
+        bounceDeadline = nil
+    }
+
+    private func cancelSpuriousTimer() {
+        spuriousTimerGeneration &+= 1
+        spuriousTimer?.invalidate()
+        spuriousTimer = nil
+        spuriousDeadline = nil
+    }
+
+    private func handleBounceTimer(generation: UInt64) {
+        guard generation == bounceTimerGeneration,
+              let deadline = bounceDeadline else {
+            return
+        }
+
+        let now = monotonicClock()
+        if now < deadline {
+            scheduleBounceTimer(deadline: deadline, generation: generation)
+        } else {
+            expireElapsedTimers(at: now)
+        }
+    }
+
+    private func handleSpuriousTimer(generation: UInt64) {
+        guard generation == spuriousTimerGeneration,
+              let deadline = spuriousDeadline else {
+            return
+        }
+
+        let now = monotonicClock()
+        if now < deadline {
+            scheduleSpuriousTimer(deadline: deadline, generation: generation)
+        } else {
+            expireElapsedTimers(at: now)
+        }
+    }
+
+    private func expireElapsedTimers(at now: UInt64) {
+        while true {
+            let bounceIsNext = switch (bounceDeadline, spuriousDeadline) {
+            case let (bounce?, spurious?):
+                bounce <= spurious
+            case (.some, .none):
+                true
+            case (.none, .some), (.none, .none):
+                false
+            }
+
+            if bounceIsNext, let deadline = bounceDeadline, deadline <= now {
+                fireBounceTimeout()
+            } else if let deadline = spuriousDeadline, deadline <= now {
+                fireSpuriousTimeout()
+            } else {
+                return
+            }
+        }
+    }
+
+    private func fireBounceTimeout() {
+        bounceTimerGeneration &+= 1
+        bounceTimer?.invalidate()
+        bounceTimer = nil
+        bounceDeadline = nil
+        process(.bounceTimeout)
+    }
+
+    private func fireSpuriousTimeout() {
+        spuriousTimerGeneration &+= 1
+        spuriousTimer?.invalidate()
+        spuriousTimer = nil
+        spuriousDeadline = nil
+        process(.spuriousTimeout)
+    }
+
+    private func interval(until deadline: UInt64) -> TimeInterval {
+        let now = monotonicClock()
+        guard deadline > now else {
+            return 0
+        }
+        return TimeInterval(deadline - now) / 1_000_000_000
+    }
+}

--- a/LinearMouse/Localizable.xcstrings
+++ b/LinearMouse/Localizable.xcstrings
@@ -2964,6 +2964,214 @@
         }
       }
     },
+    "Multiple buttons" : {
+      "localizations" : {
+        "af" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Verskeie knoppies"
+          }
+        },
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "عدة أزرار"
+          }
+        },
+        "bs" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Više dugmadi"
+          }
+        },
+        "ca" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Diversos botons"
+          }
+        },
+        "cs" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Více tlačítek"
+          }
+        },
+        "da" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Flere knapper"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mehrere Maustasten"
+          }
+        },
+        "el" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Πολλά κουμπιά"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Varios botones"
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Useita painikkeita"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Plusieurs boutons"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "מספר כפתורים"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Több gomb"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Beberapa tombol"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Più pulsanti"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "複数のボタン"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "여러 버튼"
+          }
+        },
+        "my" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ခလုတ်အများအပြား"
+          }
+        },
+        "nb-NO" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Flere knapper"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Meerdere knoppen"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Wiele przycisków"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Vários botões"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Vários botões"
+          }
+        },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mai multe butoane"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Несколько кнопок"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Viaceré tlačidlá"
+          }
+        },
+        "sr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Више дугмади"
+          }
+        },
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Flera knappar"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Birden fazla düğme"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Кілька кнопок"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nhiều nút"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "多个按钮"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "多個按鈕"
+          }
+        },
+        "zh-Hant-HK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "多個按鈕"
+          }
+        }
+      }
+    },
     "%lld pixels" : {
       "localizations" : {
         "af" : {
@@ -5041,6 +5249,214 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "所有程式"
+          }
+        }
+      }
+    },
+    "All buttons" : {
+      "localizations" : {
+        "af" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Alle knoppies"
+          }
+        },
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "جميع الأزرار"
+          }
+        },
+        "bs" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sva dugmad"
+          }
+        },
+        "ca" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tots els botons"
+          }
+        },
+        "cs" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Všechna tlačítka"
+          }
+        },
+        "da" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Alle knapper"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Alle Maustasten"
+          }
+        },
+        "el" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Όλα τα κουμπιά"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Todos los botones"
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kaikki painikkeet"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tous les boutons"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "כל הכפתורים"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Minden gomb"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Semua tombol"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tutti i pulsanti"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "すべてのボタン"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "모든 버튼"
+          }
+        },
+        "my" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ခလုတ်အားလုံး"
+          }
+        },
+        "nb-NO" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Alle knapper"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Alle knoppen"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Wszystkie przyciski"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Todos os botões"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Todos os botões"
+          }
+        },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Toate butoanele"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Все кнопки"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Všetky tlačidlá"
+          }
+        },
+        "sr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Сва дугмад"
+          }
+        },
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Alla knappar"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tüm düğmeler"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Усі кнопки"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tất cả nút"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "所有按钮"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "所有按鈕"
+          }
+        },
+        "zh-Hant-HK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "所有按鈕"
           }
         }
       }
@@ -7337,6 +7753,214 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "套用到每個觸控板。"
+          }
+        }
+      }
+    },
+    "Apply to" : {
+      "localizations" : {
+        "af" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pas toe op"
+          }
+        },
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "تطبيق على"
+          }
+        },
+        "bs" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Primijeni na"
+          }
+        },
+        "ca" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aplica-ho a"
+          }
+        },
+        "cs" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Použít na"
+          }
+        },
+        "da" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Anvend på"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Anwenden auf"
+          }
+        },
+        "el" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Εφαρμογή σε"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aplicar a"
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Käytä painikkeisiin"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Appliquer à"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "החלה על"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Alkalmazás erre"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Terapkan ke"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Applica a"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "適用先"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "적용 대상"
+          }
+        },
+        "my" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "သက်ရောက်မည့်"
+          }
+        },
+        "nb-NO" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bruk på"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Toepassen op"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Zastosuj do"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aplicar a"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aplicar a"
+          }
+        },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Se aplică la"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Применить к"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Použiť na"
+          }
+        },
+        "sr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Примени на"
+          }
+        },
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tillämpa på"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Şuna uygula"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Застосувати до"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Áp dụng cho"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "应用于"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "套用至"
+          }
+        },
+        "zh-Hant-HK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "套用至"
           }
         }
       }
@@ -12132,6 +12756,214 @@
         }
       }
     },
+    "Classic" : {
+      "localizations" : {
+        "af" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Klassiek"
+          }
+        },
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "كلاسيكي"
+          }
+        },
+        "bs" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Klasični"
+          }
+        },
+        "ca" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Clàssic"
+          }
+        },
+        "cs" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Klasická"
+          }
+        },
+        "da" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Klassisk"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Klassisch"
+          }
+        },
+        "el" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Κλασική"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Clásico"
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Klassinen"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Classique"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "קלאסי"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Klasszikus"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Klasik"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Classico"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "クラシック"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "클래식"
+          }
+        },
+        "my" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ရိုးရာ"
+          }
+        },
+        "nb-NO" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Klassisk"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Klassiek"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Klasyczna"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Clássico"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Clássico"
+          }
+        },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Clasică"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Классический"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Klasická"
+          }
+        },
+        "sr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Класични"
+          }
+        },
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Klassisk"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Klasik"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Класичний"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cổ điển"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "经典"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "經典"
+          }
+        },
+        "zh-Hant-HK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "經典"
+          }
+        }
+      }
+    },
     "Click and release to keep autoscroll active, or hold and drag to scroll only until you let go." : {
       "localizations" : {
         "af" : {
@@ -15665,6 +16497,422 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "按鈕點擊去抖動"
+          }
+        }
+      }
+    },
+    "Debounce interval" : {
+      "localizations" : {
+        "af" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ontbonsingsinterval"
+          }
+        },
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "فترة إزالة الارتداد"
+          }
+        },
+        "bs" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Interval ublažavanja odskoka"
+          }
+        },
+        "ca" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Interval antirebot"
+          }
+        },
+        "cs" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Interval potlačení zákmitů"
+          }
+        },
+        "da" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Interval for kontaktprel"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Entprellintervall"
+          }
+        },
+        "el" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Διάστημα αποθορυβοποίησης"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Intervalo antirrebote"
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Suodatusväli"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Intervalle anti-rebond"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "מרווח סינון"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pergésmentesítési időköz"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Interval debounce"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Intervallo antirimbalzo"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "チャタリング防止間隔"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "채터링 방지 간격"
+          }
+        },
+        "my" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ခလုတ်တုန်ခါမှု စစ်ထုတ်ကာလ"
+          }
+        },
+        "nb-NO" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Intervall for kontaktsprett"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ontdenderinterval"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Interwał eliminacji drgań"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Intervalo antirressalto"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Intervalo antirrepique"
+          }
+        },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Interval de eliminare a oscilațiilor"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Интервал подавления дребезга"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Interval potlačenia zákmitov"
+          }
+        },
+        "sr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Интервал ублажавања одскакања"
+          }
+        },
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Intervall för kontaktstuds"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sıçrama önleme aralığı"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Інтервал усунення брязкоту"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Khoảng khử dội"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "去抖动间隔"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "去抖動間隔"
+          }
+        },
+        "zh-Hant-HK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "去抖動間隔"
+          }
+        }
+      }
+    },
+    "Debouncing method" : {
+      "localizations" : {
+        "af" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ontbonsingsmetode"
+          }
+        },
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "طريقة إزالة ارتداد النقرات"
+          }
+        },
+        "bs" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Metoda ublažavanja odskoka"
+          }
+        },
+        "ca" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mètode antirebot"
+          }
+        },
+        "cs" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Metoda potlačení zákmitů"
+          }
+        },
+        "da" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Metode til kontaktprel"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Entprellmethode"
+          }
+        },
+        "el" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Μέθοδος αποθορυβοποίησης"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Método antirrebote"
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kytkinvärähtelyn suodatusmenetelmä"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Méthode anti-rebond"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "שיטת סינון קפיצות מגע"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pergésmentesítési mód"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Metode debounce"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Metodo antirimbalzo"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "チャタリング防止方式"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "채터링 방지 방식"
+          }
+        },
+        "my" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ခလုတ်တုန်ခါမှု စစ်ထုတ်နည်း"
+          }
+        },
+        "nb-NO" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Metode for kontaktsprett"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ontdendermethode"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Metoda eliminacji drgań styków"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Método antirressalto"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Método antirrepique"
+          }
+        },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Metodă de eliminare a oscilațiilor"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Метод устранения дребезга"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Metóda potlačenia zákmitov"
+          }
+        },
+        "sr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Метод ублажавања одскакања контакта"
+          }
+        },
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Metod för kontaktstuds"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tuş sıçraması önleme yöntemi"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Метод усунення брязкоту контактів"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Phương pháp khử dội"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "去抖动方式"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "去抖動方式"
+          }
+        },
+        "zh-Hant-HK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "去抖動方式"
           }
         }
       }
@@ -28997,214 +30245,6 @@
         }
       }
     },
-    "Ignore rapid clicks within a certain time period." : {
-      "localizations" : {
-        "af" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ignoreer vinnige klikke binne 'n sekere tydperk."
-          }
-        },
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "تجاهل النقرات السريعة خلال فترة زمنية معينة."
-          }
-        },
-        "bs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ignoriraj brze klikove unutar određenog vremenskog perioda."
-          }
-        },
-        "ca" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ignora els clics ràpids dins d'un determinat període de temps."
-          }
-        },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ignoruje rychlá kliknutí v určité časové době."
-          }
-        },
-        "da" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ignorer hurtige klik inden for et bestemt tidsrum."
-          }
-        },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Schnelle, aufeinanderfolgende Klicks innerhalb einer bestimmten Zeitspanne ignorieren."
-          }
-        },
-        "el" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Παράβλεψη γρήγορων κλικ μέσα σε ένα ορισμένο χρονικό διάστημα."
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ignorar pulsaciones rápidas dentro de un determinado período de tiempo."
-          }
-        },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ohita nopeat napsautukset tietyn ajanjakson sisällä."
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ignorer les clics rapides dans une certaine période."
-          }
-        },
-        "he" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "התעלם מלחיצות מהירות שמתרחשות בפרק זמן מסוים."
-          }
-        },
-        "hu" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Gyors kattintások figyelmen kívül hagyása egy bizonyos időn belül."
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Abaikan klik cepat dalam periode waktu tertentu."
-          }
-        },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ignora clic rapidi entro un certo periodo di tempo."
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "一定時間内での素早いクリックを無視します。"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "특정 시간 내의 빠른 클릭을 무시합니다."
-          }
-        },
-        "my" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "အချိန်တစ်ခုအတွင်း ခဏခဏ နှိပ်ခြင်းကို ကန့်သန့်ရန်။."
-          }
-        },
-        "nb-NO" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ignorer raske klikk innenfor en bestemt tidsperiode."
-          }
-        },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Negeer snelle klikken binnen een bepaalde periode."
-          }
-        },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ignoruj szybkie kliknięcia w określonym czasie."
-          }
-        },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ignorar cliques rápidos dentro de um período determinado."
-          }
-        },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ignora cliques rápidos dentro de um período determinado."
-          }
-        },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ignoră clicurile rapide într-o anumită perioadă de timp."
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Пропускает частые нажатие клавиш."
-          }
-        },
-        "sk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ignorovať rýchle kliknutia v určitom časovom období."
-          }
-        },
-        "sr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Игнориши брзе кликове у одређеном временском периоду."
-          }
-        },
-        "sv" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ignorera snabba klick inom en viss tidsperiod."
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Belli bir süre içindeki hızlı tıklamaları yok say."
-          }
-        },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ігнорувати швидкі клацання протягом певного періоду часу."
-          }
-        },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Bỏ qua các nhấp chuột nhanh chóng trong một khoảng thời gian nhất định."
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "忽略在特定时间段内的快速点击。"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "忽略在特定時間段內的快速點擊。"
-          }
-        },
-        "zh-Hant-HK" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "忽略在特定時間段內的快速點擊。"
-          }
-        }
-      }
-    },
     "Immediate" : {
       "comment" : "Preset label for response or inertia. Means the scrolling reaction happens quickly with minimal delay.",
       "localizations" : {
@@ -32322,6 +33362,214 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "允許 App 在內容邊緣套用橡筋式過度捲動。"
+          }
+        }
+      }
+    },
+    "libinput (Beta)" : {
+      "localizations" : {
+        "af" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "libinput (Beta)"
+          }
+        },
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "libinput (تجريبي)"
+          }
+        },
+        "bs" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "libinput (Beta)"
+          }
+        },
+        "ca" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "libinput (Beta)"
+          }
+        },
+        "cs" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "libinput (Beta)"
+          }
+        },
+        "da" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "libinput (Beta)"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "libinput (Beta)"
+          }
+        },
+        "el" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "libinput (Βήτα)"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "libinput (Beta)"
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "libinput (Beta)"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "libinput (Bêta)"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "libinput (בטא)"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "libinput (Béta)"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "libinput (Beta)"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "libinput (Beta)"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "libinput (ベータ)"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "libinput (베타)"
+          }
+        },
+        "my" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "libinput (ဘီတာ)"
+          }
+        },
+        "nb-NO" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "libinput (Beta)"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "libinput (Beta)"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "libinput (Beta)"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "libinput (Beta)"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "libinput (Beta)"
+          }
+        },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "libinput (Beta)"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "libinput (Бета)"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "libinput (Beta)"
+          }
+        },
+        "sr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "libinput (Бета)"
+          }
+        },
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "libinput (Beta)"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "libinput (Beta)"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "libinput (Бета)"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "libinput (Beta)"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "libinput (测试版)"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "libinput (測試版)"
+          }
+        },
+        "zh-Hant-HK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "libinput (測試版)"
           }
         }
       }
@@ -37318,6 +38566,214 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "無動作"
+          }
+        }
+      }
+    },
+    "No buttons" : {
+      "localizations" : {
+        "af" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Geen knoppies"
+          }
+        },
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "لا أزرار"
+          }
+        },
+        "bs" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bez dugmadi"
+          }
+        },
+        "ca" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cap botó"
+          }
+        },
+        "cs" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Žádná tlačítka"
+          }
+        },
+        "da" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ingen knapper"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Keine Maustasten"
+          }
+        },
+        "el" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Κανένα κουμπί"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ningún botón"
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ei painikkeita"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aucun bouton"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ללא כפתורים"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nincs gomb"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tidak ada tombol"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nessun pulsante"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ボタンなし"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "버튼 없음"
+          }
+        },
+        "my" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ခလုတ်မရွေးထားပါ"
+          }
+        },
+        "nb-NO" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ingen knapper"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Geen knoppen"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Brak przycisków"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nenhum botão"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nenhum botão"
+          }
+        },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Niciun buton"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Нет кнопок"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Žiadne tlačidlá"
+          }
+        },
+        "sr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Без дугмади"
+          }
+        },
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Inga knappar"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Düğme yok"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Немає кнопок"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Không có nút"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "未选择按钮"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "未選擇按鈕"
+          }
+        },
+        "zh-Hant-HK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "未選擇按鈕"
           }
         }
       }
@@ -43409,7 +44865,7 @@
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Timer bei Mausbewegung zurücksetzen"
+            "value" : "Timer beim Loslassen der Maustaste zurücksetzen"
           }
         },
         "el" : {
@@ -51287,6 +52743,214 @@
         }
       }
     },
+    "Select at least one mouse button." : {
+      "localizations" : {
+        "af" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kies ten minste een muisknoppie."
+          }
+        },
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "حدّد زر ماوس واحدًا على الأقل."
+          }
+        },
+        "bs" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Odaberite najmanje jedno dugme miša."
+          }
+        },
+        "ca" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Seleccioneu com a mínim un botó del ratolí."
+          }
+        },
+        "cs" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Vyberte alespoň jedno tlačítko myši."
+          }
+        },
+        "da" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Vælg mindst én museknap."
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mindestens eine Maustaste auswählen."
+          }
+        },
+        "el" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Επιλέξτε τουλάχιστον ένα κουμπί ποντικιού."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Selecciona al menos un botón del ratón."
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Valitse vähintään yksi hiiren painike."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sélectionnez au moins un bouton de souris."
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "יש לבחור לפחות כפתור עכבר אחד."
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Válasszon ki legalább egy egérgombot."
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pilih setidaknya satu tombol mouse."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Seleziona almeno un pulsante del mouse."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "マウスボタンを1つ以上選択してください。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "마우스 버튼을 하나 이상 선택하세요."
+          }
+        },
+        "my" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "မောက်စ်ခလုတ် အနည်းဆုံးတစ်ခုကို ရွေးပါ။"
+          }
+        },
+        "nb-NO" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Velg minst én museknapp."
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Selecteer ten minste één muisknop."
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Wybierz co najmniej jeden przycisk myszy."
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Selecione pelo menos um botão do rato."
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Selecione pelo menos um botão do mouse."
+          }
+        },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Selectați cel puțin un buton al mouse-ului."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Выберите хотя бы одну кнопку мыши."
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Vyberte aspoň jedno tlačidlo myši."
+          }
+        },
+        "sr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Изаберите бар једно дугме миша."
+          }
+        },
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Välj minst en musknapp."
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "En az bir fare düğmesi seçin."
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Виберіть принаймні одну кнопку миші."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Chọn ít nhất một nút chuột."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "请至少选择一个鼠标按钮。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "請至少選擇一個滑鼠按鈕。"
+          }
+        },
+        "zh-Hant-HK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "請至少選擇一個滑鼠按鈕。"
+          }
+        }
+      }
+    },
     "Selected" : {
       "comment" : "Badge text shown on the currently chosen preset or option.",
       "localizations" : {
@@ -55246,6 +56910,214 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "登入時啟動"
+          }
+        }
+      }
+    },
+    "Suppress unintended clicks caused by a worn or noisy mouse switch." : {
+      "localizations" : {
+        "af" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Onderdruk onbedoelde klikke wat deur 'n verslete of raserige muisskakelaar veroorsaak word."
+          }
+        },
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "امنع النقرات غير المقصودة الناتجة عن مفتاح ماوس مهترئ أو كثير الضوضاء."
+          }
+        },
+        "bs" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Suzbija neželjene klikove uzrokovane istrošenim ili nestabilnim prekidačem miša."
+          }
+        },
+        "ca" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Evita els clics involuntaris causats per un interruptor del ratolí desgastat o inestable."
+          }
+        },
+        "cs" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Potlačí nechtěná kliknutí způsobená opotřebeným nebo nestabilním spínačem myši."
+          }
+        },
+        "da" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Undertryk utilsigtede klik fra en slidt eller ustabil musekontakt."
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Unterdrückt unbeabsichtigte Klicks, die durch einen verschlissenen oder störanfälligen Maustaster verursacht werden."
+          }
+        },
+        "el" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Καταστέλλει ακούσια κλικ που προκαλούνται από φθαρμένο ή ασταθή διακόπτη ποντικιού."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Evita clics involuntarios causados por un interruptor del ratón desgastado o inestable."
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Estä kuluneen tai epävakaan hiirikytkimen aiheuttamat tahattomat napsautukset."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bloque les clics involontaires causés par un micro-interrupteur de souris usé ou instable."
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "סינון לחיצות לא מכוונות שנגרמות ממתג עכבר שחוק או לא יציב."
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kiszűri az elhasználódott vagy bizonytalan egérkapcsoló okozta nem szándékos kattintásokat."
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cegah klik yang tidak disengaja akibat sakelar mouse yang aus atau tidak stabil."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Impedisce i clic involontari causati da un microinterruttore del mouse usurato o instabile."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "摩耗または不安定なマウススイッチによる意図しないクリックを防止します。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "마모되었거나 불안정한 마우스 스위치로 인한 의도하지 않은 클릭을 방지합니다."
+          }
+        },
+        "my" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ဟောင်းနွမ်းနေသော သို့မဟုတ် မတည်ငြိမ်သော မောက်စ်ခလုတ်ကြောင့် မရည်ရွယ်ဘဲ နှိပ်မိခြင်းများကို တားဆီးပါ။"
+          }
+        },
+        "nb-NO" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Undertrykker utilsiktede klikk forårsaket av en slitt eller ustabil musebryter."
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Onderdrukt onbedoelde klikken die worden veroorzaakt door een versleten of instabiele muisschakelaar."
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tłumi niezamierzone kliknięcia powodowane przez zużyty lub niestabilny przełącznik myszy."
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Evita cliques involuntários causados por um interruptor do rato desgastado ou instável."
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Evita cliques involuntários causados por um interruptor do mouse desgastado ou instável."
+          }
+        },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Suprimă clicurile neintenționate cauzate de un comutator de mouse uzat sau instabil."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Подавляет непреднамеренные щелчки, вызванные изношенным или нестабильным переключателем мыши."
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Potlačí nechcené kliknutia spôsobené opotrebovaným alebo nestabilným spínačom myši."
+          }
+        },
+        "sr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Сузбија ненамерне кликове изазване истрошеним или нестабилним прекидачем миша."
+          }
+        },
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Undertrycker oavsiktliga klick som orsakas av en sliten eller instabil musbrytare."
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aşınmış veya kararsız bir fare anahtarının neden olduğu istenmeyen tıklamaları engeller."
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Пригнічує ненавмисні клацання, спричинені зношеним або нестабільним перемикачем миші."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ngăn các cú nhấp ngoài ý muốn do công tắc chuột bị mòn hoặc không ổn định."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "抑制由磨损或不稳定的鼠标微动开关引起的意外点击。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "抑制因磨損或不穩定的滑鼠微動開關所造成的意外點擊。"
+          }
+        },
+        "zh-Hant-HK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "抑制因磨損或不穩定的滑鼠微動開關引致的意外點擊。"
           }
         }
       }

--- a/LinearMouse/Model/Configuration/Scheme/Buttons/Buttons.swift
+++ b/LinearMouse/Model/Configuration/Scheme/Buttons/Buttons.swift
@@ -41,7 +41,7 @@ extension Scheme.Buttons {
         }
 
         if let clickDebouncing = $clickDebouncing {
-            buttons.clickDebouncing = clickDebouncing
+            clickDebouncing.merge(into: &buttons.$clickDebouncing)
         }
 
         if let autoScroll = $autoScroll {

--- a/LinearMouse/Model/Configuration/Scheme/Buttons/ClickDebouncing/ClickDebouncing.swift
+++ b/LinearMouse/Model/Configuration/Scheme/Buttons/ClickDebouncing/ClickDebouncing.swift
@@ -3,8 +3,50 @@
 
 extension Scheme.Buttons {
     struct ClickDebouncing: Codable, Equatable, ImplicitInitable {
+        static let standardButtons: [CGMouseButton] = [
+            .left,
+            .right,
+            .center,
+            .back,
+            .forward
+        ]
+
+        enum Mode: String, Codable, Equatable {
+            case legacy
+            case libinput
+        }
+
+        var mode: Mode?
         var timeout: Int?
         var resetTimerOnMouseUp: Bool?
         var buttons: [CGMouseButton]?
+    }
+}
+
+extension Scheme.Buttons.ClickDebouncing {
+    func merge(into clickDebouncing: inout Self) {
+        if let mode {
+            clickDebouncing.mode = mode
+        }
+
+        if let timeout {
+            clickDebouncing.timeout = timeout
+        }
+
+        if let resetTimerOnMouseUp {
+            clickDebouncing.resetTimerOnMouseUp = resetTimerOnMouseUp
+        }
+
+        if let buttons {
+            clickDebouncing.buttons = buttons
+        }
+    }
+
+    func merge(into clickDebouncing: inout Self?) {
+        if clickDebouncing == nil {
+            clickDebouncing = Self()
+        }
+
+        merge(into: &clickDebouncing!)
     }
 }

--- a/LinearMouse/ThirdPartyNotices/libinput.txt
+++ b/LinearMouse/ThirdPartyNotices/libinput.txt
@@ -1,0 +1,32 @@
+libinput button debouncer
+=========================
+
+LinearMouse's optional "libinput (Beta)" click-debouncing mode includes a
+Swift adaptation of the state machine in:
+
+https://gitlab.freedesktop.org/libinput/libinput/-/blob/d9ecf9e159325d73d438751dd86ac7d18f664ec3/src/libinput-plugin-button-debounce.c
+
+The related test cases were informed by:
+
+https://gitlab.freedesktop.org/libinput/libinput/-/blob/d9ecf9e159325d73d438751dd86ac7d18f664ec3/test/test-pointer.c
+
+Copyright © 2017-2025 Red Hat, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of this software and associated documentation files (the "Software"),
+to deal in the Software without restriction, including without limitation
+the rights to use, copy, modify, merge, publish, distribute, sublicense,
+and/or sell copies of the Software, and to permit persons to whom the
+Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice (including the next
+paragraph) shall be included in all copies or substantial portions of the
+Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.

--- a/LinearMouse/UI/ButtonsSettings/ButtonsSettingsState.swift
+++ b/LinearMouse/UI/ButtonsSettings/ButtonsSettingsState.swift
@@ -54,7 +54,12 @@ extension ButtonsSettingsState {
             mergedScheme.buttons.clickDebouncing.timeout ?? 0 > 0
         }
         set {
+            let selectedButtons = mergedScheme.buttons.clickDebouncing.buttons ?? []
             scheme.buttons.clickDebouncing.timeout = newValue ? 50 : 0
+
+            if newValue, selectedButtons.isEmpty {
+                scheme.buttons.clickDebouncing.buttons = [.left]
+            }
         }
     }
 
@@ -87,6 +92,15 @@ extension ButtonsSettingsState {
         return formatter
     }
 
+    var clickDebouncingMode: Scheme.Buttons.ClickDebouncing.Mode {
+        get {
+            mergedScheme.buttons.clickDebouncing.mode ?? .legacy
+        }
+        set {
+            scheme.buttons.clickDebouncing.mode = newValue
+        }
+    }
+
     var clickDebouncingResetTimerOnMouseUp: Bool {
         get {
             mergedScheme.buttons.clickDebouncing.resetTimerOnMouseUp ?? false
@@ -94,6 +108,19 @@ extension ButtonsSettingsState {
         set {
             scheme.buttons.clickDebouncing.resetTimerOnMouseUp = newValue
         }
+    }
+
+    var clickDebouncingHasSelectedButtons: Bool {
+        !(mergedScheme.buttons.clickDebouncing.buttons ?? []).isEmpty
+    }
+
+    var clickDebouncingSelectedButtons: [CGMouseButton] {
+        mergedScheme.buttons.clickDebouncing.buttons ?? []
+    }
+
+    func clickDebouncingButtonIsOnlySelection(_ button: CGMouseButton) -> Bool {
+        let buttons = clickDebouncingSelectedButtons
+        return buttons.count == 1 && buttons.contains(button)
     }
 
     func clickDebouncingButtonEnabledBinding(for button: CGMouseButton) -> Binding<Bool> {
@@ -104,7 +131,9 @@ extension ButtonsSettingsState {
             set: { [self] newValue in
                 let buttons = mergedScheme.buttons.clickDebouncing.buttons ?? []
                 if newValue {
-                    scheme.buttons.clickDebouncing.buttons = buttons + [button]
+                    if !buttons.contains(button) {
+                        scheme.buttons.clickDebouncing.buttons = buttons + [button]
+                    }
                 } else {
                     scheme.buttons.clickDebouncing.buttons = buttons.filter { $0 != button }
                 }

--- a/LinearMouse/UI/ButtonsSettings/ClickDebouncingSection.swift
+++ b/LinearMouse/UI/ButtonsSettings/ClickDebouncingSection.swift
@@ -12,55 +12,137 @@ struct ClickDebouncingSection: View {
                 withDescription {
                     Text("Debounce button clicks")
                     Text(
-                        "Ignore rapid clicks within a certain time period."
+                        "Suppress unintended clicks caused by a worn or noisy mouse switch."
                     )
                 }
             }
 
             if state.clickDebouncingEnabled {
-                HStack(spacing: 5) {
-                    Slider(
-                        value: $state.clickDebouncingTimeoutInDouble,
-                        in: 5 ... 500
-                    )
-                    .labelsHidden()
-                    TextField(
-                        String(""),
-                        value: $state.clickDebouncingTimeout,
-                        formatter: state.clickDebouncingTimeoutFormatter
-                    )
-                    .labelsHidden()
-                    .textFieldStyle(.roundedBorder)
-                    .multilineTextAlignment(.trailing)
-                    .frame(width: 60)
-                    Text("ms")
+                Picker("Debouncing method", selection: $state.clickDebouncingMode.animation()) {
+                    Text("Classic").tag(Scheme.Buttons.ClickDebouncing.Mode.legacy)
+                    Text("libinput (Beta)").tag(Scheme.Buttons.ClickDebouncing.Mode.libinput)
                 }
+                .pickerStyle(.segmented)
 
-                Toggle(isOn: $state.clickDebouncingResetTimerOnMouseUp.animation()) {
-                    Text("Reset timer on mouse up")
-                }
+                if state.clickDebouncingMode == .legacy {
+                    VStack(alignment: .leading, spacing: 4) {
+                        Text("Debounce interval")
 
-                VStack(alignment: .leading) {
-                    HStack(spacing: 16) {
-                        Toggle("Left button", isOn: state.clickDebouncingButtonEnabledBinding(for: .left))
-                            .fixedSize()
-                        Toggle("Right button", isOn: state.clickDebouncingButtonEnabledBinding(for: .right))
-                            .fixedSize()
-                        Toggle("Middle button", isOn: state.clickDebouncingButtonEnabledBinding(for: .center))
-                            .fixedSize()
+                        HStack(spacing: 5) {
+                            Slider(
+                                value: $state.clickDebouncingTimeoutInDouble,
+                                in: 5 ... 500
+                            )
+                            .labelsHidden()
+                            TextField(
+                                String(""),
+                                value: $state.clickDebouncingTimeout,
+                                formatter: state.clickDebouncingTimeoutFormatter
+                            )
+                            .labelsHidden()
+                            .textFieldStyle(.roundedBorder)
+                            .multilineTextAlignment(.trailing)
+                            .frame(width: 60)
+                            Text("ms")
+                        }
                     }
-                    .toggleStyle(.checkbox)
 
-                    HStack(spacing: 16) {
-                        Toggle("Back button", isOn: state.clickDebouncingButtonEnabledBinding(for: .back))
-                            .fixedSize()
-                        Toggle("Forward button", isOn: state.clickDebouncingButtonEnabledBinding(for: .forward))
-                            .fixedSize()
+                    Toggle(isOn: $state.clickDebouncingResetTimerOnMouseUp.animation()) {
+                        Text("Reset timer on mouse up")
                     }
-                    .toggleStyle(.checkbox)
+
+                    classicButtonPicker
                 }
             }
         }
         .modifier(SectionViewModifier())
+    }
+
+    @ViewBuilder private var classicButtonPicker: some View {
+        if #available(macOS 11.0, *) {
+            HStack {
+                Text("Apply to")
+
+                Spacer()
+
+                Menu {
+                    buttonMenuToggle("Left button", for: .left)
+                    buttonMenuToggle("Right button", for: .right)
+                    buttonMenuToggle("Middle button", for: .center)
+                    buttonMenuToggle("Back button", for: .back)
+                    buttonMenuToggle("Forward button", for: .forward)
+                } label: {
+                    Text(buttonSelectionSummary)
+                }
+                .menuStyle(.borderlessButton)
+                .fixedSize()
+            }
+        } else {
+            VStack(alignment: .leading, spacing: 8) {
+                Text("Apply to")
+
+                HStack(spacing: 16) {
+                    buttonCheckbox("Left button", for: .left)
+                    buttonCheckbox("Right button", for: .right)
+                    buttonCheckbox("Middle button", for: .center)
+                }
+
+                HStack(spacing: 16) {
+                    buttonCheckbox("Back button", for: .back)
+                    buttonCheckbox("Forward button", for: .forward)
+                }
+            }
+        }
+
+        if !state.clickDebouncingHasSelectedButtons {
+            Text("Select at least one mouse button.")
+                .foregroundColor(.red)
+                .controlSize(.small)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+    }
+
+    private func buttonMenuToggle(_ title: LocalizedStringKey, for button: CGMouseButton) -> some View {
+        Toggle(title, isOn: state.clickDebouncingButtonEnabledBinding(for: button))
+            .disabled(state.clickDebouncingButtonIsOnlySelection(button))
+    }
+
+    private func buttonCheckbox(_ title: LocalizedStringKey, for button: CGMouseButton) -> some View {
+        Toggle(title, isOn: state.clickDebouncingButtonEnabledBinding(for: button))
+            .toggleStyle(.checkbox)
+            .fixedSize()
+            .disabled(state.clickDebouncingButtonIsOnlySelection(button))
+    }
+
+    private var buttonSelectionSummary: LocalizedStringKey {
+        let buttons = state.clickDebouncingSelectedButtons
+
+        if buttons.isEmpty {
+            return "No buttons"
+        }
+
+        if buttons.count == Scheme.Buttons.ClickDebouncing.standardButtons.count,
+           Scheme.Buttons.ClickDebouncing.standardButtons.allSatisfy(buttons.contains) {
+            return "All buttons"
+        }
+
+        if buttons.count == 1, let button = buttons.first {
+            switch button {
+            case .left:
+                return "Left button"
+            case .right:
+                return "Right button"
+            case .center:
+                return "Middle button"
+            case .back:
+                return "Back button"
+            case .forward:
+                return "Forward button"
+            default:
+                break
+            }
+        }
+
+        return "Multiple buttons"
     }
 }

--- a/LinearMouseUnitTests/EventTransformer/ClickDebouncingTransformerTests.swift
+++ b/LinearMouseUnitTests/EventTransformer/ClickDebouncingTransformerTests.swift
@@ -1,0 +1,507 @@
+// MIT License
+// Copyright (c) 2021-2026 LinearMouse
+
+import CoreGraphics
+@testable import LinearMouse
+import XCTest
+
+private final class TestClickDebounceTimerScheduler {
+    private final class ScheduledTimer {
+        let deadline: TimeInterval
+        let handler: () -> Void
+        var active = true
+
+        init(deadline: TimeInterval, handler: @escaping () -> Void) {
+            self.deadline = deadline
+            self.handler = handler
+        }
+    }
+
+    private(set) var now: TimeInterval = 0
+    private var timers = [ScheduledTimer]()
+    private(set) var scheduledIntervals = [TimeInterval]()
+
+    var activeTimerCount: Int {
+        timers.count(where: \.active)
+    }
+
+    var nowNanoseconds: UInt64 {
+        UInt64(now * 1_000_000_000)
+    }
+
+    func schedule(
+        interval: TimeInterval,
+        handler: @escaping () -> Void
+    ) -> LibinputClickDebouncingTransformer.TimerToken {
+        scheduledIntervals.append(interval)
+        let timer = ScheduledTimer(deadline: now + interval, handler: handler)
+        timers.append(timer)
+        return .init {
+            timer.active = false
+        }
+    }
+
+    func advance(by interval: TimeInterval) {
+        let target = now + interval
+
+        while let timer = timers
+            .filter(\.active)
+            .filter({ $0.deadline <= target })
+            .min(by: { $0.deadline < $1.deadline }) {
+            now = timer.deadline
+            timer.active = false
+            timer.handler()
+        }
+
+        now = target
+    }
+
+    func elapseWithoutFiring(by interval: TimeInterval) {
+        now += interval
+    }
+
+    func invokeHandler(at index: Int) {
+        timers[index].handler()
+    }
+}
+
+private final class RecordingEventTransformer: EventTransformer {
+    private(set) var eventTypes = [CGEventType]()
+
+    func transform(_ event: CGEvent, in _: EventTransformerContext) -> CGEvent? {
+        eventTypes.append(event.type)
+        let eventNumber = event.getIntegerValueField(.mouseEventNumber)
+        event.setIntegerValueField(.mouseEventNumber, value: eventNumber + 1000)
+        return event
+    }
+}
+
+private func makeMouseButtonEvent(
+    button: CGMouseButton,
+    pressed: Bool,
+    eventNumber: Int64
+) throws -> CGEvent {
+    let event = try XCTUnwrap(CGEvent(
+        mouseEventSource: nil,
+        mouseType: button.fixedCGEventType(of: pressed ? .leftMouseDown : .leftMouseUp),
+        mouseCursorPosition: .zero,
+        mouseButton: button
+    ))
+    event.setIntegerValueField(.mouseEventButtonNumber, value: Int64(button.rawValue))
+    event.setIntegerValueField(.mouseEventNumber, value: eventNumber)
+    return event
+}
+
+final class ClickDebouncingTransformerTests: XCTestCase {
+    func testLegacyModeSuppressesRapidPressButAlwaysForwardsRelease() throws {
+        var now: UInt64 = 1_000_000_000
+        let transformer = ClickDebouncingTransformer(
+            for: .left,
+            timeout: 0.05,
+            resetTimerOnMouseUp: false
+        ) { now }
+
+        XCTAssertNotNil(try transformer.transform(
+            makeMouseButtonEvent(button: .left, pressed: true, eventNumber: 1),
+            in: .init(device: nil)
+        ))
+        now += 10_000_000
+        XCTAssertNil(try transformer.transform(
+            makeMouseButtonEvent(button: .left, pressed: true, eventNumber: 2),
+            in: .init(device: nil)
+        ))
+        XCTAssertNotNil(try transformer.transform(
+            makeMouseButtonEvent(button: .left, pressed: false, eventNumber: 3),
+            in: .init(device: nil)
+        ))
+    }
+
+    func testLegacyModeCanResetTimerOnRelease() throws {
+        var now: UInt64 = 1_000_000_000
+        let transformer = ClickDebouncingTransformer(
+            for: .left,
+            timeout: 0.05,
+            resetTimerOnMouseUp: true
+        ) { now }
+
+        XCTAssertNotNil(try transformer.transform(
+            makeMouseButtonEvent(button: .left, pressed: true, eventNumber: 1),
+            in: .init(device: nil)
+        ))
+        now += 100_000_000
+        XCTAssertNotNil(try transformer.transform(
+            makeMouseButtonEvent(button: .left, pressed: false, eventNumber: 2),
+            in: .init(device: nil)
+        ))
+        now += 10_000_000
+        XCTAssertNil(try transformer.transform(
+            makeMouseButtonEvent(button: .left, pressed: true, eventNumber: 3),
+            in: .init(device: nil)
+        ))
+    }
+}
+
+final class LibinputClickDebouncingTransformerTests: XCTestCase {
+    func testUsesLibinputFixedBounceAndSpuriousTimeouts() throws {
+        let timerScheduler = TestClickDebounceTimerScheduler()
+        let transformer = makeTransformer(timerScheduler: timerScheduler)
+
+        _ = try transformer.transform(
+            makeMouseButtonEvent(button: .left, pressed: true, eventNumber: 1),
+            in: .init(device: nil)
+        )
+        XCTAssertEqual(timerScheduler.scheduledIntervals, [0.025])
+
+        timerScheduler.advance(by: 0.025)
+        _ = try transformer.transform(
+            makeMouseButtonEvent(button: .left, pressed: false, eventNumber: 2),
+            in: .init(device: nil)
+        )
+        XCTAssertEqual(timerScheduler.scheduledIntervals, [0.025, 0.025, 0.012])
+    }
+
+    func testElapsedDeadlineIsAppliedBeforeALateTimerWakeup() throws {
+        let timerScheduler = TestClickDebounceTimerScheduler()
+        var emittedTypes = [CGEventType]()
+        let transformer = makeTransformer(timerScheduler: timerScheduler) {
+            emittedTypes.append($0.type)
+        }
+
+        XCTAssertNotNil(try transformer.transform(
+            makeMouseButtonEvent(button: .left, pressed: true, eventNumber: 1),
+            in: .init(device: nil)
+        ))
+        XCTAssertNil(try transformer.transform(
+            makeMouseButtonEvent(button: .left, pressed: false, eventNumber: 2),
+            in: .init(device: nil)
+        ))
+
+        timerScheduler.elapseWithoutFiring(by: 0.026)
+
+        XCTAssertNotNil(try transformer.transform(
+            makeMouseButtonEvent(button: .left, pressed: true, eventNumber: 3),
+            in: .init(device: nil)
+        ))
+        XCTAssertEqual(emittedTypes, [.leftMouseUp])
+    }
+
+    func testElapsedSpuriousDeadlineIsAppliedBeforeALateTimerWakeup() throws {
+        let timerScheduler = TestClickDebounceTimerScheduler()
+        var emittedTypes = [CGEventType]()
+        let transformer = makeTransformer(timerScheduler: timerScheduler) {
+            emittedTypes.append($0.type)
+        }
+
+        XCTAssertNotNil(try transformer.transform(
+            makeMouseButtonEvent(button: .left, pressed: true, eventNumber: 1),
+            in: .init(device: nil)
+        ))
+        timerScheduler.advance(by: 0.025)
+        XCTAssertNotNil(try transformer.transform(
+            makeMouseButtonEvent(button: .left, pressed: false, eventNumber: 2),
+            in: .init(device: nil)
+        ))
+        XCTAssertNil(try transformer.transform(
+            makeMouseButtonEvent(button: .left, pressed: true, eventNumber: 3),
+            in: .init(device: nil)
+        ))
+
+        timerScheduler.elapseWithoutFiring(by: 0.013)
+
+        XCTAssertNil(try transformer.transform(
+            makeMouseButtonEvent(button: .left, pressed: false, eventNumber: 4),
+            in: .init(device: nil)
+        ))
+        XCTAssertEqual(emittedTypes, [.leftMouseDown])
+    }
+
+    func testEventBeforeBounceDeadlineRemainsPartOfBounceSequence() throws {
+        let timerScheduler = TestClickDebounceTimerScheduler()
+        let transformer = makeTransformer(timerScheduler: timerScheduler)
+
+        XCTAssertNotNil(try transformer.transform(
+            makeMouseButtonEvent(button: .left, pressed: true, eventNumber: 1),
+            in: .init(device: nil)
+        ))
+        XCTAssertNil(try transformer.transform(
+            makeMouseButtonEvent(button: .left, pressed: false, eventNumber: 2),
+            in: .init(device: nil)
+        ))
+
+        timerScheduler.elapseWithoutFiring(by: 0.024999)
+
+        XCTAssertNil(try transformer.transform(
+            makeMouseButtonEvent(button: .left, pressed: true, eventNumber: 3),
+            in: .init(device: nil)
+        ))
+    }
+
+    func testCancelledTimerHandlerCannotAdvanceStateMachine() throws {
+        let timerScheduler = TestClickDebounceTimerScheduler()
+        var emittedTypes = [CGEventType]()
+        let transformer = makeTransformer(timerScheduler: timerScheduler) {
+            emittedTypes.append($0.type)
+        }
+
+        XCTAssertNotNil(try transformer.transform(
+            makeMouseButtonEvent(button: .left, pressed: true, eventNumber: 1),
+            in: .init(device: nil)
+        ))
+        XCTAssertNil(try transformer.transform(
+            makeMouseButtonEvent(button: .left, pressed: false, eventNumber: 2),
+            in: .init(device: nil)
+        ))
+        XCTAssertNotNil(try transformer.transform(
+            makeMouseButtonEvent(button: .right, pressed: true, eventNumber: 3),
+            in: .init(device: nil)
+        ))
+
+        timerScheduler.elapseWithoutFiring(by: 0.050)
+        timerScheduler.invokeHandler(at: 1)
+
+        XCTAssertEqual(emittedTypes, [.leftMouseUp])
+    }
+
+    func testQuickClickDelaysReleaseAndPreservesEventMetadata() throws {
+        let timerScheduler = TestClickDebounceTimerScheduler()
+        var emittedEvents = [CGEvent]()
+        let transformer = makeTransformer(timerScheduler: timerScheduler) {
+            emittedEvents.append($0)
+        }
+
+        XCTAssertNotNil(try transformer.transform(
+            makeMouseButtonEvent(button: .left, pressed: true, eventNumber: 41),
+            in: .init(device: nil)
+        ))
+        XCTAssertNil(try transformer.transform(
+            makeMouseButtonEvent(button: .left, pressed: false, eventNumber: 42),
+            in: .init(device: nil)
+        ))
+        XCTAssertTrue(emittedEvents.isEmpty)
+
+        timerScheduler.advance(by: 0.025)
+
+        XCTAssertEqual(emittedEvents.map(\.type), [.leftMouseUp])
+        XCTAssertEqual(emittedEvents.first?.getIntegerValueField(.mouseEventNumber), 42)
+    }
+
+    func testPressReleasePressBounceStillForwardsFinalRelease() throws {
+        let timerScheduler = TestClickDebounceTimerScheduler()
+        let transformer = makeTransformer(timerScheduler: timerScheduler)
+
+        XCTAssertNotNil(try transformer.transform(
+            makeMouseButtonEvent(button: .left, pressed: true, eventNumber: 1),
+            in: .init(device: nil)
+        ))
+        XCTAssertNil(try transformer.transform(
+            makeMouseButtonEvent(button: .left, pressed: false, eventNumber: 2),
+            in: .init(device: nil)
+        ))
+        XCTAssertNil(try transformer.transform(
+            makeMouseButtonEvent(button: .left, pressed: true, eventNumber: 3),
+            in: .init(device: nil)
+        ))
+
+        timerScheduler.advance(by: 0.025)
+
+        XCTAssertNotNil(try transformer.transform(
+            makeMouseButtonEvent(button: .left, pressed: false, eventNumber: 4),
+            in: .init(device: nil)
+        ))
+    }
+
+    func testBounceTimerRestartsForEachEventInLongBounceSequence() throws {
+        let timerScheduler = TestClickDebounceTimerScheduler()
+        var emittedTypes = [CGEventType]()
+        let transformer = makeTransformer(timerScheduler: timerScheduler) {
+            emittedTypes.append($0.type)
+        }
+
+        XCTAssertNotNil(try transformer.transform(
+            makeMouseButtonEvent(button: .left, pressed: true, eventNumber: 1),
+            in: .init(device: nil)
+        ))
+        timerScheduler.advance(by: 0.015)
+        XCTAssertNil(try transformer.transform(
+            makeMouseButtonEvent(button: .left, pressed: false, eventNumber: 2),
+            in: .init(device: nil)
+        ))
+        timerScheduler.advance(by: 0.015)
+        XCTAssertNil(try transformer.transform(
+            makeMouseButtonEvent(button: .left, pressed: true, eventNumber: 3),
+            in: .init(device: nil)
+        ))
+
+        timerScheduler.advance(by: 0.025)
+
+        XCTAssertTrue(emittedTypes.isEmpty)
+        XCTAssertNotNil(try transformer.transform(
+            makeMouseButtonEvent(button: .left, pressed: false, eventNumber: 4),
+            in: .init(device: nil)
+        ))
+    }
+
+    func testSpuriousModeFiltersContactLossButEmitsFinalRelease() throws {
+        let timerScheduler = TestClickDebounceTimerScheduler()
+        var emittedTypes = [CGEventType]()
+        let transformer = makeTransformer(timerScheduler: timerScheduler) {
+            emittedTypes.append($0.type)
+        }
+
+        XCTAssertNotNil(try transformer.transform(
+            makeMouseButtonEvent(button: .left, pressed: true, eventNumber: 1),
+            in: .init(device: nil)
+        ))
+        timerScheduler.advance(by: 0.025)
+        XCTAssertNotNil(try transformer.transform(
+            makeMouseButtonEvent(button: .left, pressed: false, eventNumber: 2),
+            in: .init(device: nil)
+        ))
+        XCTAssertNil(try transformer.transform(
+            makeMouseButtonEvent(button: .left, pressed: true, eventNumber: 3),
+            in: .init(device: nil)
+        ))
+        timerScheduler.advance(by: 0.012)
+        XCTAssertEqual(emittedTypes, [.leftMouseDown])
+
+        XCTAssertNil(try transformer.transform(
+            makeMouseButtonEvent(button: .left, pressed: false, eventNumber: 4),
+            in: .init(device: nil)
+        ))
+        XCTAssertNil(try transformer.transform(
+            makeMouseButtonEvent(button: .left, pressed: true, eventNumber: 5),
+            in: .init(device: nil)
+        ))
+        timerScheduler.advance(by: 0.012)
+        XCTAssertEqual(emittedTypes, [.leftMouseDown])
+
+        XCTAssertNil(try transformer.transform(
+            makeMouseButtonEvent(button: .left, pressed: false, eventNumber: 6),
+            in: .init(device: nil)
+        ))
+        timerScheduler.advance(by: 0.012)
+        XCTAssertEqual(emittedTypes, [.leftMouseDown, .leftMouseUp])
+    }
+
+    func testOtherButtonFlushesPendingReleaseBeforePassingThrough() throws {
+        let timerScheduler = TestClickDebounceTimerScheduler()
+        var emittedTypes = [CGEventType]()
+        let transformer = makeTransformer(timerScheduler: timerScheduler) {
+            emittedTypes.append($0.type)
+        }
+
+        _ = try transformer.transform(
+            makeMouseButtonEvent(button: .left, pressed: true, eventNumber: 1),
+            in: .init(device: nil)
+        )
+        XCTAssertNil(try transformer.transform(
+            makeMouseButtonEvent(button: .left, pressed: false, eventNumber: 2),
+            in: .init(device: nil)
+        ))
+        XCTAssertNotNil(try transformer.transform(
+            makeMouseButtonEvent(button: .right, pressed: true, eventNumber: 3),
+            in: .init(device: nil)
+        ))
+
+        XCTAssertEqual(emittedTypes, [.leftMouseUp])
+        XCTAssertEqual(timerScheduler.activeTimerCount, 0)
+    }
+
+    func testMultipleButtonDebouncersFlushPendingReleaseBeforeOtherButtonPress() throws {
+        let timerScheduler = TestClickDebounceTimerScheduler()
+        let leftDebouncer = makeTransformer(button: .left, timerScheduler: timerScheduler)
+        let rightDebouncer = makeTransformer(button: .right, timerScheduler: timerScheduler)
+        let transformers: [EventTransformer] = [leftDebouncer, rightDebouncer]
+        var postedEventNumbers = [Int64]()
+        let context = EventTransformerContext(device: nil) {
+            postedEventNumbers.append($0.getIntegerValueField(.mouseEventNumber))
+        }
+
+        XCTAssertNotNil(try transformers.transform(
+            makeMouseButtonEvent(button: .left, pressed: true, eventNumber: 1),
+            in: context
+        ))
+        XCTAssertNil(try transformers.transform(
+            makeMouseButtonEvent(button: .left, pressed: false, eventNumber: 2),
+            in: context
+        ))
+
+        let rightPress = try XCTUnwrap(try transformers.transform(
+            makeMouseButtonEvent(button: .right, pressed: true, eventNumber: 3),
+            in: context
+        ))
+
+        XCTAssertEqual(rightPress.type, .rightMouseDown)
+        XCTAssertEqual(postedEventNumbers, [2])
+    }
+
+    func testDeactivateFlushesPendingReleaseAndCancelsTimers() throws {
+        let timerScheduler = TestClickDebounceTimerScheduler()
+        var emittedTypes = [CGEventType]()
+        let transformer = makeTransformer(timerScheduler: timerScheduler) {
+            emittedTypes.append($0.type)
+        }
+
+        _ = try transformer.transform(
+            makeMouseButtonEvent(button: .left, pressed: true, eventNumber: 1),
+            in: .init(device: nil)
+        )
+        XCTAssertNil(try transformer.transform(
+            makeMouseButtonEvent(button: .left, pressed: false, eventNumber: 2),
+            in: .init(device: nil)
+        ))
+
+        transformer.deactivate()
+
+        XCTAssertEqual(emittedTypes, [.leftMouseUp])
+        XCTAssertEqual(timerScheduler.activeTimerCount, 0)
+    }
+
+    func testUnmatchedReleasePassesThrough() throws {
+        let transformer = makeTransformer(timerScheduler: TestClickDebounceTimerScheduler())
+
+        XCTAssertNotNil(try transformer.transform(
+            makeMouseButtonEvent(button: .left, pressed: false, eventNumber: 1),
+            in: .init(device: nil)
+        ))
+    }
+
+    func testDelayedEventContinuesThroughRemainingTransformers() throws {
+        let timerScheduler = TestClickDebounceTimerScheduler()
+        let debouncer = makeTransformer(timerScheduler: timerScheduler)
+        let recorder = RecordingEventTransformer()
+        let transformers: [EventTransformer] = [debouncer, recorder]
+        var postedEventNumbers = [Int64]()
+        let context = EventTransformerContext(device: nil) {
+            postedEventNumbers.append($0.getIntegerValueField(.mouseEventNumber))
+        }
+
+        let press = try XCTUnwrap(try transformers.transform(
+            makeMouseButtonEvent(button: .left, pressed: true, eventNumber: 1),
+            in: context
+        ))
+        XCTAssertEqual(press.getIntegerValueField(.mouseEventNumber), 1001)
+        XCTAssertNil(try transformers.transform(
+            makeMouseButtonEvent(button: .left, pressed: false, eventNumber: 2),
+            in: context
+        ))
+
+        timerScheduler.advance(by: 0.025)
+
+        XCTAssertEqual(recorder.eventTypes, [.leftMouseDown, .leftMouseUp])
+        XCTAssertEqual(postedEventNumbers, [1002])
+    }
+
+    private func makeTransformer(
+        button: CGMouseButton = .left,
+        timerScheduler: TestClickDebounceTimerScheduler,
+        eventSink: @escaping (CGEvent) -> Void = { _ in }
+    ) -> LibinputClickDebouncingTransformer {
+        LibinputClickDebouncingTransformer(
+            for: button,
+            scheduleTimer: timerScheduler.schedule,
+            monotonicClock: { timerScheduler.nowNanoseconds },
+            eventSink: eventSink
+        )
+    }
+}

--- a/LinearMouseUnitTests/EventTransformer/EventTransformerManagerTests.swift
+++ b/LinearMouseUnitTests/EventTransformer/EventTransformerManagerTests.swift
@@ -29,6 +29,42 @@ final class EventTransformerManagerTests: XCTestCase {
         XCTAssertEqual(firstKey, secondKey)
     }
 
+    func testClickDebouncingWithoutModeUsesLegacyTransformer() throws {
+        var scheme = Scheme()
+        scheme.buttons.clickDebouncing.timeout = 50
+        scheme.buttons.clickDebouncing.buttons = [.left]
+        ConfigurationState.shared.configuration = .init(schemes: [scheme])
+
+        let transformers = try XCTUnwrap(EventTransformerManager.shared.get(
+            withDevice: nil,
+            withPid: nil,
+            withDisplay: nil
+        ) as? [EventTransformer])
+
+        XCTAssertEqual(transformers.compactMap { $0 as? ClickDebouncingTransformer }.count, 1)
+        XCTAssertTrue(transformers.compactMap { $0 as? LibinputClickDebouncingTransformer }.isEmpty)
+    }
+
+    func testLibinputClickDebouncingModeUsesBetaTransformer() throws {
+        var scheme = Scheme()
+        scheme.buttons.clickDebouncing.mode = .libinput
+        scheme.buttons.clickDebouncing.timeout = 25
+        scheme.buttons.clickDebouncing.buttons = [.left]
+        ConfigurationState.shared.configuration = .init(schemes: [scheme])
+
+        let transformers = try XCTUnwrap(EventTransformerManager.shared.get(
+            withDevice: nil,
+            withPid: nil,
+            withDisplay: nil
+        ) as? [EventTransformer])
+
+        XCTAssertTrue(transformers.compactMap { $0 as? ClickDebouncingTransformer }.isEmpty)
+        XCTAssertEqual(
+            transformers.compactMap { $0 as? LibinputClickDebouncingTransformer }.count,
+            Scheme.Buttons.ClickDebouncing.standardButtons.count
+        )
+    }
+
     func testTransformerCacheDoesNotReuseValueForNewProcess() throws {
         ConfigurationState.shared.configuration = .init(schemes: [
             Scheme(scrolling: .init(reverse: .init(vertical: true)))

--- a/LinearMouseUnitTests/EventTransformer/LibinputClickDebouncingEngineTests.swift
+++ b/LinearMouseUnitTests/EventTransformer/LibinputClickDebouncingEngineTests.swift
@@ -1,0 +1,149 @@
+// MIT License
+// Copyright (c) 2021-2026 LinearMouse
+
+@testable import LinearMouse
+import XCTest
+
+final class LibinputClickDebouncingEngineTests: XCTestCase {
+    func testFirstPressIsImmediateAndQuickReleaseIsDelayed() {
+        var engine = LibinputClickDebouncingEngine()
+
+        XCTAssertEqual(engine.handle(.press), [.setBounceTimer, .emit(.pressed)])
+        XCTAssertEqual(engine.state, .isDownWaiting)
+        XCTAssertEqual(engine.handle(.release), [.setBounceTimer])
+        XCTAssertEqual(engine.state, .isUpDelaying)
+        XCTAssertEqual(engine.handle(.bounceTimeout), [.emit(.released)])
+        XCTAssertEqual(engine.state, .isUp)
+    }
+
+    func testReleaseAfterHeldPressIsImmediate() {
+        var engine = LibinputClickDebouncingEngine()
+
+        _ = engine.handle(.press)
+        XCTAssertEqual(engine.handle(.bounceTimeout), [])
+        XCTAssertEqual(engine.state, .isDown)
+        XCTAssertEqual(
+            engine.handle(.release),
+            [.setBounceTimer, .setSpuriousTimer, .emit(.released)]
+        )
+        XCTAssertEqual(engine.state, .isUpDetectingSpurious)
+    }
+
+    func testPressReleasePressBounceLeavesButtonLogicallyDown() {
+        var engine = LibinputClickDebouncingEngine()
+
+        _ = engine.handle(.press)
+        XCTAssertEqual(engine.handle(.release), [.setBounceTimer])
+        XCTAssertEqual(engine.handle(.press), [.setBounceTimer])
+        XCTAssertEqual(engine.handle(.bounceTimeout), [])
+        XCTAssertEqual(engine.state, .isDown)
+
+        XCTAssertEqual(
+            engine.handle(.release),
+            [.setBounceTimer, .setSpuriousTimer, .emit(.released)]
+        )
+    }
+
+    func testReleasePressReleaseBounceLeavesButtonLogicallyUp() {
+        var engine = LibinputClickDebouncingEngine()
+
+        _ = engine.handle(.press)
+        _ = engine.handle(.bounceTimeout)
+        _ = engine.handle(.release)
+        XCTAssertEqual(
+            engine.handle(.press),
+            [.setBounceTimer, .setSpuriousTimer]
+        )
+        XCTAssertEqual(
+            engine.handle(.release),
+            [.setBounceTimer, .setSpuriousTimer]
+        )
+        XCTAssertEqual(engine.handle(.bounceTimeout), [])
+        XCTAssertEqual(engine.state, .isUp)
+    }
+
+    func testSpuriousContactLossEnablesShortReleaseDebouncing() {
+        var engine = LibinputClickDebouncingEngine()
+
+        _ = engine.handle(.press)
+        _ = engine.handle(.bounceTimeout)
+        _ = engine.handle(.release)
+        _ = engine.handle(.press)
+
+        XCTAssertEqual(
+            engine.handle(.spuriousTimeout),
+            [.cancelBounceTimer, .spuriousDebouncingEnabled, .emit(.pressed)]
+        )
+        XCTAssertTrue(engine.spuriousDebouncingEnabled)
+        XCTAssertEqual(engine.state, .isDown)
+
+        XCTAssertEqual(
+            engine.handle(.release),
+            [.setBounceTimer, .setSpuriousTimer]
+        )
+        XCTAssertEqual(
+            engine.handle(.press),
+            [.cancelBounceTimer, .cancelSpuriousTimer]
+        )
+        XCTAssertEqual(engine.state, .isDown)
+    }
+
+    func testFinalReleaseIsEmittedInSpuriousMode() {
+        var engine = engineWithSpuriousDebouncingEnabled()
+
+        XCTAssertEqual(
+            engine.handle(.release),
+            [.setBounceTimer, .setSpuriousTimer]
+        )
+        XCTAssertEqual(engine.handle(.spuriousTimeout), [.emit(.released)])
+        XCTAssertEqual(engine.state, .isUpWaiting)
+        XCTAssertEqual(engine.handle(.bounceTimeout), [])
+        XCTAssertEqual(engine.state, .isUp)
+    }
+
+    func testOtherButtonFlushesDelayedRelease() {
+        var engine = LibinputClickDebouncingEngine()
+
+        _ = engine.handle(.press)
+        _ = engine.handle(.release)
+
+        XCTAssertEqual(
+            engine.handle(.otherButton),
+            [.cancelBounceTimer, .cancelSpuriousTimer, .emit(.released)]
+        )
+        XCTAssertEqual(engine.state, .isUp)
+    }
+
+    func testOtherButtonFlushesDelayedPressWithoutEnablingSpuriousMode() {
+        var engine = LibinputClickDebouncingEngine()
+
+        _ = engine.handle(.press)
+        _ = engine.handle(.bounceTimeout)
+        _ = engine.handle(.release)
+        _ = engine.handle(.press)
+
+        XCTAssertEqual(
+            engine.handle(.otherButton),
+            [.cancelBounceTimer, .cancelSpuriousTimer, .emit(.pressed)]
+        )
+        XCTAssertFalse(engine.spuriousDebouncingEnabled)
+        XCTAssertEqual(engine.state, .isDown)
+    }
+
+    func testUnmatchedReleaseIsForwardedToAvoidStuckButton() {
+        var engine = LibinputClickDebouncingEngine()
+
+        XCTAssertEqual(engine.handle(.release), [.emit(.released)])
+        XCTAssertEqual(engine.state, .isUp)
+    }
+
+    private func engineWithSpuriousDebouncingEnabled() -> LibinputClickDebouncingEngine {
+        var engine = LibinputClickDebouncingEngine()
+        _ = engine.handle(.press)
+        _ = engine.handle(.bounceTimeout)
+        _ = engine.handle(.release)
+        _ = engine.handle(.press)
+        _ = engine.handle(.spuriousTimeout)
+        return engine
+    }
+}

--- a/LinearMouseUnitTests/Model/Scheme/Buttons/ClickDebouncingTests.swift
+++ b/LinearMouseUnitTests/Model/Scheme/Buttons/ClickDebouncingTests.swift
@@ -1,0 +1,58 @@
+// MIT License
+// Copyright (c) 2021-2026 LinearMouse
+
+@testable import LinearMouse
+import XCTest
+
+final class ClickDebouncingTests: XCTestCase {
+    func testLegacyConfigurationWithoutModeStillDecodes() throws {
+        let clickDebouncing = try JSONDecoder().decode(
+            Scheme.Buttons.ClickDebouncing.self,
+            from: Data(#"{"timeout":50,"resetTimerOnMouseUp":true,"buttons":[0,1]}"#.utf8)
+        )
+
+        XCTAssertNil(clickDebouncing.mode)
+        XCTAssertEqual(clickDebouncing.timeout, 50)
+        XCTAssertTrue(try XCTUnwrap(clickDebouncing.resetTimerOnMouseUp))
+        XCTAssertEqual(clickDebouncing.buttons, [.left, .right])
+    }
+
+    func testLibinputModeDecodes() throws {
+        let clickDebouncing = try JSONDecoder().decode(
+            Scheme.Buttons.ClickDebouncing.self,
+            from: Data(#"{"mode":"libinput","timeout":25,"buttons":[0]}"#.utf8)
+        )
+
+        XCTAssertEqual(clickDebouncing.mode, .libinput)
+        XCTAssertEqual(clickDebouncing.timeout, 25)
+        XCTAssertEqual(clickDebouncing.buttons, [.left])
+    }
+
+    func testModeEncodesAsStableConfigurationValue() throws {
+        var clickDebouncing = Scheme.Buttons.ClickDebouncing()
+        clickDebouncing.mode = .libinput
+        clickDebouncing.timeout = 25
+
+        let data = try JSONEncoder().encode(clickDebouncing)
+        let object = try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: Any])
+
+        XCTAssertEqual(object["mode"] as? String, "libinput")
+        XCTAssertEqual(object["timeout"] as? Int, 25)
+    }
+
+    func testModeOverridePreservesInheritedClickDebouncingSettings() throws {
+        var mergedScheme = Scheme()
+        mergedScheme.buttons.clickDebouncing.timeout = 50
+        mergedScheme.buttons.clickDebouncing.resetTimerOnMouseUp = true
+        mergedScheme.buttons.clickDebouncing.buttons = [.left, .right]
+
+        var overrideScheme = Scheme()
+        overrideScheme.buttons.clickDebouncing.mode = .libinput
+        overrideScheme.merge(into: &mergedScheme)
+
+        XCTAssertEqual(mergedScheme.buttons.clickDebouncing.mode, .libinput)
+        XCTAssertEqual(mergedScheme.buttons.clickDebouncing.timeout, 50)
+        XCTAssertTrue(try XCTUnwrap(mergedScheme.buttons.clickDebouncing.resetTimerOnMouseUp))
+        XCTAssertEqual(mergedScheme.buttons.clickDebouncing.buttons, [.left, .right])
+    }
+}


### PR DESCRIPTION
## Summary

- preserve Classic click debouncing as the default and add an opt-in libinput (Beta) mode
- adapt the libinput press and release state machine with monotonic 25 ms bounce and 12 ms spurious-release windows
- continue delayed events through downstream transformers and flush pending state safely when configuration changes
- add a native segmented mode picker, compact Classic button scope menu, generated configuration docs, complete localizations, and the upstream MIT notice
- preserve inherited debounce settings when a device- or application-specific rule overrides only one field

## Validation

- make test: 358 tests passed
- make lint: 0 formatting issues and 0 serious lint violations
- npm run generate:json-schema: generated schema is current
- verified all 10 new strings cover all 34 non-English locales
- verified libinput.txt is bundled in the built app

Relates to #1316