### PR TITLE
Avoid redundant status item visibility updates

### DIFF
--- a/LinearMouse/UI/StatusItem.swift
+++ b/LinearMouse/UI/StatusItem.swift
@@ -164,11 +164,14 @@ class StatusItem: NSObject, NSMenuDelegate {
     private func updateStatusItemPresentation() {
         let currentBatteryLevel = currentDeviceBatteryLevel()
         let menuBarBatteryDisplayMode = Defaults[.menuBarBatteryDisplayMode]
-        statusItem.isVisible = Self.menuBarIsVisible(
+        let shouldBeVisible = Self.menuBarIsVisible(
             currentBatteryLevel: currentBatteryLevel,
             visibilityMode: Defaults[.menuBarVisibilityMode],
             batteryDisplayMode: menuBarBatteryDisplayMode
         )
+        if statusItem.isVisible != shouldBeVisible {
+            statusItem.isVisible = shouldBeVisible
+        }
         updateStatusItemBatteryIndicator(
             currentBatteryLevel: currentBatteryLevel,
             menuBarBatteryDisplayMode: menuBarBatteryDisplayMode


### PR DESCRIPTION
## Summary

- Only update `NSStatusItem.isVisible` when the desired visibility changes.
- Avoid unnecessary status item visibility work during battery- and device-driven presentation refreshes.

## Context

While investigating the crash report in [Discussion #1197](https://github.com/linearmouse/linearmouse/discussions/1197#discussioncomment-17855663), I noticed that `updateStatusItemPresentation()` unconditionally reassigns `isVisible`, including during periodic battery refreshes. The reported crash appears to be an upstream macOS 27 beta ViewBridge issue; this PR is a defensive optimization and does not claim to work around the underlying OS bug.

## Testing

- `xcodebuild test -project LinearMouse.xcodeproj -scheme LinearMouse -only-testing:LinearMouseUnitTests/StatusItemBatteryIndicatorTests CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY= DEVELOPMENT_TEAM=`
- 17 tests passed with 0 failures.
- `swiftformat --lint LinearMouse/UI/StatusItem.swift`