### PR TITLE
Fix crash when Logitech receiver channel fails to open

### DIFF
--- a/LinearMouse/Device/VendorSpecific/Logitech/LogitechHIDPPDeviceMetadataProvider.swift
+++ b/LinearMouse/Device/VendorSpecific/Logitech/LogitechHIDPPDeviceMetadataProvider.swift
@@ -1102,6 +1102,7 @@ final class LogitechReceiverChannel: VendorSpecificDeviceContext {
     private let ioQueue: DispatchQueue
     private let ioQueueKey = DispatchSpecificKey<Void>()
     private let cancellationSemaphore = DispatchSemaphore(value: 0)
+    private var isActivated = false
     private let inputReportBufferLength: Int
     private var inputReportBuffer: UnsafeMutablePointer<UInt8>?
     private let pendingLock = NSLock()
@@ -1214,9 +1215,15 @@ final class LogitechReceiverChannel: VendorSpecificDeviceContext {
             cancellationSemaphore.signal()
         }
         IOHIDDeviceActivate(device)
+        isActivated = true
     }
 
     deinit {
+        // Skip teardown if the device never activated
+        guard isActivated else {
+            return
+        }
+
         IOHIDDeviceCancel(device)
         if DispatchQueue.getSpecific(key: ioQueueKey) == nil {
             cancellationSemaphore.wait()


### PR DESCRIPTION
`deinit {}` is always called, but its logic should be skipped if [the channel didn't get opened](https://github.com/ksc98/linearmouse/blob/78cbaab7c058071201ee9588d3c7931cef59223b/LinearMouse/Device/VendorSpecific/Logitech/LogitechHIDPPDeviceMetadataProvider.swift#L1194-L1197).

An example situation in which the channel doesn't get opened: a battery poller happens to hold the interface at open time, so `IOHIDDeviceOpen` fails with `kIOReturnExclusiveAccess`

`IOHIDDeviceCancel` on a never-activated device then aborts the app — hence the crash on startup:

```
Process:           LinearMouse [72112]
Version:           0.11.4
Launch Time:       2026-08-04 23:38:16.3020 -0700
Crashed:           2026-08-04 23:38:16.6776 -0700   (~0.3 s after launch, as a login item)
Exception Type:    EXC_CRASH (SIGABRT)
Termination:       Application Triggered Fault
Assertion:         Cancel failed queue: %p runLoop: %p

Thread Crashed:
0   libsystem_kernel.dylib   __abort_with_payload
1   libsystem_kernel.dylib   abort_with_payload_wrapper_internal
2   libsystem_kernel.dylib   abort_with_payload
3   libsystem_c.dylib        _os_crash_msg
4   IOKit                    IOHIDDeviceCancel
5   LinearMouse              0xfa9c
6   LinearMouse              0xfba0
7   libswiftCore.dylib       _swift_release_dealloc
```
