### PR TITLE
Add support for a secondary gesture button and additional gesture actions

### DIFF
--- a/LinearMouse/EventTransformer/ButtonMappingTransformer.swift
+++ b/LinearMouse/EventTransformer/ButtonMappingTransformer.swift
@@ -65,7 +65,7 @@ final class ButtonMappingTransformer: EventTransformer, DeferredEventTransformer
     private let monotonicClock: MonotonicClock
     private let fallbackEventSink: (CGEvent) -> Void
     private let swapsPrimaryAndSecondaryButtons: Bool
-    private let gestureTransformer: GestureButtonTransformer?
+    private let gestureTransformers: [GestureButtonTransformer]
     private let policy: ButtonMappingPolicy
 
     private var timer: TimerToken?
@@ -82,7 +82,7 @@ final class ButtonMappingTransformer: EventTransformer, DeferredEventTransformer
         scheduleTimer: @escaping TimerScheduler = ButtonMappingTransformer.scheduleEventThreadTimer,
         monotonicClock: @escaping MonotonicClock = { DispatchTime.now().uptimeNanoseconds },
         keySimulator: KeySimulating? = nil,
-        gestureTransformer: GestureButtonTransformer? = nil,
+        gestureTransformers: [GestureButtonTransformer] = [],
         eventSink: @escaping (CGEvent) -> Void = { $0.post(tap: .cgSessionEventTap) }
     ) {
         self.mappings = mappings
@@ -96,7 +96,7 @@ final class ButtonMappingTransformer: EventTransformer, DeferredEventTransformer
         self.monotonicClock = monotonicClock
         fallbackEventSink = eventSink
         self.swapsPrimaryAndSecondaryButtons = swapsPrimaryAndSecondaryButtons
-        self.gestureTransformer = gestureTransformer
+        self.gestureTransformers = gestureTransformers
     }
 
     func transform(_ event: CGEvent, in context: EventTransformerContext) -> CGEvent? {
@@ -106,10 +106,14 @@ final class ButtonMappingTransformer: EventTransformer, DeferredEventTransformer
             return event
         }
 
-        if let gestureTransformer,
-           !isRecording || gestureTransformer.hasActiveInteraction,
-           gestureTransformer.transform(event, in: context) == nil {
-            return nil
+        for gestureTransformer in gestureTransformers {
+            guard !isRecording || gestureTransformer.hasActiveInteraction else {
+                continue
+            }
+
+            if gestureTransformer.transform(event, in: context) == nil {
+                return nil
+            }
         }
 
         if [.keyDown, .keyUp].contains(event.type) {
@@ -446,18 +450,22 @@ final class ButtonMappingTransformer: EventTransformer, DeferredEventTransformer
     }
 
     private func cancelCompetingGestureIfNeeded(
-        after output: ButtonMappingEngine.Output,
-        in lane: RecognitionLane?
-    ) {
-        guard output.discardsBufferedEvents,
-              let gestureTransformer,
-              let button = gestureTransformer.configuredTriggerButton,
+    after output: ButtonMappingEngine.Output,
+    in lane: RecognitionLane?
+) {
+    guard output.discardsBufferedEvents else {
+        return
+    }
+
+    for gestureTransformer in gestureTransformers {
+        guard let button = gestureTransformer.configuredTriggerButton,
               lane?.engine.ownsInteraction(overlapping: button) == true else {
-            return
+            continue
         }
 
         gestureTransformer.cancelInteraction(containing: button)
     }
+}
 
     private func replayBufferedEvents(in lane: RecognitionLane?, remappingTo target: CGMouseButton) {
         let events = lane?.bufferedEvents ?? []
@@ -548,11 +556,29 @@ extension ButtonMappingTransformer: LogitechControlEventHandling, LogitechContro
             return .notHandled
         }
 
-        let gestureResult: LogitechControlEventHandlingResult = if !isRecording ||
-            gestureTransformer?.hasActiveInteraction == true {
-            gestureTransformer?.handleLogitechControlEvent(context) ?? .notHandled
-        } else {
-            .notHandled
+        var gestureResult: LogitechControlEventHandlingResult = .notHandled
+
+        for gestureTransformer in gestureTransformers {
+            guard !isRecording || gestureTransformer.hasActiveInteraction else {
+                continue
+            }
+
+            let result = gestureTransformer.handleLogitechControlEvent(context)
+
+            switch result {
+            case .handled:
+                gestureResult = .handled
+            case .handledDeferringSyntheticFallback:
+                if gestureResult != .handled {
+                    gestureResult = .handledDeferringSyntheticFallback
+                }
+            case .handledAllowingSyntheticFallback:
+                if gestureResult == .notHandled {
+                    gestureResult = .handledAllowingSyntheticFallback
+                }
+            case .notHandled:
+                break
+            }
         }
         if gestureResult == .handled {
             cancelGestureInteraction(for: context)
@@ -619,7 +645,9 @@ extension ButtonMappingTransformer: LogitechControlEventHandling, LogitechContro
 
     @discardableResult
     func cancelLogitechControlInteraction(_ context: LogitechEventContext) -> Bool {
-        let canceledGesture = gestureTransformer?.cancelLogitechControlInteraction(context) == true
+        let canceledGesture = gestureTransformers.reduce(false) { canceled, transformer in
+            transformer.cancelLogitechControlInteraction(context) || canceled
+        }
         let canceledMapping = cancelMappingInteractions(
             for: configuredButtons(matching: context),
             replayingBufferedEvents: true
@@ -684,13 +712,15 @@ extension ButtonMappingTransformer: Deactivatable {
         }
         recognitionLanes.removeAll()
         actionExecutor.deactivate()
-        gestureTransformer?.deactivate()
+        for gestureTransformer in gestureTransformers {
+            gestureTransformer.deactivate()
+        }
     }
 }
 
 extension ButtonMappingTransformer: EventTransformerInteractionTracking {
     var hasActiveInteraction: Bool {
         recognitionLanes.contains(where: \.engine.hasActiveInteraction)
-            || gestureTransformer?.hasActiveInteraction == true
+            || gestureTransformers.contains(where: \.hasActiveInteraction)
     }
 }

--- a/LinearMouse/EventTransformer/ButtonMappingTransformer.swift
+++ b/LinearMouse/EventTransformer/ButtonMappingTransformer.swift
@@ -450,22 +450,22 @@ final class ButtonMappingTransformer: EventTransformer, DeferredEventTransformer
     }
 
     private func cancelCompetingGestureIfNeeded(
-    after output: ButtonMappingEngine.Output,
-    in lane: RecognitionLane?
-) {
-    guard output.discardsBufferedEvents else {
-        return
-    }
-
-    for gestureTransformer in gestureTransformers {
-        guard let button = gestureTransformer.configuredTriggerButton,
-              lane?.engine.ownsInteraction(overlapping: button) == true else {
-            continue
+        after output: ButtonMappingEngine.Output,
+        in lane: RecognitionLane?
+    ) {
+        guard output.discardsBufferedEvents else {
+            return
         }
 
-        gestureTransformer.cancelInteraction(containing: button)
+        for gestureTransformer in gestureTransformers {
+            guard let button = gestureTransformer.configuredTriggerButton,
+                  lane?.engine.ownsInteraction(overlapping: button) == true else {
+                continue
+            }
+
+            gestureTransformer.cancelInteraction(containing: button)
+        }
     }
-}
 
     private func replayBufferedEvents(in lane: RecognitionLane?, remappingTo target: CGMouseButton) {
         let events = lane?.bufferedEvents ?? []

--- a/LinearMouse/EventTransformer/EventTransformerManager.swift
+++ b/LinearMouse/EventTransformer/EventTransformerManager.swift
@@ -769,19 +769,36 @@ class EventTransformerManager {
             mapping.normalizeAsStructured()
             return mapping
         }
-        let gestureTransformer: GestureButtonTransformer? = if let gesture = scheme.buttons.$gesture,
-                                                               gesture.enabled ?? false,
-                                                               let trigger = gesture.trigger,
-                                                               trigger.button != nil {
-            GestureButtonTransformer(
-                trigger: trigger,
-                threshold: Double(gesture.threshold ?? 50),
-                deadZone: Double(gesture.deadZone ?? 40),
-                cooldownMs: gesture.cooldownMs ?? 500,
-                actions: gesture.actions
+        var gestureTransformers: [GestureButtonTransformer] = []
+
+        if let gesture = scheme.buttons.$gesture,
+           gesture.enabled ?? false,
+           let trigger = gesture.trigger,
+           trigger.button != nil {
+            gestureTransformers.append(
+                GestureButtonTransformer(
+                    trigger: trigger,
+                    threshold: Double(gesture.threshold ?? 50),
+                    deadZone: Double(gesture.deadZone ?? 40),
+                    cooldownMs: gesture.cooldownMs ?? 500,
+                    actions: gesture.actions
+                )
             )
-        } else {
-            nil
+        }
+
+        if let gesture = scheme.buttons.$secondaryGesture,
+           gesture.enabled ?? false,
+           let trigger = gesture.trigger,
+           trigger.button != nil {
+            gestureTransformers.append(
+                GestureButtonTransformer(
+                    trigger: trigger,
+                    threshold: Double(gesture.threshold ?? 50),
+                    deadZone: Double(gesture.deadZone ?? 40),
+                    cooldownMs: gesture.cooldownMs ?? 500,
+                    actions: gesture.actions
+                )
+            )
         }
         let autoScrollTransformer = autoScrollTransformer(for: scheme.buttons.$autoScroll)
         if device != nil {
@@ -814,7 +831,7 @@ class EventTransformerManager {
             eventTransformer.append(ButtonMappingTransformer(
                 mappings: buttonMappings,
                 universalBackForward: scheme.buttons.universalBackForward,
-                gestureTransformer: gestureTransformer
+                gestureTransformers: gestureTransformers
             ))
         }
 
@@ -895,8 +912,10 @@ class EventTransformerManager {
             eventTransformer.append(ModifierActionsTransformer(modifiers: modifiers))
         }
 
-        if buttonMappings.isEmpty, let gestureTransformer {
-            eventTransformer.append(gestureTransformer)
+        if buttonMappings.isEmpty {
+            for gestureTransformer in gestureTransformers {
+                eventTransformer.append(gestureTransformer)
+            }
         }
 
         if let universalBackForward = scheme.buttons.universalBackForward,

--- a/LinearMouse/EventTransformer/GestureButtonTransformer.swift
+++ b/LinearMouse/EventTransformer/GestureButtonTransformer.swift
@@ -300,7 +300,7 @@ extension GestureButtonTransformer: EventTransformer {
 
         case .launchpad:
             launchpad()
-        
+
         case .previousTrack:
             postMediaKey(NX_KEYTYPE_PREVIOUS)
 
@@ -314,6 +314,7 @@ extension GestureButtonTransformer: EventTransformer {
             minimizeFocusedWindow()
         }
     }
+
     private func postMediaKey(_ key: Int32) {
         let keyDown = NSEvent.otherEvent(
             with: .systemDefined,
@@ -342,6 +343,7 @@ extension GestureButtonTransformer: EventTransformer {
         keyDown?.cgEvent?.post(tap: .cghidEventTap)
         keyUp?.cgEvent?.post(tap: .cghidEventTap)
     }
+
     private func focusedWindow() -> AXUIElement? {
         guard let application = NSWorkspace.shared.frontmostApplication else {
             return nil
@@ -373,13 +375,13 @@ extension GestureButtonTransformer: EventTransformer {
             kAXPositionAttribute as CFString,
             &positionValue
         ) == .success,
-        AXUIElementCopyAttributeValue(
-            window,
-            kAXSizeAttribute as CFString,
-            &sizeValue
-        ) == .success,
-        let positionValue,
-        let sizeValue else {
+            AXUIElementCopyAttributeValue(
+                window,
+                kAXSizeAttribute as CFString,
+                &sizeValue
+            ) == .success,
+            let positionValue,
+            let sizeValue else {
             return nil
         }
 
@@ -391,11 +393,11 @@ extension GestureButtonTransformer: EventTransformer {
             .cgPoint,
             &position
         ),
-        AXValueGetValue(
-            sizeValue as! AXValue,
-            .cgSize,
-            &size
-        ) else {
+            AXValueGetValue(
+                sizeValue as! AXValue,
+                .cgSize,
+                &size
+            ) else {
             return nil
         }
 

--- a/LinearMouse/EventTransformer/GestureButtonTransformer.swift
+++ b/LinearMouse/EventTransformer/GestureButtonTransformer.swift
@@ -4,6 +4,7 @@
 import AppKit
 import DockKit
 import Foundation
+import IOKit.hidsystem
 import KeyKit
 import os.log
 
@@ -299,7 +300,47 @@ extension GestureButtonTransformer: EventTransformer {
 
         case .launchpad:
             launchpad()
+        
+        case .previousTrack:
+            postMediaKey(NX_KEYTYPE_PREVIOUS)
+
+        case .nextTrack:
+            postMediaKey(NX_KEYTYPE_NEXT)
+
+        case .maximizeWindow:
+            break
+
+        case .minimizeWindow:
+            break
         }
+    }
+    private func postMediaKey(_ key: Int32) {
+        let keyDown = NSEvent.otherEvent(
+            with: .systemDefined,
+            location: .zero,
+            modifierFlags: NSEvent.ModifierFlags(rawValue: 0xA00),
+            timestamp: 0,
+            windowNumber: 0,
+            context: nil,
+            subtype: 8,
+            data1: Int((key << 16) | (0xA << 8)),
+            data2: -1
+        )
+
+        let keyUp = NSEvent.otherEvent(
+            with: .systemDefined,
+            location: .zero,
+            modifierFlags: NSEvent.ModifierFlags(rawValue: 0xB00),
+            timestamp: 0,
+            windowNumber: 0,
+            context: nil,
+            subtype: 8,
+            data1: Int((key << 16) | (0xB << 8)),
+            data2: -1
+        )
+
+        keyDown?.cgEvent?.post(tap: .cghidEventTap)
+        keyUp?.cgEvent?.post(tap: .cghidEventTap)
     }
 }
 

--- a/LinearMouse/EventTransformer/GestureButtonTransformer.swift
+++ b/LinearMouse/EventTransformer/GestureButtonTransformer.swift
@@ -308,10 +308,10 @@ extension GestureButtonTransformer: EventTransformer {
             postMediaKey(NX_KEYTYPE_NEXT)
 
         case .maximizeWindow:
-            break
+            maximizeFocusedWindow()
 
         case .minimizeWindow:
-            break
+            minimizeFocusedWindow()
         }
     }
     private func postMediaKey(_ key: Int32) {
@@ -341,6 +341,122 @@ extension GestureButtonTransformer: EventTransformer {
 
         keyDown?.cgEvent?.post(tap: .cghidEventTap)
         keyUp?.cgEvent?.post(tap: .cghidEventTap)
+    }
+    private func focusedWindow() -> AXUIElement? {
+        guard let application = NSWorkspace.shared.frontmostApplication else {
+            return nil
+        }
+
+        let appElement = AXUIElementCreateApplication(application.processIdentifier)
+
+        var value: CFTypeRef?
+        let result = AXUIElementCopyAttributeValue(
+            appElement,
+            kAXFocusedWindowAttribute as CFString,
+            &value
+        )
+
+        guard result == .success,
+              let value else {
+            return nil
+        }
+
+        return (value as! AXUIElement)
+    }
+
+    private func windowFrame(_ window: AXUIElement) -> CGRect? {
+        var positionValue: CFTypeRef?
+        var sizeValue: CFTypeRef?
+
+        guard AXUIElementCopyAttributeValue(
+            window,
+            kAXPositionAttribute as CFString,
+            &positionValue
+        ) == .success,
+        AXUIElementCopyAttributeValue(
+            window,
+            kAXSizeAttribute as CFString,
+            &sizeValue
+        ) == .success,
+        let positionValue,
+        let sizeValue else {
+            return nil
+        }
+
+        var position = CGPoint.zero
+        var size = CGSize.zero
+
+        guard AXValueGetValue(
+            positionValue as! AXValue,
+            .cgPoint,
+            &position
+        ),
+        AXValueGetValue(
+            sizeValue as! AXValue,
+            .cgSize,
+            &size
+        ) else {
+            return nil
+        }
+
+        return CGRect(origin: position, size: size)
+    }
+
+    private func screenForWindow(_ window: AXUIElement) -> NSScreen? {
+        guard let frame = windowFrame(window) else {
+            return NSScreen.main
+        }
+
+        return NSScreen.screens.max {
+            $0.frame.intersection(frame).area
+                < $1.frame.intersection(frame).area
+        }
+    }
+
+    private func maximizeFocusedWindow() {
+        guard let window = focusedWindow(),
+              let screen = screenForWindow(window) else {
+            return
+        }
+
+        let visibleFrame = screen.visibleFrame
+        let screenFrame = screen.frame
+
+        var position = CGPoint(
+            x: visibleFrame.minX,
+            y: screenFrame.maxY - visibleFrame.maxY
+        )
+
+        var size = visibleFrame.size
+
+        guard let positionValue = AXValueCreate(.cgPoint, &position),
+              let sizeValue = AXValueCreate(.cgSize, &size) else {
+            return
+        }
+
+        AXUIElementSetAttributeValue(
+            window,
+            kAXPositionAttribute as CFString,
+            positionValue
+        )
+
+        AXUIElementSetAttributeValue(
+            window,
+            kAXSizeAttribute as CFString,
+            sizeValue
+        )
+    }
+
+    private func minimizeFocusedWindow() {
+        guard let window = focusedWindow() else {
+            return
+        }
+
+        AXUIElementSetAttributeValue(
+            window,
+            kAXMinimizedAttribute as CFString,
+            kCFBooleanTrue
+        )
     }
 }
 
@@ -445,5 +561,11 @@ extension GestureButtonTransformer: EventTransformerInteractionTracking {
         case let .cooldown(_, released):
             return !released
         }
+    }
+}
+
+private extension CGRect {
+    var area: CGFloat {
+        width * height
     }
 }

--- a/LinearMouse/Localizable.xcstrings
+++ b/LinearMouse/Localizable.xcstrings
@@ -24829,6 +24829,7 @@
       }
     },
     "Enable gesture button" : {
+      "extractionState" : "stale",
       "localizations" : {
         "af" : {
           "stringUnit" : {
@@ -25035,6 +25036,12 @@
           }
         }
       }
+    },
+    "Enable primary gesture button" : {
+
+    },
+    "Enable secondary gesture button" : {
+
     },
     "Enable universal back and forward" : {
       "localizations" : {
@@ -37748,6 +37755,9 @@
         }
       }
     },
+    "Maximize Window" : {
+
+    },
     "Media" : {
       "localizations" : {
         "af" : {
@@ -38581,6 +38591,9 @@
           }
         }
       }
+    },
+    "Minimize Window" : {
+
     },
     "Missing key %1$@ at %2$@" : {
       "localizations" : {
@@ -41911,6 +41924,9 @@
           }
         }
       }
+    },
+    "Next Track" : {
+
     },
     "No action" : {
       "localizations" : {
@@ -47544,6 +47560,9 @@
           }
         }
       }
+    },
+    "Previous Track" : {
+
     },
     "Primary" : {
       "comment" : "Primary mouse button",
@@ -69835,6 +69854,9 @@
           }
         }
       }
+    },
+    "Use a second mouse button as an independent gesture trigger." : {
+
     },
     "Use finer vertical wheel steps on supported Logitech mice." : {
       "localizations" : {

--- a/LinearMouse/Model/Configuration/Scheme/Buttons/Buttons.swift
+++ b/LinearMouse/Model/Configuration/Scheme/Buttons/Buttons.swift
@@ -23,6 +23,8 @@ extension Scheme {
         @ImplicitOptional var autoScroll: AutoScroll
 
         @ImplicitOptional var gesture: Gesture
+
+        @ImplicitOptional var secondaryGesture: Gesture
     }
 }
 
@@ -51,6 +53,9 @@ extension Scheme.Buttons {
         if let gesture = $gesture {
             buttons.$gesture = gesture
         }
+        if let secondaryGesture = $secondaryGesture {
+            buttons.$secondaryGesture = secondaryGesture
+        }
     }
 
     func merge(into buttons: inout Self?) {
@@ -70,6 +75,7 @@ extension Scheme.Buttons {
         case clickDebouncing
         case autoScroll
         case gesture
+        case secondaryGesture
     }
 
     init(from decoder: Decoder) throws {
@@ -93,6 +99,10 @@ extension Scheme.Buttons {
         )
         _autoScroll = try container.decode(ImplicitOptional<AutoScroll>.self, forKey: .autoScroll)
         _gesture = try container.decode(ImplicitOptional<Gesture>.self, forKey: .gesture)
+        _secondaryGesture = try container.decode(
+            ImplicitOptional<Gesture>.self,
+            forKey: .secondaryGesture
+        )
     }
 
     func encode(to encoder: Encoder) throws {
@@ -111,6 +121,7 @@ extension Scheme.Buttons {
         try container.encode(_clickDebouncing, forKey: .clickDebouncing)
         try container.encode(_autoScroll, forKey: .autoScroll)
         try container.encode(_gesture, forKey: .gesture)
+        try container.encode(_secondaryGesture, forKey: .secondaryGesture)
     }
 }
 

--- a/LinearMouse/Model/Configuration/Scheme/Buttons/Gesture/Gesture.swift
+++ b/LinearMouse/Model/Configuration/Scheme/Buttons/Gesture/Gesture.swift
@@ -32,6 +32,11 @@ extension Scheme.Buttons {
             case appExpose
             case showDesktop
             case launchpad
+
+            case previousTrack
+            case nextTrack
+            case maximizeWindow
+            case minimizeWindow
         }
     }
 }

--- a/LinearMouse/UI/ButtonsSettings/ButtonsSettingsState.swift
+++ b/LinearMouse/UI/ButtonsSettings/ButtonsSettingsState.swift
@@ -387,4 +387,131 @@ extension ButtonsSettingsState {
             scheme.buttons.gesture.actions.down = newValue
         }
     }
+
+    var secondaryGestureEnabled: Bool {
+    get {
+        mergedScheme.buttons.secondaryGesture.enabled ?? false
+    }
+    set {
+        guard newValue != secondaryGestureEnabled else {
+            return
+        }
+
+        if newValue {
+            scheme.buttons.secondaryGesture.enabled = true
+
+            if scheme.buttons.secondaryGesture.trigger == nil {
+                scheme.buttons.secondaryGesture.trigger = defaultGestureTrigger
+            }
+
+            if scheme.buttons.secondaryGesture.threshold == nil {
+                scheme.buttons.secondaryGesture.threshold = 50
+            }
+
+            if scheme.buttons.secondaryGesture.actions.left == nil {
+                scheme.buttons.secondaryGesture.actions.left = .spaceLeft
+            }
+
+            if scheme.buttons.secondaryGesture.actions.right == nil {
+                scheme.buttons.secondaryGesture.actions.right = .spaceRight
+            }
+
+            if scheme.buttons.secondaryGesture.actions.up == nil {
+                scheme.buttons.secondaryGesture.actions.up = .missionControl
+            }
+
+            if scheme.buttons.secondaryGesture.actions.down == nil {
+                scheme.buttons.secondaryGesture.actions.down = .appExpose
+            }
+        } else {
+            scheme.buttons.secondaryGesture.enabled = false
+        }
+
+        GlobalEventTap.shared.stop()
+        GlobalEventTap.shared.start()
+    }
+}
+
+var secondaryGestureTrigger: Scheme.Buttons.Mapping {
+    get {
+        mergedScheme.buttons.secondaryGesture.trigger ?? defaultGestureTrigger
+    }
+    set {
+        var trigger = newValue
+        trigger.action = nil
+        trigger.repeat = nil
+        trigger.hold = nil
+        trigger.scroll = nil
+        scheme.buttons.secondaryGesture.trigger = trigger
+    }
+}
+
+var secondaryGestureTriggerBinding: Binding<Scheme.Buttons.Mapping> {
+    Binding(
+        get: { [self] in
+            secondaryGestureTrigger
+        },
+        set: { [self] in
+            secondaryGestureTrigger = $0
+        }
+    )
+}
+
+var secondaryGestureTriggerValid: Bool {
+    secondaryGestureTrigger.valid
+}
+
+var secondaryGestureThreshold: Int {
+    get {
+        mergedScheme.buttons.secondaryGesture.threshold ?? 50
+    }
+    set {
+        scheme.buttons.secondaryGesture.threshold = newValue
+    }
+}
+
+var secondaryGestureThresholdDouble: Double {
+    get {
+        Double(secondaryGestureThreshold)
+    }
+    set {
+        secondaryGestureThreshold = Int(round(newValue / 5)) * 5
+    }
+}
+
+var secondaryGestureActionLeft: Scheme.Buttons.Gesture.GestureAction {
+    get {
+        mergedScheme.buttons.secondaryGesture.actions.left ?? .spaceLeft
+    }
+    set {
+        scheme.buttons.secondaryGesture.actions.left = newValue
+    }
+}
+
+var secondaryGestureActionRight: Scheme.Buttons.Gesture.GestureAction {
+    get {
+        mergedScheme.buttons.secondaryGesture.actions.right ?? .spaceRight
+    }
+    set {
+        scheme.buttons.secondaryGesture.actions.right = newValue
+    }
+}
+
+var secondaryGestureActionUp: Scheme.Buttons.Gesture.GestureAction {
+    get {
+        mergedScheme.buttons.secondaryGesture.actions.up ?? .missionControl
+    }
+    set {
+        scheme.buttons.secondaryGesture.actions.up = newValue
+    }
+}
+
+var secondaryGestureActionDown: Scheme.Buttons.Gesture.GestureAction {
+    get {
+        mergedScheme.buttons.secondaryGesture.actions.down ?? .appExpose
+    }
+    set {
+        scheme.buttons.secondaryGesture.actions.down = newValue
+    }
+}
 }

--- a/LinearMouse/UI/ButtonsSettings/ButtonsSettingsState.swift
+++ b/LinearMouse/UI/ButtonsSettings/ButtonsSettingsState.swift
@@ -389,129 +389,129 @@ extension ButtonsSettingsState {
     }
 
     var secondaryGestureEnabled: Bool {
-    get {
-        mergedScheme.buttons.secondaryGesture.enabled ?? false
-    }
-    set {
-        guard newValue != secondaryGestureEnabled else {
-            return
+        get {
+            mergedScheme.buttons.secondaryGesture.enabled ?? false
         }
-
-        if newValue {
-            scheme.buttons.secondaryGesture.enabled = true
-
-            if scheme.buttons.secondaryGesture.trigger == nil {
-                scheme.buttons.secondaryGesture.trigger = defaultGestureTrigger
+        set {
+            guard newValue != secondaryGestureEnabled else {
+                return
             }
 
-            if scheme.buttons.secondaryGesture.threshold == nil {
-                scheme.buttons.secondaryGesture.threshold = 50
+            if newValue {
+                scheme.buttons.secondaryGesture.enabled = true
+
+                if scheme.buttons.secondaryGesture.trigger == nil {
+                    scheme.buttons.secondaryGesture.trigger = defaultGestureTrigger
+                }
+
+                if scheme.buttons.secondaryGesture.threshold == nil {
+                    scheme.buttons.secondaryGesture.threshold = 50
+                }
+
+                if scheme.buttons.secondaryGesture.actions.left == nil {
+                    scheme.buttons.secondaryGesture.actions.left = .spaceLeft
+                }
+
+                if scheme.buttons.secondaryGesture.actions.right == nil {
+                    scheme.buttons.secondaryGesture.actions.right = .spaceRight
+                }
+
+                if scheme.buttons.secondaryGesture.actions.up == nil {
+                    scheme.buttons.secondaryGesture.actions.up = .missionControl
+                }
+
+                if scheme.buttons.secondaryGesture.actions.down == nil {
+                    scheme.buttons.secondaryGesture.actions.down = .appExpose
+                }
+            } else {
+                scheme.buttons.secondaryGesture.enabled = false
             }
 
-            if scheme.buttons.secondaryGesture.actions.left == nil {
-                scheme.buttons.secondaryGesture.actions.left = .spaceLeft
-            }
-
-            if scheme.buttons.secondaryGesture.actions.right == nil {
-                scheme.buttons.secondaryGesture.actions.right = .spaceRight
-            }
-
-            if scheme.buttons.secondaryGesture.actions.up == nil {
-                scheme.buttons.secondaryGesture.actions.up = .missionControl
-            }
-
-            if scheme.buttons.secondaryGesture.actions.down == nil {
-                scheme.buttons.secondaryGesture.actions.down = .appExpose
-            }
-        } else {
-            scheme.buttons.secondaryGesture.enabled = false
+            GlobalEventTap.shared.stop()
+            GlobalEventTap.shared.start()
         }
-
-        GlobalEventTap.shared.stop()
-        GlobalEventTap.shared.start()
     }
-}
 
-var secondaryGestureTrigger: Scheme.Buttons.Mapping {
-    get {
-        mergedScheme.buttons.secondaryGesture.trigger ?? defaultGestureTrigger
-    }
-    set {
-        var trigger = newValue
-        trigger.action = nil
-        trigger.repeat = nil
-        trigger.hold = nil
-        trigger.scroll = nil
-        scheme.buttons.secondaryGesture.trigger = trigger
-    }
-}
-
-var secondaryGestureTriggerBinding: Binding<Scheme.Buttons.Mapping> {
-    Binding(
-        get: { [self] in
-            secondaryGestureTrigger
-        },
-        set: { [self] in
-            secondaryGestureTrigger = $0
+    var secondaryGestureTrigger: Scheme.Buttons.Mapping {
+        get {
+            mergedScheme.buttons.secondaryGesture.trigger ?? defaultGestureTrigger
         }
-    )
-}
+        set {
+            var trigger = newValue
+            trigger.action = nil
+            trigger.repeat = nil
+            trigger.hold = nil
+            trigger.scroll = nil
+            scheme.buttons.secondaryGesture.trigger = trigger
+        }
+    }
 
-var secondaryGestureTriggerValid: Bool {
-    secondaryGestureTrigger.valid
-}
+    var secondaryGestureTriggerBinding: Binding<Scheme.Buttons.Mapping> {
+        Binding(
+            get: { [self] in
+                secondaryGestureTrigger
+            },
+            set: { [self] in
+                secondaryGestureTrigger = $0
+            }
+        )
+    }
 
-var secondaryGestureThreshold: Int {
-    get {
-        mergedScheme.buttons.secondaryGesture.threshold ?? 50
+    var secondaryGestureTriggerValid: Bool {
+        secondaryGestureTrigger.valid
     }
-    set {
-        scheme.buttons.secondaryGesture.threshold = newValue
-    }
-}
 
-var secondaryGestureThresholdDouble: Double {
-    get {
-        Double(secondaryGestureThreshold)
+    var secondaryGestureThreshold: Int {
+        get {
+            mergedScheme.buttons.secondaryGesture.threshold ?? 50
+        }
+        set {
+            scheme.buttons.secondaryGesture.threshold = newValue
+        }
     }
-    set {
-        secondaryGestureThreshold = Int(round(newValue / 5)) * 5
-    }
-}
 
-var secondaryGestureActionLeft: Scheme.Buttons.Gesture.GestureAction {
-    get {
-        mergedScheme.buttons.secondaryGesture.actions.left ?? .spaceLeft
+    var secondaryGestureThresholdDouble: Double {
+        get {
+            Double(secondaryGestureThreshold)
+        }
+        set {
+            secondaryGestureThreshold = Int(round(newValue / 5)) * 5
+        }
     }
-    set {
-        scheme.buttons.secondaryGesture.actions.left = newValue
-    }
-}
 
-var secondaryGestureActionRight: Scheme.Buttons.Gesture.GestureAction {
-    get {
-        mergedScheme.buttons.secondaryGesture.actions.right ?? .spaceRight
+    var secondaryGestureActionLeft: Scheme.Buttons.Gesture.GestureAction {
+        get {
+            mergedScheme.buttons.secondaryGesture.actions.left ?? .spaceLeft
+        }
+        set {
+            scheme.buttons.secondaryGesture.actions.left = newValue
+        }
     }
-    set {
-        scheme.buttons.secondaryGesture.actions.right = newValue
-    }
-}
 
-var secondaryGestureActionUp: Scheme.Buttons.Gesture.GestureAction {
-    get {
-        mergedScheme.buttons.secondaryGesture.actions.up ?? .missionControl
+    var secondaryGestureActionRight: Scheme.Buttons.Gesture.GestureAction {
+        get {
+            mergedScheme.buttons.secondaryGesture.actions.right ?? .spaceRight
+        }
+        set {
+            scheme.buttons.secondaryGesture.actions.right = newValue
+        }
     }
-    set {
-        scheme.buttons.secondaryGesture.actions.up = newValue
-    }
-}
 
-var secondaryGestureActionDown: Scheme.Buttons.Gesture.GestureAction {
-    get {
-        mergedScheme.buttons.secondaryGesture.actions.down ?? .appExpose
+    var secondaryGestureActionUp: Scheme.Buttons.Gesture.GestureAction {
+        get {
+            mergedScheme.buttons.secondaryGesture.actions.up ?? .missionControl
+        }
+        set {
+            scheme.buttons.secondaryGesture.actions.up = newValue
+        }
     }
-    set {
-        scheme.buttons.secondaryGesture.actions.down = newValue
+
+    var secondaryGestureActionDown: Scheme.Buttons.Gesture.GestureAction {
+        get {
+            mergedScheme.buttons.secondaryGesture.actions.down ?? .appExpose
+        }
+        set {
+            scheme.buttons.secondaryGesture.actions.down = newValue
+        }
     }
-}
 }

--- a/LinearMouse/UI/ButtonsSettings/GestureButtonSection/GestureActionPicker.swift
+++ b/LinearMouse/UI/ButtonsSettings/GestureButtonSection/GestureActionPicker.swift
@@ -18,7 +18,7 @@ struct GestureActionPicker: View {
             Text("App Expose").tag(GestureAction.appExpose)
             Text("Show Desktop").tag(GestureAction.showDesktop)
             Text("Launchpad").tag(GestureAction.launchpad)
-            
+
             Text("Previous Track").tag(GestureAction.previousTrack)
             Text("Next Track").tag(GestureAction.nextTrack)
             Text("Maximize Window").tag(GestureAction.maximizeWindow)

--- a/LinearMouse/UI/ButtonsSettings/GestureButtonSection/GestureActionPicker.swift
+++ b/LinearMouse/UI/ButtonsSettings/GestureButtonSection/GestureActionPicker.swift
@@ -18,6 +18,11 @@ struct GestureActionPicker: View {
             Text("App Expose").tag(GestureAction.appExpose)
             Text("Show Desktop").tag(GestureAction.showDesktop)
             Text("Launchpad").tag(GestureAction.launchpad)
+            
+            Text("Previous Track").tag(GestureAction.previousTrack)
+            Text("Next Track").tag(GestureAction.nextTrack)
+            Text("Maximize Window").tag(GestureAction.maximizeWindow)
+            Text("Minimize Window").tag(GestureAction.minimizeWindow)
         }
         .modifier(PickerViewModifier())
     }

--- a/LinearMouse/UI/ButtonsSettings/GestureButtonSection/GestureButtonSection.swift
+++ b/LinearMouse/UI/ButtonsSettings/GestureButtonSection/GestureButtonSection.swift
@@ -17,7 +17,6 @@ struct GestureButtonSection: View {
         }
     }
 
-    @ViewBuilder
     private var primaryGestureSection: some View {
         Section {
             Toggle(isOn: $state.gestureEnabled.animation()) {
@@ -45,7 +44,6 @@ struct GestureButtonSection: View {
         .modifier(SectionViewModifier())
     }
 
-    @ViewBuilder
     private var secondaryGestureSection: some View {
         Section {
             Toggle(isOn: $state.secondaryGestureEnabled.animation()) {

--- a/LinearMouse/UI/ButtonsSettings/GestureButtonSection/GestureButtonSection.swift
+++ b/LinearMouse/UI/ButtonsSettings/GestureButtonSection/GestureButtonSection.swift
@@ -12,76 +12,138 @@ struct GestureButtonSection: View {
 
     var body: some View {
         if isMouseDevice {
-            Section {
-                Toggle(isOn: $state.gestureEnabled.animation()) {
-                    withDescription {
-                        Text("Enable gesture button")
-                        Text(
-                            "Press and hold a button while dragging to trigger gestures like switching desktop spaces or opening Mission Control."
-                        )
-                    }
-                }
+            primaryGestureSection
+            secondaryGestureSection
+        }
+    }
 
-                if state.gestureEnabled {
-                    VStack(alignment: .leading, spacing: 8) {
-                        Text("Trigger")
-                            .font(.headline)
-
-                        ButtonMappingButtonRecorder(
-                            mapping: state.gestureTriggerBinding
-                        )
-
-                        if !state.gestureTriggerValid {
-                            Text("Choose a mouse button trigger. Left click without modifier keys is not allowed.")
-                                .foregroundColor(.red)
-                                .controlSize(.small)
-                                .fixedSize(horizontal: false, vertical: true)
-                        }
-                    }
-
-                    VStack(alignment: .leading, spacing: 4) {
-                        HStack {
-                            Text("Threshold")
-                            Spacer()
-                            Text("\(state.gestureThreshold) pixels")
-                                .foregroundColor(.secondary)
-                        }
-                        Slider(value: $state.gestureThresholdDouble, in: 20 ... 200, step: 5)
-                    }
-
-                    Divider()
-
-                    Text("Gesture Actions")
-                        .font(.headline)
-
-                    GestureActionPicker(
-                        label: "Swipe left",
-                        selection: $state.gestureActionLeft
-                    )
-
-                    GestureActionPicker(
-                        label: "Swipe right",
-                        selection: $state.gestureActionRight
-                    )
-
-                    GestureActionPicker(
-                        label: "Swipe up",
-                        selection: $state.gestureActionUp
-                    )
-
-                    GestureActionPicker(
-                        label: "Swipe down",
-                        selection: $state.gestureActionDown
-                    )
-
+    @ViewBuilder
+    private var primaryGestureSection: some View {
+        Section {
+            Toggle(isOn: $state.gestureEnabled.animation()) {
+                withDescription {
+                    Text("Enable primary gesture button")
                     Text(
-                        "Hold the button and drag to trigger gestures. Drag at least \(state.gestureThreshold) pixels in one direction."
+                        "Press and hold a button while dragging to trigger gestures like switching desktop spaces or opening Mission Control."
                     )
-                    .settingsDescriptionStyle()
-                    .padding(.top, 8)
                 }
             }
-            .modifier(SectionViewModifier())
+
+            if state.gestureEnabled {
+                gestureConfiguration(
+                    trigger: state.gestureTriggerBinding,
+                    triggerValid: state.gestureTriggerValid,
+                    threshold: $state.gestureThresholdDouble,
+                    thresholdPixels: state.gestureThreshold,
+                    actionLeft: $state.gestureActionLeft,
+                    actionRight: $state.gestureActionRight,
+                    actionUp: $state.gestureActionUp,
+                    actionDown: $state.gestureActionDown
+                )
+            }
         }
+        .modifier(SectionViewModifier())
+    }
+
+    @ViewBuilder
+    private var secondaryGestureSection: some View {
+        Section {
+            Toggle(isOn: $state.secondaryGestureEnabled.animation()) {
+                withDescription {
+                    Text("Enable secondary gesture button")
+                    Text(
+                        "Use a second mouse button as an independent gesture trigger."
+                    )
+                }
+            }
+
+            if state.secondaryGestureEnabled {
+                gestureConfiguration(
+                    trigger: state.secondaryGestureTriggerBinding,
+                    triggerValid: state.secondaryGestureTriggerValid,
+                    threshold: $state.secondaryGestureThresholdDouble,
+                    thresholdPixels: state.secondaryGestureThreshold,
+                    actionLeft: $state.secondaryGestureActionLeft,
+                    actionRight: $state.secondaryGestureActionRight,
+                    actionUp: $state.secondaryGestureActionUp,
+                    actionDown: $state.secondaryGestureActionDown
+                )
+            }
+        }
+        .modifier(SectionViewModifier())
+    }
+
+    @ViewBuilder
+    private func gestureConfiguration(
+        trigger: Binding<Scheme.Buttons.Mapping>,
+        triggerValid: Bool,
+        threshold: Binding<Double>,
+        thresholdPixels: Int,
+        actionLeft: Binding<Scheme.Buttons.Gesture.GestureAction>,
+        actionRight: Binding<Scheme.Buttons.Gesture.GestureAction>,
+        actionUp: Binding<Scheme.Buttons.Gesture.GestureAction>,
+        actionDown: Binding<Scheme.Buttons.Gesture.GestureAction>
+    ) -> some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("Trigger")
+                .font(.headline)
+
+            ButtonMappingButtonRecorder(
+                mapping: trigger
+            )
+
+            if !triggerValid {
+                Text("Choose a mouse button trigger. Left click without modifier keys is not allowed.")
+                    .foregroundColor(.red)
+                    .controlSize(.small)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+        }
+
+        VStack(alignment: .leading, spacing: 4) {
+            HStack {
+                Text("Threshold")
+                Spacer()
+                Text("\(thresholdPixels) pixels")
+                    .foregroundColor(.secondary)
+            }
+
+            Slider(
+                value: threshold,
+                in: 20 ... 200,
+                step: 5
+            )
+        }
+
+        Divider()
+
+        Text("Gesture Actions")
+            .font(.headline)
+
+        GestureActionPicker(
+            label: "Swipe left",
+            selection: actionLeft
+        )
+
+        GestureActionPicker(
+            label: "Swipe right",
+            selection: actionRight
+        )
+
+        GestureActionPicker(
+            label: "Swipe up",
+            selection: actionUp
+        )
+
+        GestureActionPicker(
+            label: "Swipe down",
+            selection: actionDown
+        )
+
+        Text(
+            "Hold the button and drag to trigger gestures. Drag at least \(thresholdPixels) pixels in one direction."
+        )
+        .settingsDescriptionStyle()
+        .padding(.top, 8)
     }
 }

--- a/LinearMouseUnitTests/EventTransformer/ButtonMappingTransformerTests.swift
+++ b/LinearMouseUnitTests/EventTransformer/ButtonMappingTransformerTests.swift
@@ -205,7 +205,7 @@ final class ButtonMappingTransformerTests: XCTestCase {
             mappings: [buttonMapping(short: .arg1(.keyPress([.a])))],
             scheduler: scheduler,
             keySimulator: keySimulator,
-            gestureTransformer: gestureTransformer
+            gestureTransformers: [gestureTransformer]
         )
 
         XCTAssertNil(try transformer.transform(buttonEvent(pressed: true), in: .init(device: nil)))
@@ -228,7 +228,7 @@ final class ButtonMappingTransformerTests: XCTestCase {
         let transformer = makeTransformer(
             mappings: [mapping],
             scheduler: scheduler,
-            gestureTransformer: gestureTransformer
+            gestureTransformers: [gestureTransformer]
         )
 
         XCTAssertNil(try transformer.transform(buttonEvent(pressed: true), in: .init(device: nil)))
@@ -243,7 +243,7 @@ final class ButtonMappingTransformerTests: XCTestCase {
         let transformer = makeTransformer(
             mappings: [buttonMapping(long: .arg0(.none))],
             scheduler: scheduler,
-            gestureTransformer: gestureTransformer
+            gestureTransformers: [gestureTransformer]
         )
 
         XCTAssertNil(try transformer.transform(buttonEvent(pressed: true), in: .init(device: nil)))
@@ -265,7 +265,7 @@ final class ButtonMappingTransformerTests: XCTestCase {
         let transformer = makeTransformer(
             mappings: [mapping],
             scheduler: scheduler,
-            gestureTransformer: gestureTransformer
+            gestureTransformers: [gestureTransformer]
         )
 
         let down = try XCTUnwrap(transformer.transform(
@@ -301,7 +301,7 @@ final class ButtonMappingTransformerTests: XCTestCase {
                 buttonMapping(button: 5, long: .arg0(.none))
             ],
             scheduler: scheduler,
-            gestureTransformer: makeGestureTransformer(button: .mouse(4))
+            gestureTransformers: [makeGestureTransformer(button: .mouse(4))]
         ) { deliveredEvents.append($0) }
 
         XCTAssertNil(try transformer.transform(
@@ -344,7 +344,7 @@ final class ButtonMappingTransformerTests: XCTestCase {
             mappings: [buttonMapping(short: .arg1(.keyPress([.a])))],
             scheduler: scheduler,
             keySimulator: keySimulator,
-            gestureTransformer: makeGestureTransformer(button: .mouse(4))
+            gestureTransformers: [makeGestureTransformer(button: .mouse(4))]
         )
 
         XCTAssertNil(try transformer.transform(buttonEvent(pressed: true), in: .init(device: nil)))
@@ -908,7 +908,7 @@ final class ButtonMappingTransformerTests: XCTestCase {
             mappings: [mapping],
             scheduler: scheduler,
             keySimulator: keySimulator,
-            gestureTransformer: makeGestureTransformer(button: .logitechControl(identity))
+            gestureTransformers: [makeGestureTransformer(button: .logitechControl(identity))]
         )
 
         XCTAssertEqual(
@@ -939,7 +939,7 @@ final class ButtonMappingTransformerTests: XCTestCase {
         let transformer = makeTransformer(
             mappings: [mapping],
             scheduler: scheduler,
-            gestureTransformer: gestureTransformer
+            gestureTransformers: [gestureTransformer]
         )
 
         XCTAssertEqual(
@@ -1223,7 +1223,7 @@ final class ButtonMappingTransformerTests: XCTestCase {
         scheduler: ButtonMappingTestTimerScheduler,
         swapsPrimaryAndSecondaryButtons: Bool = false,
         keySimulator: KeySimulating? = nil,
-        gestureTransformer: GestureButtonTransformer? = nil,
+        gestureTransformers: [GestureButtonTransformer] = [],
         eventSink: @escaping (CGEvent) -> Void = { _ in }
     ) -> ButtonMappingTransformer {
         .init(
@@ -1232,7 +1232,7 @@ final class ButtonMappingTransformerTests: XCTestCase {
             scheduleTimer: scheduler.schedule,
             monotonicClock: { scheduler.now },
             keySimulator: keySimulator,
-            gestureTransformer: gestureTransformer,
+            gestureTransformers: gestureTransformers,
             eventSink: eventSink
         )
     }


### PR DESCRIPTION
This PR adds support for configuring a second independent gesture button alongside the existing gesture trigger.

The change updates ButtonMappingTransformer to support multiple GestureButtonTransformer instances while preserving the existing click-vs-gesture arbitration behavior.

It also adds new gesture actions:

Previous Track
Next Track
Maximize Window
Minimize Window

The secondary gesture profile has its own trigger, threshold, and directional action assignments.

Tested hardware

Tested with a Logitech MX Master 4.

Configuration used during testing:

Primary gesture trigger: standard mouse button
Secondary gesture trigger: Logitech HID++ Control 0x00C3
0x00C3 also mapped independently to Play/Pause on button release

Verified that:

both gesture buttons operate independently
normal short-click mappings continue to work on a gesture trigger
Previous/Next Track actions work with system media playback
Maximize resizes the focused window to the usable screen area
Minimize sends the focused window to the Dock
existing unit tests pass
SwiftFormat lint passes

Local make reaches a successful archive, but final export cannot complete because the local machine does not have the project’s Developer ID Application signing certificate.