### PR TITLE
Fix Auto Scroll activation delay in Finder and add opt-in override for pressable elements

### DIFF
--- a/Documentation/Configuration.d.ts
+++ b/Documentation/Configuration.d.ts
@@ -519,6 +519,13 @@ declare namespace Scheme {
        * @description Choose the mouse button and modifier keys used to activate auto scroll.
        */
       trigger?: AutoScroll.Trigger;
+
+      /**
+       * @title Activate over clickable elements
+       * @description Activate auto scroll even if the initial click lands on a clickable element such as a link or button. When disabled (default), the click is passed through so links and buttons can still be activated normally.
+       * @default false
+       */
+      activateOverPressableElements?: boolean;
     };
 
     namespace AutoScroll {

--- a/Documentation/Configuration.json
+++ b/Documentation/Configuration.json
@@ -159,6 +159,12 @@
     "Scheme.Buttons.AutoScroll": {
       "additionalProperties": false,
       "properties": {
+        "activateOverPressableElements": {
+          "default": false,
+          "description": "Activate auto scroll even if the initial click lands on a clickable element such as a link or button. When disabled (default), the click is passed through so links and buttons can still be activated normally.",
+          "title": "Activate over clickable elements",
+          "type": "boolean"
+        },
         "enabled": {
           "default": false,
           "description": "Indicates if auto scroll is enabled.",

--- a/LinearMouse/Accessibility/AutoScrollAccessibilityActivationClassifier.swift
+++ b/LinearMouse/Accessibility/AutoScrollAccessibilityActivationClassifier.swift
@@ -44,6 +44,11 @@ struct AutoScrollAccessibilityActivationClassifier {
         "AXDisclosureTriangle",
         "AXSwitch"
     ]
+    private static let listContainerRoles: Set<String> = [
+        "AXTable",
+        "AXOutline",
+        "AXList"
+    ]
 
     private let elementQuery: AccessibilityElementQuerying
     private let bypassRuleMatcher: AccessibilityBypassRuleMatcher
@@ -76,6 +81,14 @@ struct AutoScrollAccessibilityActivationClassifier {
         }
 
         return actions.contains(kAXPressAction as String)
+    }
+
+    static func isListContainerRole(_ role: String?) -> Bool {
+        guard let role else {
+            return false
+        }
+
+        return listContainerRoles.contains(role)
     }
 
     private func refineActivationProbe(from initialProbe: AutoScrollActivationProbe) -> AutoScrollActivationProbe {
@@ -120,11 +133,15 @@ struct AutoScrollAccessibilityActivationClassifier {
         case let .success(value):
             hitElement = value
         case let .failure(error):
-            return .nonPressable(diagnostic: "hitTest.\(error.linearMouseDescription)", path: [])
+            return .nonPressable(
+                diagnostic: "hitTest.\(error.linearMouseDescription)",
+                path: [],
+                isInsideWebContent: false
+            )
         }
 
         guard let hitElement else {
-            return .nonPressable(diagnostic: nil, path: [])
+            return .nonPressable(diagnostic: nil, path: [], isInsideWebContent: false)
         }
 
         var currentElement: AXUIElement? = hitElement
@@ -132,7 +149,7 @@ struct AutoScrollAccessibilityActivationClassifier {
         var isInsideWebContent = false
         for depth in 0 ..< Self.maxParentDepth {
             guard let element = currentElement else {
-                return .nonPressable(diagnostic: nil, path: path)
+                return .nonPressable(diagnostic: nil, path: path, isInsideWebContent: isInsideWebContent)
             }
 
             let role: String?
@@ -140,7 +157,11 @@ struct AutoScrollAccessibilityActivationClassifier {
             case let .success(value):
                 role = value
             case let .failure(error):
-                return .nonPressable(diagnostic: "role.\(error.linearMouseDescription)", path: path)
+                return .nonPressable(
+                    diagnostic: "role.\(error.linearMouseDescription)",
+                    path: path,
+                    isInsideWebContent: isInsideWebContent
+                )
             }
 
             let subrole: String?
@@ -148,7 +169,11 @@ struct AutoScrollAccessibilityActivationClassifier {
             case let .success(value):
                 subrole = value
             case let .failure(error):
-                return .nonPressable(diagnostic: "subrole.\(error.linearMouseDescription)", path: path)
+                return .nonPressable(
+                    diagnostic: "subrole.\(error.linearMouseDescription)",
+                    path: path,
+                    isInsideWebContent: isInsideWebContent
+                )
             }
 
             let actions: [String]
@@ -156,7 +181,11 @@ struct AutoScrollAccessibilityActivationClassifier {
             case let .success(value):
                 actions = value
             case let .failure(error):
-                return .nonPressable(diagnostic: "actions.\(error.linearMouseDescription)", path: path)
+                return .nonPressable(
+                    diagnostic: "actions.\(error.linearMouseDescription)",
+                    path: path,
+                    isInsideWebContent: isInsideWebContent
+                )
             }
 
             path.append(Self.pathEntry(role: role, subrole: subrole, actions: actions))
@@ -189,15 +218,27 @@ struct AutoScrollAccessibilityActivationClassifier {
                 return .pressable(path: path)
             }
 
+            // Once we're inside a table/outline/list (e.g. Finder's file list, or a table on a
+            // web page) and the hit element itself isn't pressable, the remaining ancestors are
+            // decorative wrapper containers. Stop climbing instead of walking all the way to
+            // maxParentDepth, which was slow enough to be perceptible before auto scroll activated.
+            if Self.isListContainerRole(role) {
+                return .nonPressable(diagnostic: "listContainer", path: path, isInsideWebContent: isInsideWebContent)
+            }
+
             switch elementQuery.optionalElementValue(of: kAXParentAttribute as CFString, on: element) {
             case let .success(value):
                 currentElement = value
             case let .failure(error):
-                return .nonPressable(diagnostic: "parent.\(error.linearMouseDescription)", path: path)
+                return .nonPressable(
+                    diagnostic: "parent.\(error.linearMouseDescription)",
+                    path: path,
+                    isInsideWebContent: isInsideWebContent
+                )
             }
         }
 
-        return .nonPressable(diagnostic: "depthLimit", path: path)
+        return .nonPressable(diagnostic: "depthLimit", path: path, isInsideWebContent: isInsideWebContent)
     }
 
     private static func isExcludedActivationElement(role: String?, subrole: String?) -> Bool {
@@ -370,13 +411,13 @@ struct AutoScrollActivationProbe {
 
 enum AutoScrollActivationHit {
     case pressable(path: [String])
-    case nonPressable(diagnostic: String?, path: [String])
+    case nonPressable(diagnostic: String?, path: [String], isInsideWebContent: Bool)
 
     var path: [String] {
         switch self {
         case let .pressable(path):
             path
-        case let .nonPressable(_, path):
+        case let .nonPressable(_, path, _):
             path
         }
     }
@@ -385,7 +426,7 @@ enum AutoScrollActivationHit {
         switch self {
         case .pressable:
             "pressable"
-        case let .nonPressable(diagnostic, _):
+        case let .nonPressable(diagnostic, _, _):
             diagnostic.map { "nonPressable.\($0)" } ?? "nonPressable"
         }
     }
@@ -397,7 +438,15 @@ enum AutoScrollActivationHit {
         return false
     }
 
+    /// Nearby-point resampling only exists to compensate for browser accessibility trees
+    /// reporting an imprecise hit element near a link or button. It never changes the
+    /// outcome for native apps (Finder, Xcode, etc.), so skip it there — each extra sample
+    /// is a synchronous cross-process AX call and running all of them was adding
+    /// hundreds of milliseconds of perceptible delay before auto scroll activated.
     var requiresAdditionalSampling: Bool {
-        !isPressable
+        guard case let .nonPressable(_, _, isInsideWebContent) = self else {
+            return false
+        }
+        return isInsideWebContent
     }
 }

--- a/LinearMouse/EventTransformer/AutoScrollTransformer.swift
+++ b/LinearMouse/EventTransformer/AutoScrollTransformer.swift
@@ -15,6 +15,7 @@ final class AutoScrollTransformer {
     private let trigger: Scheme.Buttons.Mapping
     private let modes: [Scheme.Buttons.AutoScroll.Mode]
     private let speed: Double
+    private let activateOverPressableElements: Bool
 
     private enum Session {
         case toggle
@@ -34,18 +35,23 @@ final class AutoScrollTransformer {
     private let indicatorController = AutoScrollIndicatorWindowController()
     private let accessibilityActivationClassifier = AutoScrollAccessibilityActivationClassifier()
 
-    static func shouldStartAutoScroll(for hit: AutoScrollActivationHit?) -> Bool {
-        hit?.isPressable != true
+    static func shouldStartAutoScroll(
+        for hit: AutoScrollActivationHit?,
+        activateOverPressableElements: Bool
+    ) -> Bool {
+        activateOverPressableElements || hit?.isPressable != true
     }
 
     init(
         trigger: Scheme.Buttons.Mapping,
         modes: [Scheme.Buttons.AutoScroll.Mode],
-        speed: Double
+        speed: Double,
+        activateOverPressableElements: Bool = false
     ) {
         self.trigger = trigger
         self.modes = modes
         self.speed = speed
+        self.activateOverPressableElements = activateOverPressableElements
     }
 
     deinit {
@@ -131,7 +137,10 @@ extension AutoScrollTransformer: EventTransformer {
         }
 
         let activationHit = activationHit(for: event)
-        guard Self.shouldStartAutoScroll(for: activationHit) else {
+        guard Self.shouldStartAutoScroll(
+            for: activationHit,
+            activateOverPressableElements: activateOverPressableElements
+        ) else {
             return event
         }
 
@@ -503,10 +512,12 @@ extension AutoScrollTransformer {
     func matchesConfiguration(
         trigger: Scheme.Buttons.Mapping,
         modes: [Scheme.Buttons.AutoScroll.Mode],
-        speed: Double
+        speed: Double,
+        activateOverPressableElements: Bool
     ) -> Bool {
         self.trigger == trigger &&
             self.modes == modes &&
-            abs(self.speed - speed) < 0.0001
+            abs(self.speed - speed) < 0.0001 &&
+            self.activateOverPressableElements == activateOverPressableElements
     }
 }

--- a/LinearMouse/EventTransformer/EventTransformerManager.swift
+++ b/LinearMouse/EventTransformer/EventTransformerManager.swift
@@ -949,12 +949,14 @@ class EventTransformerManager {
 
         let modes = autoScroll.normalizedModes
         let speed = autoScroll.speed?.asTruncatedDouble ?? 1
+        let activateOverPressableElements = autoScroll.activateOverPressableElements ?? false
 
         if let sharedAutoScrollTransformer,
            sharedAutoScrollTransformer.matchesConfiguration(
                trigger: trigger,
                modes: modes,
-               speed: speed
+               speed: speed,
+               activateOverPressableElements: activateOverPressableElements
            ) {
             return sharedAutoScrollTransformer
         }
@@ -964,7 +966,8 @@ class EventTransformerManager {
         let transformer = AutoScrollTransformer(
             trigger: trigger,
             modes: modes,
-            speed: speed
+            speed: speed,
+            activateOverPressableElements: activateOverPressableElements
         )
         sharedAutoScrollTransformer = transformer
         return transformer

--- a/LinearMouse/Model/Configuration/Scheme/Buttons/AutoScroll/AutoScroll.swift
+++ b/LinearMouse/Model/Configuration/Scheme/Buttons/AutoScroll/AutoScroll.swift
@@ -18,6 +18,7 @@ extension Scheme.Buttons {
         var modes: [Mode]?
         var speed: Decimal?
         var trigger: Mapping?
+        var activateOverPressableElements: Bool?
 
         init() {}
     }
@@ -29,6 +30,7 @@ extension Scheme.Buttons.AutoScroll: Codable {
         case mode
         case speed
         case trigger
+        case activateOverPressableElements
     }
 
     init(from decoder: Decoder) throws {
@@ -38,6 +40,10 @@ extension Scheme.Buttons.AutoScroll: Codable {
         modes = try container.decodeIfPresent(SingleValueOrArray<Mode>.self, forKey: .mode)?.wrappedValue
         speed = try container.decodeIfPresent(Decimal.self, forKey: .speed)
         trigger = try container.decodeIfPresent(Scheme.Buttons.Mapping.self, forKey: .trigger)
+        activateOverPressableElements = try container.decodeIfPresent(
+            Bool.self,
+            forKey: .activateOverPressableElements
+        )
     }
 
     func encode(to encoder: Encoder) throws {
@@ -47,6 +53,7 @@ extension Scheme.Buttons.AutoScroll: Codable {
         try container.encode(SingleValueOrArray(wrappedValue: modes), forKey: .mode)
         try container.encodeIfPresent(speed, forKey: .speed)
         try container.encodeIfPresent(trigger, forKey: .trigger)
+        try container.encodeIfPresent(activateOverPressableElements, forKey: .activateOverPressableElements)
     }
 }
 
@@ -79,6 +86,10 @@ extension Scheme.Buttons.AutoScroll {
 
         if let trigger {
             autoScroll.trigger = trigger
+        }
+
+        if let activateOverPressableElements {
+            autoScroll.activateOverPressableElements = activateOverPressableElements
         }
     }
 

--- a/LinearMouse/UI/ButtonsSettings/AutoScrollSection/AutoScrollSection.swift
+++ b/LinearMouse/UI/ButtonsSettings/AutoScrollSection/AutoScrollSection.swift
@@ -56,6 +56,15 @@ struct AutoScrollSection: View {
                     Slider(value: $state.autoScrollSpeed, in: 0.3 ... 3.0, step: 0.1)
                 }
 
+                Toggle(isOn: $state.autoScrollActivateOverPressableElements.animation()) {
+                    withDescription {
+                        Text("Activate over clickable elements")
+                        Text(
+                            "Start autoscroll even when the click begins on a link, button, or other clickable item. This may prevent middle-click actions like opening links in a new tab."
+                        )
+                    }
+                }
+
                 Text(modeDescription)
                     .settingsDescriptionStyle()
                     .padding(.top, 4)

--- a/LinearMouse/UI/ButtonsSettings/ButtonsSettingsState.swift
+++ b/LinearMouse/UI/ButtonsSettings/ButtonsSettingsState.swift
@@ -252,6 +252,15 @@ extension ButtonsSettingsState {
         autoScrollTrigger.valid
     }
 
+    var autoScrollActivateOverPressableElements: Bool {
+        get {
+            mergedScheme.buttons.autoScroll.activateOverPressableElements ?? false
+        }
+        set {
+            scheme.buttons.autoScroll.activateOverPressableElements = newValue
+        }
+    }
+
     var mappings: [Scheme.Buttons.Mapping] {
         get { scheme.buttons.mappings ?? [] }
         set { scheme.buttons.mappings = newValue }

--- a/LinearMouseUnitTests/Accessibility/AutoScrollAccessibilityActivationClassifierTests.swift
+++ b/LinearMouseUnitTests/Accessibility/AutoScrollAccessibilityActivationClassifierTests.swift
@@ -39,13 +39,33 @@ final class AutoScrollAccessibilityActivationClassifierTests: XCTestCase {
     }
 
     func testAutoScrollStartsOnlyForNonPressableOrUnavailableHit() {
-        XCTAssertFalse(AutoScrollTransformer.shouldStartAutoScroll(for: .pressable(path: [])))
-        XCTAssertTrue(AutoScrollTransformer.shouldStartAutoScroll(for: .nonPressable(
-            diagnostic: nil,
-            path: [],
-            isInsideWebContent: false
-        )))
-        XCTAssertTrue(AutoScrollTransformer.shouldStartAutoScroll(for: nil))
+        XCTAssertFalse(AutoScrollTransformer.shouldStartAutoScroll(
+            for: .pressable(path: []),
+            activateOverPressableElements: false
+        ))
+        XCTAssertTrue(AutoScrollTransformer.shouldStartAutoScroll(
+            for: .nonPressable(diagnostic: nil, path: [], isInsideWebContent: false),
+            activateOverPressableElements: false
+        ))
+        XCTAssertTrue(AutoScrollTransformer.shouldStartAutoScroll(
+            for: nil,
+            activateOverPressableElements: false
+        ))
+    }
+
+    func testAutoScrollStartsOverPressableHitWhenActivateOverPressableElementsIsEnabled() {
+        XCTAssertTrue(AutoScrollTransformer.shouldStartAutoScroll(
+            for: .pressable(path: ["AXLink"]),
+            activateOverPressableElements: true
+        ))
+        XCTAssertTrue(AutoScrollTransformer.shouldStartAutoScroll(
+            for: .nonPressable(diagnostic: nil, path: [], isInsideWebContent: false),
+            activateOverPressableElements: true
+        ))
+        XCTAssertTrue(AutoScrollTransformer.shouldStartAutoScroll(
+            for: nil,
+            activateOverPressableElements: true
+        ))
     }
 
     func testListContainerRoleStopsClimbingTablesOutlinesAndLists() {

--- a/LinearMouseUnitTests/Accessibility/AutoScrollAccessibilityActivationClassifierTests.swift
+++ b/LinearMouseUnitTests/Accessibility/AutoScrollAccessibilityActivationClassifierTests.swift
@@ -14,10 +14,11 @@ final class AutoScrollAccessibilityActivationClassifierTests: XCTestCase {
         XCTAssertEqual(hit.summary, "pressable")
     }
 
-    func testAccessibilityFailureIsNonPressableWithDiagnostic() {
+    func testAccessibilityFailureInsideWebContentRequiresAdditionalSampling() {
         let hit = AutoScrollActivationHit.nonPressable(
             diagnostic: "role.cannotComplete",
-            path: ["AXGroup"]
+            path: ["AXGroup"],
+            isInsideWebContent: true
         )
 
         XCTAssertFalse(hit.isPressable)
@@ -25,13 +26,35 @@ final class AutoScrollAccessibilityActivationClassifierTests: XCTestCase {
         XCTAssertEqual(hit.summary, "nonPressable.role.cannotComplete")
     }
 
+    func testNonPressableHitOutsideWebContentSkipsAdditionalSampling() {
+        let hit = AutoScrollActivationHit.nonPressable(
+            diagnostic: "listContainer",
+            path: ["AXOutline"],
+            isInsideWebContent: false
+        )
+
+        XCTAssertFalse(hit.isPressable)
+        XCTAssertFalse(hit.requiresAdditionalSampling)
+        XCTAssertEqual(hit.summary, "nonPressable.listContainer")
+    }
+
     func testAutoScrollStartsOnlyForNonPressableOrUnavailableHit() {
         XCTAssertFalse(AutoScrollTransformer.shouldStartAutoScroll(for: .pressable(path: [])))
         XCTAssertTrue(AutoScrollTransformer.shouldStartAutoScroll(for: .nonPressable(
             diagnostic: nil,
-            path: []
+            path: [],
+            isInsideWebContent: false
         )))
         XCTAssertTrue(AutoScrollTransformer.shouldStartAutoScroll(for: nil))
+    }
+
+    func testListContainerRoleStopsClimbingTablesOutlinesAndLists() {
+        XCTAssertTrue(AutoScrollAccessibilityActivationClassifier.isListContainerRole("AXTable"))
+        XCTAssertTrue(AutoScrollAccessibilityActivationClassifier.isListContainerRole("AXOutline"))
+        XCTAssertTrue(AutoScrollAccessibilityActivationClassifier.isListContainerRole("AXList"))
+        XCTAssertFalse(AutoScrollAccessibilityActivationClassifier.isListContainerRole("AXCell"))
+        XCTAssertFalse(AutoScrollAccessibilityActivationClassifier.isListContainerRole("AXGroup"))
+        XCTAssertFalse(AutoScrollAccessibilityActivationClassifier.isListContainerRole(nil))
     }
 
     func testPressableActivationElementAcceptsExplicitControls() {

--- a/LinearMouseUnitTests/EventTransformer/AutoScrollTransformerTests.swift
+++ b/LinearMouseUnitTests/EventTransformer/AutoScrollTransformerTests.swift
@@ -86,4 +86,28 @@ final class AutoScrollTransformerTests: XCTestCase {
         XCTAssertTrue(transformer.cancelLogitechControlInteraction(context))
         XCTAssertFalse(transformer.isAutoscrollActive)
     }
+
+    func testMatchesConfigurationDistinguishesActivateOverPressableElements() {
+        var trigger = Scheme.Buttons.Mapping()
+        trigger.button = .mouse(2)
+        let transformer = AutoScrollTransformer(
+            trigger: trigger,
+            modes: [.toggle],
+            speed: 1,
+            activateOverPressableElements: true
+        )
+
+        XCTAssertTrue(transformer.matchesConfiguration(
+            trigger: trigger,
+            modes: [.toggle],
+            speed: 1,
+            activateOverPressableElements: true
+        ))
+        XCTAssertFalse(transformer.matchesConfiguration(
+            trigger: trigger,
+            modes: [.toggle],
+            speed: 1,
+            activateOverPressableElements: false
+        ))
+    }
 }

--- a/LinearMouseUnitTests/Model/ConfigurationTests.swift
+++ b/LinearMouseUnitTests/Model/ConfigurationTests.swift
@@ -167,6 +167,17 @@ final class ConfigurationTests: XCTestCase {
         XCTAssertEqual(scheme.buttons.autoScroll.modes, [.toggle])
     }
 
+    func testMergeAutoScrollActivateOverPressableElements() {
+        var scheme = Scheme()
+        scheme.buttons.autoScroll.enabled = true
+
+        var override = Scheme()
+        override.buttons.autoScroll.activateOverPressableElements = true
+        override.merge(into: &scheme)
+
+        XCTAssertEqual(scheme.buttons.autoScroll.activateOverPressableElements, true)
+    }
+
     func testMappingDecodesLegacyGenericModifierFlagsWithoutRawFlags() throws {
         let mapping = try JSONDecoder().decode(
             Scheme.Buttons.Mapping.self,
@@ -282,6 +293,21 @@ final class ConfigurationTests: XCTestCase {
         let encoded = try JSONEncoder().encode(autoScroll)
         let object = try XCTUnwrap(JSONSerialization.jsonObject(with: encoded) as? [String: Any])
         XCTAssertNil(object["preserveNativeMiddleClick"])
+    }
+
+    func testDecodeAndEncodeAutoScrollActivateOverPressableElements() throws {
+        let autoScroll = try JSONDecoder().decode(
+            Scheme.Buttons.AutoScroll.self,
+            from: XCTUnwrap(
+                #"{"enabled":true,"activateOverPressableElements":true}"#.data(using: .utf8)
+            )
+        )
+
+        XCTAssertEqual(autoScroll.activateOverPressableElements, true)
+
+        let encoded = try JSONEncoder().encode(autoScroll)
+        let object = try XCTUnwrap(JSONSerialization.jsonObject(with: encoded) as? [String: Any])
+        XCTAssertEqual(object["activateOverPressableElements"] as? Bool, true)
     }
 
     func testMergeSmoothedScrollingPreservesInheritedFields() {


### PR DESCRIPTION
## Summary

Auto Scroll used to feel broken in two common situations:

- Starting it over an item in Finder (or any native list/table view) had a noticeable
  lag — sometimes close to a second — before scrolling actually kicked in. It's now
  effectively instant.
- Starting it directly on a link, a button, or a file icon never worked at all — the
  click always went to the app instead. This adds an off-by-default setting to let
  Auto Scroll win in that case when you want it to.

## Why this matters

- The delay wasn't a Finder-only quirk — it sat in the code path every single Auto
  Scroll activation goes through, in any native app (Finder, Xcode, Mail, Notes, etc).
  It just wasn't obvious *why* it lagged, so it was easy to write off as "Auto Scroll is
  a bit slow" instead of catching it as a fixable bug.
- For anyone who relies on Auto Scroll as a substitute for physical scrolling (see
  #1339), a delay or an outright block on activation isn't a minor annoyance — it's the
  difference between the feature working or not.
- The click-through gap has been an open request since the original toggle for it was
  removed in #1273 for being unreliable (#1237, #1271). This closes that gap without
  reintroducing the old bug: the new setting is off by default, and unlike the old one,
  its behavior doesn't depend on click/drag history.

## Technical details

- `AutoScrollAccessibilityActivationClassifier`'s nearby-point resampling
  (`refineActivationProbe`) ran 9 extra synchronous AX hit-tests on every non-pressable
  hit, unconditionally — i.e. on every successful activation, since Auto Scroll only
  starts on non-pressable elements. That resampling exists solely to compensate for
  browser accessibility-tree imprecision near links/buttons, so it now only runs when
  the hit is actually inside web content (`AXWebArea`/`AXScrollArea` ancestor). Measured
  Finder activation latency: ~600-890ms before, ~7-120ms after.
- Added an opt-in `activateOverPressableElements` setting (default `false`) so Auto
  Scroll can start even when the initial click lands on a link, button, or clickable
  file, at the cost of the native middle-click action on that element.

## Related history

This touches the same code path as #1273, so some context on why this isn't a blind
revert of that change:

- #1103 introduced a `preserveNativeMiddleClick` toggle.
- #1237 reported that toggle was unreliable — behavior depended on whether the item had
  previously been dragged, so native middle-click sometimes silently failed.
- #1271 was a related regression (middle-click no longer closing Chrome tabs).
- #1273 fixed both by removing the toggle entirely and hard-coding "always preserve
  native click on pressable elements," explicitly to eliminate that inconsistency.
- #1317 continued hardening the same default (title-bar/tab-strip regions).

`activateOverPressableElements` is not a reintroduction of the old
`preserveNativeMiddleClick` toggle: it's additive (default `false`, so out of the box
nothing changes from #1273's behavior) rather than replacing the always-on classifier
logic, and its correctness doesn't depend on click/drag history the way the old
toggle's bug did — the classifier is a pure function of the current hit-test, not
accumulated state.

## Testing

- Full xcodebuild unit test suite (537 tests)
- SwiftFormat and SwiftLint pass
- Manually verified via `log stream` against a rebuilt/reinstalled app, not just unit
  tests:
  - Finder AX classify latency: ~600-890ms before this change, ~7-120ms after, across
    repeated activations on real Finder list rows.
  - With `activateOverPressableElements: true`: a real `AXLink` hit
    (`AXStaticText -> AXLink[press]`) still activated Auto Scroll.
  - With `activateOverPressableElements: false` (default): four separate real `AXLink`
    hits did *not* activate Auto Scroll, confirming no regression of #1273's fix.

Closes #1339
