### PR TITLE
Add maximize and minimize button mapping actions

### DIFF
--- a/Documentation/Configuration.d.ts
+++ b/Documentation/Configuration.d.ts
@@ -768,8 +768,8 @@ declare namespace Scheme {
         | ShowDesktop
         | LookUpAndDataDetectors
         | SmartZoom
-	| WindowMaximize
-	| WindowMinimize
+        | WindowMaximize
+        | WindowMinimize
         | DisplayBrightnessUp
         | DisplayBrightnessDown
         | MediaVolumeUp

--- a/Documentation/Configuration.d.ts
+++ b/Documentation/Configuration.d.ts
@@ -768,6 +768,8 @@ declare namespace Scheme {
         | ShowDesktop
         | LookUpAndDataDetectors
         | SmartZoom
+	| WindowMaximize
+	| WindowMinimize
         | DisplayBrightnessUp
         | DisplayBrightnessDown
         | MediaVolumeUp
@@ -839,6 +841,15 @@ declare namespace Scheme {
        * @description Smart zoom.
        */
       type SmartZoom = "smartZoom";
+      /**
+       * @description Window: Maximize.
+       */
+      type WindowMaximize = "window.maximize";
+
+      /**
+       * @description Window: Minimize.
+       */
+      type WindowMinimize = "window.minimize";
 
       /**
        * @description Display: Brightness up.

--- a/Documentation/Configuration.json
+++ b/Documentation/Configuration.json
@@ -1046,6 +1046,12 @@
           "$ref": "#/definitions/Scheme.Buttons.Mapping.SmartZoom"
         },
         {
+          "$ref": "#/definitions/Scheme.Buttons.Mapping.WindowMaximize"
+        },
+        {
+          "$ref": "#/definitions/Scheme.Buttons.Mapping.WindowMinimize"
+        },
+        {
           "$ref": "#/definitions/Scheme.Buttons.Mapping.DisplayBrightnessUp"
         },
         {
@@ -1210,6 +1216,16 @@
         "input"
       ],
       "type": "object"
+    },
+    "Scheme.Buttons.Mapping.WindowMaximize": {
+      "const": "window.maximize",
+      "description": "Window: Maximize.",
+      "type": "string"
+    },
+    "Scheme.Buttons.Mapping.WindowMinimize": {
+      "const": "window.minimize",
+      "description": "Window: Minimize.",
+      "type": "string"
     },
     "Scheme.Buttons.UniversalBackForward": {
       "anyOf": [

--- a/LinearMouse/EventTransformer/ButtonActionExecutor.swift
+++ b/LinearMouse/EventTransformer/ButtonActionExecutor.swift
@@ -32,6 +32,8 @@ final class ButtonActionExecutor {
 
     static let log = OSLog(subsystem: Bundle.main.bundleIdentifier!, category: "ButtonActions")
 
+    private static let enhancedUserInterfaceAttribute = "AXEnhancedUserInterface" as CFString
+
     final class RuntimeState {
         var repeatTimers = [Set<Scheme.Buttons.Mapping.Button>: TimerToken]()
         var pendingReleaseActions = [
@@ -304,28 +306,123 @@ extension ButtonActionExecutor {
     private func maximizeFocusedWindow() {
         guard let window = focusedWindow(),
               let screen = screenForWindow(window),
-              var position = axPosition(fromAppKitFrame: screen.visibleFrame) else {
+              let position = axPosition(fromAppKitFrame: screen.visibleFrame) else {
             return
         }
 
-        var size = screen.visibleFrame.size
+        let targetFrame = CGRect(origin: position, size: screen.visibleFrame.size)
+        setWindowFrame(targetFrame, window: window)
+    }
+
+    private func setWindowFrame(_ targetFrame: CGRect, window: AXUIElement) {
+        // AXEnhancedUserInterface can make Firefox window frame updates unreliable:
+        // https://bugzilla.mozilla.org/show_bug.cgi?id=1664992
+        // Rectangle and Hammerspoon temporarily disable it while applying size-position-size:
+        // https://github.com/rxhanson/Rectangle/blob/master/Rectangle/AccessibilityElement.swift
+        // https://github.com/Hammerspoon/hammerspoon/blob/master/Hammerspoon/HSuicore.m
+        var pid = pid_t()
+        let appElement: AXUIElement? = if AXUIElementGetPid(window, &pid) == .success {
+            AXUIElementCreateApplication(pid)
+        } else {
+            nil
+        }
+
+        let enhancedUserInterfaceWasEnabled = appElement.flatMap {
+            enhancedUserInterfaceEnabled(for: $0)
+        }
+
+        if let appElement, enhancedUserInterfaceWasEnabled == true {
+            os_log(
+                "Temporarily disabling AXEnhancedUserInterface before setting window frame",
+                log: Self.log,
+                type: .info
+            )
+            let result = AXUIElementSetAttributeValue(
+                appElement,
+                Self.enhancedUserInterfaceAttribute,
+                kCFBooleanFalse
+            )
+            if result != .success {
+                os_log(
+                    "Failed to disable AXEnhancedUserInterface: %{public}@",
+                    log: Self.log,
+                    type: .error,
+                    String(describing: result)
+                )
+            }
+        }
+
+        defer {
+            if let appElement, enhancedUserInterfaceWasEnabled == true {
+                let result = AXUIElementSetAttributeValue(
+                    appElement,
+                    Self.enhancedUserInterfaceAttribute,
+                    kCFBooleanTrue
+                )
+                if result != .success {
+                    os_log(
+                        "Failed to restore AXEnhancedUserInterface: %{public}@",
+                        log: Self.log,
+                        type: .error,
+                        String(describing: result)
+                    )
+                }
+            }
+        }
+
+        var position = targetFrame.origin
+        var size = targetFrame.size
 
         guard let positionValue = AXValueCreate(.cgPoint, &position),
               let sizeValue = AXValueCreate(.cgSize, &size) else {
             return
         }
 
-        AXUIElementSetAttributeValue(
+        let initialSizeResult = AXUIElementSetAttributeValue(
+            window,
+            kAXSizeAttribute as CFString,
+            sizeValue
+        )
+
+        let positionResult = AXUIElementSetAttributeValue(
             window,
             kAXPositionAttribute as CFString,
             positionValue
         )
 
-        AXUIElementSetAttributeValue(
+        let finalSizeResult = AXUIElementSetAttributeValue(
             window,
             kAXSizeAttribute as CFString,
             sizeValue
         )
+
+        if initialSizeResult != .success
+            || positionResult != .success
+            || finalSizeResult != .success {
+            os_log(
+                "Failed to set window frame: size=%{public}@, position=%{public}@, finalSize=%{public}@",
+                log: Self.log,
+                type: .error,
+                String(describing: initialSizeResult),
+                String(describing: positionResult),
+                String(describing: finalSizeResult)
+            )
+        }
+    }
+
+    private func enhancedUserInterfaceEnabled(for application: AXUIElement) -> Bool? {
+        var value: CFTypeRef?
+        guard AXUIElementCopyAttributeValue(
+            application,
+            Self.enhancedUserInterfaceAttribute,
+            &value
+        ) == .success,
+            let value,
+            CFGetTypeID(value) == CFBooleanGetTypeID() else {
+            return nil
+        }
+
+        return CFBooleanGetValue(unsafeBitCast(value, to: CFBoolean.self))
     }
 
     private func minimizeFocusedWindow() {

--- a/LinearMouse/EventTransformer/ButtonActionExecutor.swift
+++ b/LinearMouse/EventTransformer/ButtonActionExecutor.swift
@@ -204,18 +204,17 @@ extension ButtonActionExecutor {
         let appElement = AXUIElementCreateApplication(application.processIdentifier)
 
         var value: CFTypeRef?
-        let result = AXUIElementCopyAttributeValue(
+        guard AXUIElementCopyAttributeValue(
             appElement,
             kAXFocusedWindowAttribute as CFString,
             &value
-        )
-
-        guard result == .success,
-              let value else {
+        ) == .success,
+            let value,
+            CFGetTypeID(value) == AXUIElementGetTypeID() else {
             return nil
         }
 
-        return value as! AXUIElement
+        return unsafeBitCast(value, to: AXUIElement.self)
     }
 
     private func windowFrame(_ window: AXUIElement) -> CGRect? {
@@ -233,7 +232,17 @@ extension ButtonActionExecutor {
                 &sizeValue
             ) == .success,
             let positionValue,
-            let sizeValue else {
+            let sizeValue,
+            CFGetTypeID(positionValue) == AXValueGetTypeID(),
+            CFGetTypeID(sizeValue) == AXValueGetTypeID() else {
+            return nil
+        }
+
+        let axPositionValue = unsafeBitCast(positionValue, to: AXValue.self)
+        let axSizeValue = unsafeBitCast(sizeValue, to: AXValue.self)
+
+        guard AXValueGetType(axPositionValue) == .cgPoint,
+              AXValueGetType(axSizeValue) == .cgSize else {
             return nil
         }
 
@@ -241,12 +250,12 @@ extension ButtonActionExecutor {
         var size = CGSize.zero
 
         guard AXValueGetValue(
-            positionValue as! AXValue,
+            axPositionValue,
             .cgPoint,
             &position
         ),
             AXValueGetValue(
-                sizeValue as! AXValue,
+                axSizeValue,
                 .cgSize,
                 &size
             ) else {
@@ -256,8 +265,33 @@ extension ButtonActionExecutor {
         return CGRect(origin: position, size: size)
     }
 
+    private func appKitFrame(fromAXFrame frame: CGRect) -> CGRect? {
+        guard let primaryScreen = NSScreen.screens.first else {
+            return nil
+        }
+
+        return CGRect(
+            x: frame.minX,
+            y: primaryScreen.frame.maxY - frame.maxY,
+            width: frame.width,
+            height: frame.height
+        )
+    }
+
+    private func axPosition(fromAppKitFrame frame: CGRect) -> CGPoint? {
+        guard let primaryScreen = NSScreen.screens.first else {
+            return nil
+        }
+
+        return CGPoint(
+            x: frame.minX,
+            y: primaryScreen.frame.maxY - frame.maxY
+        )
+    }
+
     private func screenForWindow(_ window: AXUIElement) -> NSScreen? {
-        guard let frame = windowFrame(window) else {
+        guard let axFrame = windowFrame(window),
+              let frame = appKitFrame(fromAXFrame: axFrame) else {
             return NSScreen.main
         }
 
@@ -269,19 +303,12 @@ extension ButtonActionExecutor {
 
     private func maximizeFocusedWindow() {
         guard let window = focusedWindow(),
-              let screen = screenForWindow(window) else {
+              let screen = screenForWindow(window),
+              var position = axPosition(fromAppKitFrame: screen.visibleFrame) else {
             return
         }
 
-        let visibleFrame = screen.visibleFrame
-        let screenFrame = screen.frame
-
-        var position = CGPoint(
-            x: visibleFrame.minX,
-            y: screenFrame.maxY - visibleFrame.maxY
-        )
-
-        var size = visibleFrame.size
+        var size = screen.visibleFrame.size
 
         guard let positionValue = AXValueCreate(.cgPoint, &position),
               let sizeValue = AXValueCreate(.cgSize, &size) else {

--- a/LinearMouse/EventTransformer/ButtonActionExecutor.swift
+++ b/LinearMouse/EventTransformer/ButtonActionExecutor.swift
@@ -196,6 +196,123 @@ extension ButtonActionExecutor {
         }
     }
 
+    private func focusedWindow() -> AXUIElement? {
+        guard let application = NSWorkspace.shared.frontmostApplication else {
+            return nil
+        }
+
+        let appElement = AXUIElementCreateApplication(application.processIdentifier)
+
+        var value: CFTypeRef?
+        let result = AXUIElementCopyAttributeValue(
+            appElement,
+            kAXFocusedWindowAttribute as CFString,
+            &value
+        )
+
+        guard result == .success,
+              let value else {
+            return nil
+        }
+
+        return value as! AXUIElement
+    }
+
+    private func windowFrame(_ window: AXUIElement) -> CGRect? {
+        var positionValue: CFTypeRef?
+        var sizeValue: CFTypeRef?
+
+        guard AXUIElementCopyAttributeValue(
+            window,
+            kAXPositionAttribute as CFString,
+            &positionValue
+        ) == .success,
+            AXUIElementCopyAttributeValue(
+                window,
+                kAXSizeAttribute as CFString,
+                &sizeValue
+            ) == .success,
+            let positionValue,
+            let sizeValue else {
+            return nil
+        }
+
+        var position = CGPoint.zero
+        var size = CGSize.zero
+
+        guard AXValueGetValue(
+            positionValue as! AXValue,
+            .cgPoint,
+            &position
+        ),
+            AXValueGetValue(
+                sizeValue as! AXValue,
+                .cgSize,
+                &size
+            ) else {
+            return nil
+        }
+
+        return CGRect(origin: position, size: size)
+    }
+
+    private func screenForWindow(_ window: AXUIElement) -> NSScreen? {
+        guard let frame = windowFrame(window) else {
+            return NSScreen.main
+        }
+
+        return NSScreen.screens.max {
+            $0.frame.intersection(frame).area
+                < $1.frame.intersection(frame).area
+        }
+    }
+
+    private func maximizeFocusedWindow() {
+        guard let window = focusedWindow(),
+              let screen = screenForWindow(window) else {
+            return
+        }
+
+        let visibleFrame = screen.visibleFrame
+        let screenFrame = screen.frame
+
+        var position = CGPoint(
+            x: visibleFrame.minX,
+            y: screenFrame.maxY - visibleFrame.maxY
+        )
+
+        var size = visibleFrame.size
+
+        guard let positionValue = AXValueCreate(.cgPoint, &position),
+              let sizeValue = AXValueCreate(.cgSize, &size) else {
+            return
+        }
+
+        AXUIElementSetAttributeValue(
+            window,
+            kAXPositionAttribute as CFString,
+            positionValue
+        )
+
+        AXUIElementSetAttributeValue(
+            window,
+            kAXSizeAttribute as CFString,
+            sizeValue
+        )
+    }
+
+    private func minimizeFocusedWindow() {
+        guard let window = focusedWindow() else {
+            return
+        }
+
+        AXUIElementSetAttributeValue(
+            window,
+            kAXMinimizedAttribute as CFString,
+            kCFBooleanTrue
+        )
+    }
+
     private func scheduleRepeatActions(
         action: Scheme.Buttons.Mapping.Action,
         buttons: Set<Scheme.Buttons.Mapping.Button>,
@@ -286,6 +403,12 @@ extension ButtonActionExecutor {
 
         case .arg0(.smartZoom):
             GestureEvent(zoomToggleSource: nil)?.post(tap: .cgSessionEventTap)
+
+        case .arg0(.windowMaximize):
+            maximizeFocusedWindow()
+
+        case .arg0(.windowMinimize):
+            minimizeFocusedWindow()
 
         case .arg0(.displayBrightnessUp):
             postSystemDefinedKey(.brightnessUp)
@@ -535,5 +658,11 @@ extension ButtonActionExecutor: Deactivatable {
             try? keySimulator.up(keys: heldKeys, tap: .cgSessionEventTap)
             keySimulator.reset()
         }
+    }
+}
+
+private extension CGRect {
+    var area: CGFloat {
+        width * height
     }
 }

--- a/LinearMouse/Localizable.xcstrings
+++ b/LinearMouse/Localizable.xcstrings
@@ -37748,6 +37748,9 @@
         }
       }
     },
+    "Maximize Window" : {
+      "extractionState" : "manual"
+    },
     "Media" : {
       "localizations" : {
         "af" : {
@@ -38581,6 +38584,9 @@
           }
         }
       }
+    },
+    "Minimize Window" : {
+      "extractionState" : "manual"
     },
     "Missing key %1$@ at %2$@" : {
       "localizations" : {
@@ -72130,6 +72136,9 @@
           }
         }
       }
+    },
+    "Window" : {
+      "extractionState" : "manual"
     },
     "You may also press ⌃⇧⌘Z to revert to system defaults." : {
       "localizations" : {

--- a/LinearMouse/Localizable.xcstrings
+++ b/LinearMouse/Localizable.xcstrings
@@ -37749,7 +37749,212 @@
       }
     },
     "Maximize Window" : {
-      "extractionState" : "manual"
+      "localizations" : {
+        "af" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Maksimeer venster"
+          }
+        },
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "تكبير النافذة"
+          }
+        },
+        "bs" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Maksimiziraj prozor"
+          }
+        },
+        "ca" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Maximitza la finestra"
+          }
+        },
+        "cs" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Maximalizovat okno"
+          }
+        },
+        "da" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Maksimer vindue"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Fenster maximieren"
+          }
+        },
+        "el" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Μεγιστοποίηση παραθύρου"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Maximizar ventana"
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Suurenna ikkuna"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Agrandir la fenêtre"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "הגדל חלון"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ablak maximalizálása"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Maksimalkan jendela"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ingrandisci finestra"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ウィンドウを最大化"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "윈도우 최대화"
+          }
+        },
+        "my" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ဝင်းဒိုးကို အကြီးဆုံးချဲ့ရန်"
+          }
+        },
+        "nb-NO" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Maksimer vindu"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Venster maximaliseren"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Maksymalizuj okno"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Maximizar janela"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Maximizar janela"
+          }
+        },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Maximizează fereastra"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Развернуть окно"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Maximalizovať okno"
+          }
+        },
+        "sr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Увећај прозор"
+          }
+        },
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Maximera fönster"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pencereyi büyüt"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Розгорнути вікно"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Phóng to cửa sổ"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "最大化窗口"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "將視窗放到最大"
+          }
+        },
+        "zh-Hant-HK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "將視窗放至最大"
+          }
+        }
+      }
     },
     "Media" : {
       "localizations" : {
@@ -38586,7 +38791,212 @@
       }
     },
     "Minimize Window" : {
-      "extractionState" : "manual"
+      "localizations" : {
+        "af" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Minimeer venster"
+          }
+        },
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "تصغير النافذة"
+          }
+        },
+        "bs" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Minimiziraj prozor"
+          }
+        },
+        "ca" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Minimitza la finestra"
+          }
+        },
+        "cs" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Minimalizovat okno"
+          }
+        },
+        "da" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Minimer vindue"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Fenster minimieren"
+          }
+        },
+        "el" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ελαχιστοποίηση παραθύρου"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Minimizar ventana"
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pienennä ikkuna"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Réduire la fenêtre"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "מזער חלון"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ablak minimalizálása"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Minimalkan jendela"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Riduci finestra"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ウィンドウを最小化"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "윈도우 최소화"
+          }
+        },
+        "my" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ဝင်းဒိုးကို အနိမ့်ဆုံးချုံ့ရန်"
+          }
+        },
+        "nb-NO" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Minimer vindu"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Venster minimaliseren"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Minimalizuj okno"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Minimizar janela"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Minimizar janela"
+          }
+        },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Minimizează fereastra"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Свернуть окно"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Minimalizovať okno"
+          }
+        },
+        "sr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Умањи прозор"
+          }
+        },
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Minimera fönster"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pencereyi küçült"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Згорнути вікно"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Thu nhỏ cửa sổ"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "最小化窗口"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "將視窗縮到最小"
+          }
+        },
+        "zh-Hant-HK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "將視窗縮至最小"
+          }
+        }
+      }
     },
     "Missing key %1$@ at %2$@" : {
       "localizations" : {
@@ -72138,7 +72548,212 @@
       }
     },
     "Window" : {
-      "extractionState" : "manual"
+      "localizations" : {
+        "af" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Venster"
+          }
+        },
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "نافذة"
+          }
+        },
+        "bs" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Prozor"
+          }
+        },
+        "ca" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Finestra"
+          }
+        },
+        "cs" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Okno"
+          }
+        },
+        "da" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Vindue"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Fenster"
+          }
+        },
+        "el" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Παράθυρο"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ventana"
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ikkuna"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Fenêtre"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "חלון"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ablak"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Jendela"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Finestra"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ウィンドウ"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "윈도우"
+          }
+        },
+        "my" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ဝင်းဒိုး"
+          }
+        },
+        "nb-NO" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Vindu"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Venster"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Okno"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Janela"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Janela"
+          }
+        },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Fereastră"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Окно"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Okno"
+          }
+        },
+        "sr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Прозор"
+          }
+        },
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Fönster"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pencere"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Вікно"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cửa sổ"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "窗口"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "視窗"
+          }
+        },
+        "zh-Hant-HK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "視窗"
+          }
+        }
+      }
     },
     "You may also press ⌃⇧⌘Z to revert to system defaults." : {
       "localizations" : {

--- a/LinearMouse/Model/Configuration/Scheme/Buttons/Mapping/Action+CustomStringConvertible.swift
+++ b/LinearMouse/Model/Configuration/Scheme/Buttons/Mapping/Action+CustomStringConvertible.swift
@@ -37,6 +37,10 @@ extension Scheme.Buttons.Mapping.Action.Arg0: CustomStringConvertible {
             return NSLocalizedString("Look up & data detectors", comment: "")
         case .smartZoom:
             return NSLocalizedString("Smart zoom", comment: "")
+        case .windowMaximize:
+            return NSLocalizedString("Maximize Window", comment: "")
+        case .windowMinimize:
+            return NSLocalizedString("Minimize Window", comment: "")
         case .displayBrightnessUp:
             return NSLocalizedString("Increase display brightness", comment: "")
         case .displayBrightnessDown:

--- a/LinearMouse/Model/Configuration/Scheme/Buttons/Mapping/Action.swift
+++ b/LinearMouse/Model/Configuration/Scheme/Buttons/Mapping/Action.swift
@@ -32,6 +32,9 @@ extension Scheme.Buttons.Mapping.Action {
         case lookUpAndDataDetectors
         case smartZoom
 
+        case windowMaximize = "window.maximize"
+        case windowMinimize = "window.minimize"
+
         case displayBrightnessUp = "display.brightnessUp"
         case displayBrightnessDown = "display.brightnessDown"
 

--- a/LinearMouse/UI/ButtonsSettings/ButtonMappingsSection/ButtonMappingAction/ButtonMappingActionPicker.swift
+++ b/LinearMouse/UI/ButtonsSettings/ButtonMappingsSection/ButtonMappingAction/ButtonMappingActionPicker.swift
@@ -60,6 +60,11 @@ extension ButtonMappingActionPicker {
         .actionType(.arg0(.showDesktop)),
         .actionType(.arg0(.lookUpAndDataDetectors)),
         .actionType(.arg0(.smartZoom)),
+        .section("Window") { [
+            .actionType(.arg0(.windowMaximize)),
+            .actionType(.arg0(.windowMinimize))
+        ]
+        },
         .section("Display") { [
             .actionType(.arg0(.displayBrightnessUp)),
             .actionType(.arg0(.displayBrightnessDown))


### PR DESCRIPTION
Adds two new Button Mapping actions:

Maximize Window
Minimize Window

Maximize Window resizes the focused window to the usable area of its display while preserving the menu bar and Dock, rather than entering macOS full-screen mode.

Minimize Window minimizes the focused window to the Dock using the macOS Accessibility API.

These actions work with the existing Button Mapping system, including the swipe triggers introduced in #1326.

Tested successfully with:

Logitech MX Master 4
Samsung Bluetooth Mouse Slim

Verified:

Maximize correctly fits the focused window within the visible screen area
Minimize correctly sends the focused window to the Dock
Full test suite passes
SwiftFormat lint passes