### PR TITLE
fix: parse hex vendor/product IDs case-insensitively (accept 0X prefix)

### DIFF
--- a/LinearMouse/Utilities/Codable/HexRepresentation.swift
+++ b/LinearMouse/Utilities/Codable/HexRepresentation.swift
@@ -27,7 +27,10 @@ extension HexRepresentation: Codable {
         let container = try decoder.singleValueContainer()
         do {
             var hexValue = try container.decode(String.self)
-            if hexValue.hasPrefix("0x") {
+            // Hex prefixes are conventionally case-insensitive (0x or 0X);
+            // strip either form before radix-16 parsing so hand-edited or
+            // third-party configs using an uppercase 0X prefix still load.
+            if hexValue.lowercased().hasPrefix("0x") {
                 hexValue = String(hexValue.dropFirst(2))
             }
             guard let parsedValue = Int64(hexValue, radix: 16) else {

--- a/LinearMouseUnitTests/Model/ConfigurationTests.swift
+++ b/LinearMouseUnitTests/Model/ConfigurationTests.swift
@@ -249,6 +249,28 @@ final class ConfigurationTests: XCTestCase {
         )
     }
 
+    func testLoadUppercaseHexDeviceID() throws {
+        // Hex prefixes are conventionally case-insensitive, but the
+        // decoder used to strip only a lowercase 0x. A device matcher
+        // whose vendor/product IDs use an uppercase 0X prefix must still
+        // load (hand-edited and third-party configs frequently use 0X).
+        let configuration = try Configuration.load(from: #"""
+        {
+          "schemes": [
+            {
+              "if": [
+                { "device": { "vendorID": "0X045E", "productID": "0X00C5" } }
+              ]
+            }
+          ]
+        }
+        """#)
+
+        let device = try XCTUnwrap(configuration.schemes[0].if?[0].device)
+        XCTAssertEqual(device.vendorID, 0x045E) // 1118
+        XCTAssertEqual(device.productID, 0x00C5) // 197
+    }
+
     func testDecodeAutoScrollSingleMode() throws {
         let autoScroll = try JSONDecoder().decode(
             Scheme.Buttons.AutoScroll.self,


### PR DESCRIPTION
<!-- Suggested title: fix: parse hex vendor/product IDs case-insensitively (accept 0X prefix) -->

## Summary

`HexRepresentation`'s decoder stripped the hex prefix with a **case-sensitive** `hexValue.hasPrefix("0x")`. A conventional uppercase `0X` prefix (e.g. `"vendorID": "0X045E"`) was not stripped, so `Int64("0X045E", radix: 16)` returned `nil`, the catch fell back to decoding the value as a `String`, and the whole config failed to load with a misleading `typeMismatch: expected Int` at `schemes[*].if[*].device.vendorID`. Hand-edited or third-party-generated configs that use `0X` were silently rejected even though hex prefixes are conventionally case-insensitive. LinearMouse's own encoder emits lowercase only, which is why this only bites externally-authored configs.

The fix strips the prefix case-insensitively. Behavior for lowercase `0x` and for already-stripped digits is unchanged.

## Root cause

`HexRepresentation.init(from:)` (`LinearMouse/Utilities/Codable/HexRepresentation.swift`) used `hexValue.hasPrefix("0x")` — byte-exact — before `Int64(hexValue, radix: 16)`. `0X` failed the prefix test, was not stripped, and the radix-16 parse of the still-prefixed string returned `nil`. This wrapper backs every `DeviceMatcher` `vendorID`/`productID` and `LogitechControlIdentity` `productID`. There was no test for the uppercase form (`ConfigurationTests` only exercised lowercase `"0x405E"`).

## Changes

| File | Change |
| --- | --- |
| `LinearMouse/Utilities/Codable/HexRepresentation.swift` | `hexValue.hasPrefix("0x")` → `hexValue.lowercased().hasPrefix("0x")`. The subsequent `dropFirst(2)` still operates on the original string, so it drops the actual `0x`/`0X` two characters. The encoder and the String-fallback catch branch are untouched. |
| `LinearMouseUnitTests/Model/ConfigurationTests.swift` | New `testLoadUppercaseHexDeviceID`: loads a config whose device matcher uses `"vendorID":"0X045E"`, `"productID":"0X00C5"` and asserts `vendorID == 0x045E` (1118), `productID == 0x00C5` (197). |

## Test plan

- [x] New `testLoadUppercaseHexDeviceID` passes (RED on `main`, where `Configuration.load` throws `.parseError` for `0X`; GREEN after the fix).
- [x] The existing lowercase test (`"0x405E"`) still passes — no regression.
- [x] `make test` (`xcodebuild test -project LinearMouse.xcodeproj -scheme LinearMouse -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO`) → **TEST SUCCEEDED**.

A bare hex value without any prefix (`"045E"`) is unaffected: the prefix check is false, nothing is dropped, it parses as before.