### PR TITLE
Scale continuous scroll deltas in pixel space in the speed-adjustment transformer

### DIFF
--- a/LinearMouse/EventTransformer/ScrollingAccelerationSpeedAdjustmentTransformer.swift
+++ b/LinearMouse/EventTransformer/ScrollingAccelerationSpeedAdjustmentTransformer.swift
@@ -51,7 +51,9 @@ class ScrollingAccelerationSpeedAdjustmentTransformer: EventTransformer {
             let targetPt = scrollWheelEventView.deltaYPt + Double(deltaYSignum) * speed
             scrollWheelEventView.deltaY = deltaYSignum * max(1, Int64(abs(targetPt) / 10))
             scrollWheelEventView.deltaYPt = targetPt
-            scrollWheelEventView.deltaYFixedPt = targetPt / 10
+            // deltaYFixedPt carries pixel deltas for continuous events but line deltas
+            // for discrete ones, so keep it in the event's native delta unit.
+            scrollWheelEventView.deltaYFixedPt = scrollWheelEventView.continuous ? targetPt : targetPt / 10
             // TODO: Test if ioHidScrollY needs to be modified.
             os_log("deltaY: speed=%{public}f", log: Self.log, type: .info, speed)
         }
@@ -61,7 +63,7 @@ class ScrollingAccelerationSpeedAdjustmentTransformer: EventTransformer {
             let targetPt = scrollWheelEventView.deltaXPt + Double(deltaXSignum) * speed
             scrollWheelEventView.deltaX = deltaXSignum * max(1, Int64(abs(targetPt) / 10))
             scrollWheelEventView.deltaXPt = targetPt
-            scrollWheelEventView.deltaXFixedPt = targetPt / 10
+            scrollWheelEventView.deltaXFixedPt = scrollWheelEventView.continuous ? targetPt : targetPt / 10
             os_log("deltaX: speed=%{public}f", log: Self.log, type: .info, speed)
         }
 

--- a/LinearMouseUnitTests/EventTransformer/ScrollingAccelerationSpeedAdjustmentTransformerTests.swift
+++ b/LinearMouseUnitTests/EventTransformer/ScrollingAccelerationSpeedAdjustmentTransformerTests.swift
@@ -1,0 +1,166 @@
+// MIT License
+// Copyright (c) 2021-2026 LinearMouse
+
+@testable import LinearMouse
+import XCTest
+
+final class ScrollingAccelerationSpeedAdjustmentTransformerTests: XCTestCase {
+    /// The fixed-point delta fields are stored as 16.16 fixed point; allow for one
+    /// quantization step when comparing against the expected value.
+    private let fixedPointTolerance = 1.0 / 32_768.0
+
+    func testSpeedAdjustmentKeepsContinuousFixedPointInPixelSpace() throws {
+        // A continuous (pixel-mode) scroll event carries its delta in pixel units: both
+        // deltaYPt and deltaYFixedPt hold the same pixel value.
+        let transformer = ScrollingAccelerationSpeedAdjustmentTransformer(
+            acceleration: Scheme.Scrolling.Bidirectional<Decimal>(vertical: nil, horizontal: nil),
+            speed: Scheme.Scrolling.Bidirectional<Decimal>(vertical: 3, horizontal: nil)
+        )
+
+        let event = try makeVerticalScrollEvent(
+            continuous: true,
+            deltaY: 0,
+            deltaYPt: 5,
+            deltaYFixedPt: 5
+        )
+
+        let result = try XCTUnwrap(
+            transformer.transform(event, in: EventTransformerContext(device: nil))
+        )
+
+        let view = ScrollWheelEventView(result)
+
+        // targetPt = 5 + sign(5) * 3 = 8 px. For a continuous event the fixed-point
+        // delta must stay in pixel space (8), not be divided into line units (0.8).
+        XCTAssertEqual(view.deltaYPt, 8, accuracy: fixedPointTolerance)
+        XCTAssertEqual(view.deltaYFixedPt, 8, accuracy: fixedPointTolerance)
+    }
+
+    func testSpeedAdjustmentKeepsDiscreteFixedPointInLineSpace() throws {
+        // A discrete (line-mode) scroll event carries its fixed-point delta in line units.
+        let transformer = ScrollingAccelerationSpeedAdjustmentTransformer(
+            acceleration: Scheme.Scrolling.Bidirectional<Decimal>(vertical: nil, horizontal: nil),
+            speed: Scheme.Scrolling.Bidirectional<Decimal>(vertical: 3, horizontal: nil)
+        )
+
+        let event = try makeVerticalScrollEvent(
+            continuous: false,
+            deltaY: 1,
+            deltaYPt: 10,
+            deltaYFixedPt: 1
+        )
+
+        let result = try XCTUnwrap(
+            transformer.transform(event, in: EventTransformerContext(device: nil))
+        )
+
+        let view = ScrollWheelEventView(result)
+
+        // targetPt = 10 + sign(1) * 3 = 13 px. The discrete fixed-point delta stays in
+        // line units (13 / 10 = 1.3); the discrete path must remain unchanged.
+        XCTAssertEqual(view.deltaYPt, 13, accuracy: fixedPointTolerance)
+        XCTAssertEqual(view.deltaYFixedPt, 1.3, accuracy: fixedPointTolerance)
+    }
+
+    func testAccelerationScalesAllDeltasUniformly() throws {
+        // The acceleration path scales every delta field by the same factor, which is
+        // correct for both continuous and discrete events; only the speed path needed
+        // the mode-aware fixed-point fix.
+        let transformer = ScrollingAccelerationSpeedAdjustmentTransformer(
+            acceleration: Scheme.Scrolling.Bidirectional<Decimal>(vertical: 2, horizontal: nil),
+            speed: Scheme.Scrolling.Bidirectional<Decimal>(vertical: nil, horizontal: nil)
+        )
+
+        let event = try makeVerticalScrollEvent(
+            continuous: true,
+            deltaY: 1,
+            deltaYPt: 5,
+            deltaYFixedPt: 5
+        )
+
+        let result = try XCTUnwrap(
+            transformer.transform(event, in: EventTransformerContext(device: nil))
+        )
+
+        let view = ScrollWheelEventView(result)
+
+        XCTAssertEqual(view.deltaYPt, 10, accuracy: fixedPointTolerance)
+        XCTAssertEqual(view.deltaYFixedPt, 10, accuracy: fixedPointTolerance)
+    }
+
+    func testSpeedAdjustmentKeepsContinuousHorizontalFixedPointInPixelSpace() throws {
+        // Same as the vertical case but on the horizontal axis: a continuous event's
+        // deltaXFixedPt must stay in pixel space, not be divided into line units.
+        let transformer = ScrollingAccelerationSpeedAdjustmentTransformer(
+            acceleration: Scheme.Scrolling.Bidirectional<Decimal>(vertical: nil, horizontal: nil),
+            speed: Scheme.Scrolling.Bidirectional<Decimal>(vertical: nil, horizontal: 3)
+        )
+
+        let event = try makeHorizontalScrollEvent(
+            continuous: true,
+            deltaX: 0,
+            deltaXPt: 5,
+            deltaXFixedPt: 5
+        )
+
+        let result = try XCTUnwrap(
+            transformer.transform(event, in: EventTransformerContext(device: nil))
+        )
+
+        let view = ScrollWheelEventView(result)
+
+        // targetPt = 5 + sign(5) * 3 = 8 px; the horizontal fixed-point delta stays in pixels.
+        XCTAssertEqual(view.deltaXPt, 8, accuracy: fixedPointTolerance)
+        XCTAssertEqual(view.deltaXFixedPt, 8, accuracy: fixedPointTolerance)
+    }
+
+    private func makeVerticalScrollEvent(
+        continuous: Bool,
+        deltaY: Int64,
+        deltaYPt: Double,
+        deltaYFixedPt: Double
+    ) throws -> CGEvent {
+        let event = try XCTUnwrap(CGEvent(
+            scrollWheelEvent2Source: nil,
+            units: continuous ? .pixel : .line,
+            wheelCount: 1,
+            wheel1: 1,
+            wheel2: 0,
+            wheel3: 0
+        ))
+        let view = ScrollWheelEventView(event)
+        view.continuous = continuous
+        view.deltaY = deltaY
+        view.deltaYPt = deltaYPt
+        view.deltaYFixedPt = deltaYFixedPt
+        view.deltaX = 0
+        view.deltaXPt = 0
+        view.deltaXFixedPt = 0
+        return event
+    }
+
+    private func makeHorizontalScrollEvent(
+        continuous: Bool,
+        deltaX: Int64,
+        deltaXPt: Double,
+        deltaXFixedPt: Double
+    ) throws -> CGEvent {
+        let event = try XCTUnwrap(CGEvent(
+            scrollWheelEvent2Source: nil,
+            units: continuous ? .pixel : .line,
+            wheelCount: 2,
+            wheel1: 0,
+            wheel2: 1,
+            wheel3: 0
+        ))
+        let view = ScrollWheelEventView(event)
+        view.continuous = continuous
+        view.deltaX = deltaX
+        view.deltaXPt = deltaXPt
+        view.deltaXFixedPt = deltaXFixedPt
+        view.deltaY = 0
+        view.deltaYPt = 0
+        view.deltaYFixedPt = 0
+        return event
+    }
+}


### PR DESCRIPTION
## Summary
Continuous (pixel-mode) scroll events processed by the Scrolling speed-adjustment transformer are now scaled in pixel space, fixing a ~10× under-scale for trackpad and high-resolution-wheel continuous scrolls. Discrete (line-mode) behavior is unchanged.

## Root cause
`ScrollingAccelerationSpeedAdjustmentTransformer` wrote `deltaYFixedPt = targetPt / 10` unconditionally. For discrete events `deltaYFixedPt` is in line units (10 per line), so `/ 10` is correct; but for continuous events `deltaYFixedPt` is in pixels — every other producer in the repo (`LinearScrollingVerticalTransformer`, `SmoothedScrollingTransformer`'s reader) treats it as pixels for continuous events. Dividing a pixel value by 10 left continuous scrolls ~10× too small after the speed adjustment.

## Changes
- `LinearMouse/EventTransformer/ScrollingAccelerationSpeedAdjustmentTransformer.swift` — write `deltaYFixedPt` mode-aware: `scrollWheelEventView.continuous ? targetPt : targetPt / 10` for both axes. The discrete branch is byte-for-byte the old `targetPt / 10`.
- `LinearMouseUnitTests/EventTransformer/ScrollingAccelerationSpeedAdjustmentTransformerTests.swift` (new) — continuous vertical/horizontal events keep `deltaYFixedPt` in pixel space (RED before: `0.8`, GREEN after: `8`); a discrete-event regression guard asserts the discrete path is unchanged (`1.3` before and after); an acceleration-path test confirms the matrix branch was already mode-correct.

## Test plan
- [x] `swiftformat --lint .` + `swiftlint .` — clean.
- [x] `xcodebuild test -project LinearMouse.xcodeproj -scheme LinearMouse -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO …` — 536 tests, 0 failures (the 4 new tests pass).
- [x] Convention cross-checked against the canonical reader (`SmoothedScrollingTransformer.deltaYInPixels`) and producer (`LinearScrollingVerticalTransformer`) of `deltaYFixedPt`.

Co-authored-by: Claude <noreply@anthropic.com>
