### PR TITLE
Fix Auto Scroll drag activation over clickable elements

### DIFF
--- a/LinearMouse/EventTransformer/AutoScrollTransformer.swift
+++ b/LinearMouse/EventTransformer/AutoScrollTransformer.swift
@@ -6,6 +6,8 @@ import Foundation
 import os.log
 
 final class AutoScrollTransformer {
+    typealias ActivationHitProvider = (CGEvent) -> AutoScrollActivationHit?
+
     static let log = OSLog(subsystem: Bundle.main.bundleIdentifier!, category: "AutoScroll")
 
     private static let deadZone: Double = 10
@@ -15,6 +17,8 @@ final class AutoScrollTransformer {
     private let trigger: Scheme.Buttons.Mapping
     private let modes: [Scheme.Buttons.AutoScroll.Mode]
     private let speed: Double
+    private let activationHitProvider: ActivationHitProvider?
+    private let fallbackEventSink: (CGEvent) -> Void
 
     private enum Session {
         case toggle
@@ -22,8 +26,19 @@ final class AutoScrollTransformer {
         case pendingToggleOrHold
     }
 
+    private struct DeferredEvent {
+        var event: CGEvent
+        var sink: (CGEvent) -> Void
+    }
+
+    private struct PendingActivation {
+        var anchor: CGPoint
+        var bufferedEvents: [DeferredEvent]
+    }
+
     private enum State {
         case idle
+        case pending(PendingActivation)
         case active(anchor: CGPoint, current: CGPoint, session: Session)
     }
 
@@ -41,11 +56,15 @@ final class AutoScrollTransformer {
     init(
         trigger: Scheme.Buttons.Mapping,
         modes: [Scheme.Buttons.AutoScroll.Mode],
-        speed: Double
+        speed: Double,
+        activationHitProvider: ActivationHitProvider? = nil,
+        eventSink: @escaping (CGEvent) -> Void = { $0.post(tap: .cgSessionEventTap) }
     ) {
         self.trigger = trigger
         self.modes = modes
         self.speed = speed
+        self.activationHitProvider = activationHitProvider
+        fallbackEventSink = eventSink
     }
 
     deinit {
@@ -55,11 +74,23 @@ final class AutoScrollTransformer {
     }
 }
 
-extension AutoScrollTransformer: EventTransformer {
-    func transform(_ event: CGEvent, in _: EventTransformerContext) -> CGEvent? {
+extension AutoScrollTransformer: EventTransformer, DeferredEventTransformer {
+    func transform(_ event: CGEvent, in context: EventTransformerContext) -> CGEvent? {
         guard !SettingsState.shared.recording else {
+            if case .pending = state {
+                replayPendingActivation(including: deferredEvent(event, in: context))
+                return nil
+            }
+
             cancelInteractionForButtonMappingRecording()
             return event
+        }
+
+        if case .pending = state,
+           isAnyMouseDownEvent(event),
+           !matchesTriggerButton(event) {
+            replayPendingActivation(including: deferredEvent(event, in: context))
+            return nil
         }
 
         if case let .active(_, _, session) = state,
@@ -79,11 +110,11 @@ extension AutoScrollTransformer: EventTransformer {
 
         switch event.type {
         case triggerMouseDownEventType:
-            return handleTriggerDown(event)
+            return handleTriggerDown(event, in: context)
         case triggerMouseUpEventType:
-            return handleTriggerUp(event)
+            return handleTriggerUp(event, in: context)
         case triggerMouseDraggedEventType, .mouseMoved:
-            return handlePointerMoved(event)
+            return handlePointerMoved(event, in: context)
         default:
             return event
         }
@@ -111,7 +142,7 @@ extension AutoScrollTransformer: EventTransformer {
         trigger.button?.logitechControl != nil
     }
 
-    private func handleTriggerDown(_ event: CGEvent) -> CGEvent? {
+    private func handleTriggerDown(_ event: CGEvent, in context: EventTransformerContext) -> CGEvent? {
         guard matchesTriggerButton(event) else {
             return event
         }
@@ -130,9 +161,20 @@ extension AutoScrollTransformer: EventTransformer {
             return event
         }
 
-        let activationHit = activationHit(for: event)
-        guard Self.shouldStartAutoScroll(for: activationHit) else {
-            return event
+        let activationHitResult: AutoScrollActivationHit?
+        if let activationHitProvider {
+            activationHitResult = activationHitProvider(event)
+        } else {
+            activationHitResult = activationHit(for: event)
+        }
+        guard Self.shouldStartAutoScroll(for: activationHitResult) else {
+            // Delay the native stream only until movement distinguishes a click from
+            // an Auto Scroll drag. A click replays the complete stream in order.
+            state = .pending(.init(
+                anchor: pointerLocation(for: event),
+                bufferedEvents: [deferredEvent(event, in: context)]
+            ))
+            return nil
         }
 
         activate(at: pointerLocation(for: event), session: activationSession)
@@ -140,9 +182,14 @@ extension AutoScrollTransformer: EventTransformer {
         return nil
     }
 
-    private func handleTriggerUp(_ event: CGEvent) -> CGEvent? {
+    private func handleTriggerUp(_ event: CGEvent, in context: EventTransformerContext) -> CGEvent? {
         guard matchesTriggerButton(event) else {
             return event
+        }
+
+        if case .pending = state {
+            replayPendingActivation(including: deferredEvent(event, in: context))
+            return nil
         }
 
         guard suppressTriggerUp else {
@@ -150,6 +197,9 @@ extension AutoScrollTransformer: EventTransformer {
         }
 
         switch state {
+        case .pending:
+            break
+
         case let .active(anchor, current, session):
             switch session {
             case .hold:
@@ -163,6 +213,7 @@ extension AutoScrollTransformer: EventTransformer {
             case .toggle:
                 break
             }
+
         case .idle:
             break
         }
@@ -171,12 +222,31 @@ extension AutoScrollTransformer: EventTransformer {
         return nil
     }
 
-    private func handlePointerMoved(_ event: CGEvent) -> CGEvent? {
+    private func handlePointerMoved(_ event: CGEvent, in context: EventTransformerContext) -> CGEvent? {
         switch state {
+        case var .pending(pending):
+            guard event.type == triggerMouseDraggedEventType,
+                  matchesTriggerButton(event) else {
+                return event
+            }
+
+            let point = pointerLocation(for: event)
+            guard exceedsDeadZone(from: pending.anchor, to: point) else {
+                pending.bufferedEvents.append(deferredEvent(event, in: context))
+                state = .pending(pending)
+                return nil
+            }
+
+            activate(at: pending.anchor, session: activationSession)
+            suppressTriggerUp = true
+            return handlePointerMoved(event, in: context)
+
         case let .active(anchor, _, session):
             let point = pointerLocation(for: event)
             let resolvedSession: Session
-            let isDragOrLogitechMove = event.type == triggerMouseDraggedEventType
+            let isTriggerDrag = event.type == triggerMouseDraggedEventType
+                && matchesTriggerButton(event)
+            let isDragOrLogitechMove = isTriggerDrag
                 || (triggerIsLogitechControl && event.type == .mouseMoved)
             if session == .pendingToggleOrHold,
                isDragOrLogitechMove,
@@ -192,11 +262,12 @@ extension AutoScrollTransformer: EventTransformer {
                 indicatorController.update(delta: delta)
             }
 
-            if event.type == triggerMouseDraggedEventType, suppressTriggerUp {
+            if isTriggerDrag, suppressTriggerUp {
                 return nil
             }
 
             return event
+
         case .idle:
             return event
         }
@@ -207,6 +278,35 @@ extension AutoScrollTransformer: EventTransformer {
             return true
         }
         return false
+    }
+
+    private var hasPendingActivation: Bool {
+        if case .pending = state {
+            return true
+        }
+        return false
+    }
+
+    private func deferredEvent(_ event: CGEvent, in context: EventTransformerContext) -> DeferredEvent {
+        .init(
+            event: event.copy() ?? event,
+            sink: context.deferredEventSink ?? fallbackEventSink
+        )
+    }
+
+    private func replayPendingActivation(including finalEvent: DeferredEvent? = nil) {
+        guard case let .pending(pending) = state else {
+            return
+        }
+
+        state = .idle
+        var events = pending.bufferedEvents
+        if let finalEvent {
+            events.append(finalEvent)
+        }
+        for event in events {
+            event.sink(event.event)
+        }
     }
 
     private func matchesActivationTrigger(_ event: CGEvent) -> Bool {
@@ -354,7 +454,7 @@ extension AutoScrollTransformer: EventTransformer {
     }
 
     private func cancelInteractionForButtonMappingRecording() {
-        guard isAutoscrollActive || suppressTriggerUp || suppressedExitMouseButton != nil else {
+        guard hasPendingActivation || isAutoscrollActive || suppressTriggerUp || suppressedExitMouseButton != nil else {
             return
         }
 
@@ -484,6 +584,8 @@ extension AutoScrollTransformer: LogitechControlInteractionCanceling {
 
 extension AutoScrollTransformer: Deactivatable {
     func deactivate() {
+        replayPendingActivation()
+
         if isAutoscrollActive {
             os_log("Auto scroll deactivated", log: Self.log, type: .info)
         }

--- a/LinearMouseUnitTests/EventTransformer/AutoScrollTransformerTests.swift
+++ b/LinearMouseUnitTests/EventTransformer/AutoScrollTransformerTests.swift
@@ -6,6 +6,8 @@ import CoreGraphics
 import XCTest
 
 final class AutoScrollTransformerTests: XCTestCase {
+    private typealias Mapping = Scheme.Buttons.Mapping
+
     override func tearDown() {
         SettingsState.shared.endButtonMappingRecording()
         super.tearDown()
@@ -85,5 +87,160 @@ final class AutoScrollTransformerTests: XCTestCase {
 
         XCTAssertTrue(transformer.cancelLogitechControlInteraction(context))
         XCTAssertFalse(transformer.isAutoscrollActive)
+    }
+
+    func testDraggingPressableElementBeyondDeadZoneActivatesAutoScroll() throws {
+        var replayedEvents = [CGEventType]()
+        let transformer = pressableElementTransformer { replayedEvents.append($0.type) }
+
+        XCTAssertNil(try transformer.transform(
+            mouseEvent(type: .otherMouseDown, location: CGPoint(x: 100, y: 100)),
+            in: .init(device: nil)
+        ))
+        XCTAssertFalse(transformer.isAutoscrollActive)
+
+        XCTAssertNil(try transformer.transform(
+            mouseEvent(type: .otherMouseDragged, location: CGPoint(x: 120, y: 100)),
+            in: .init(device: nil)
+        ))
+        XCTAssertTrue(transformer.isAutoscrollActive)
+
+        XCTAssertNil(try transformer.transform(
+            mouseEvent(type: .otherMouseUp, location: CGPoint(x: 120, y: 100)),
+            in: .init(device: nil)
+        ))
+        XCTAssertFalse(transformer.isAutoscrollActive)
+        XCTAssertEqual(replayedEvents, [])
+    }
+
+    func testClickingPressableElementReplaysBalancedNativeClick() throws {
+        var replayedEvents = [CGEventType]()
+        let transformer = pressableElementTransformer { replayedEvents.append($0.type) }
+        let down = try mouseEvent(type: .otherMouseDown, location: CGPoint(x: 100, y: 100))
+        let up = try mouseEvent(type: .otherMouseUp, location: CGPoint(x: 100, y: 100))
+
+        XCTAssertNil(transformer.transform(down, in: .init(device: nil)))
+        XCTAssertNil(transformer.transform(up, in: .init(device: nil)))
+
+        XCTAssertEqual(replayedEvents, [.otherMouseDown, .otherMouseUp])
+        XCTAssertFalse(transformer.isAutoscrollActive)
+    }
+
+    func testReplayedClickUsesEachEventsDownstreamContinuation() throws {
+        let transformer = pressableElementTransformer { _ in
+            XCTFail("Expected the contextual event sinks to be used")
+        }
+        var deliveries = [(String, CGEventType)]()
+        let down = try mouseEvent(type: .otherMouseDown, location: CGPoint(x: 100, y: 100))
+        let up = try mouseEvent(type: .otherMouseUp, location: CGPoint(x: 100, y: 100))
+
+        XCTAssertNil(transformer.transform(
+            down,
+            in: .init(device: nil) { deliveries.append(("down", $0.type)) }
+        ))
+        XCTAssertNil(transformer.transform(
+            up,
+            in: .init(device: nil) { deliveries.append(("up", $0.type)) }
+        ))
+
+        XCTAssertEqual(deliveries.map(\.0), ["down", "up"])
+        XCTAssertEqual(deliveries.map(\.1), [.otherMouseDown, .otherMouseUp])
+    }
+
+    func testOtherButtonPressIsReplayedAfterPendingTriggerDown() throws {
+        var replayedEvents = [CGEventType]()
+        let transformer = pressableElementTransformer { replayedEvents.append($0.type) }
+        let otherDown = try XCTUnwrap(CGEvent(
+            mouseEventSource: nil,
+            mouseType: .leftMouseDown,
+            mouseCursorPosition: CGPoint(x: 100, y: 100),
+            mouseButton: .left
+        ))
+
+        XCTAssertNil(try transformer.transform(
+            mouseEvent(type: .otherMouseDown, location: CGPoint(x: 100, y: 100)),
+            in: .init(device: nil)
+        ))
+        XCTAssertNil(transformer.transform(otherDown, in: .init(device: nil)))
+
+        XCTAssertEqual(replayedEvents, [.otherMouseDown, .leftMouseDown])
+        XCTAssertFalse(transformer.isAutoscrollActive)
+    }
+
+    func testSubDeadZoneDragOnPressableElementReplaysNativeStream() throws {
+        var replayedEvents = [CGEventType]()
+        let transformer = pressableElementTransformer { replayedEvents.append($0.type) }
+        let up = try mouseEvent(type: .otherMouseUp, location: CGPoint(x: 105, y: 100))
+
+        XCTAssertNil(try transformer.transform(
+            mouseEvent(type: .otherMouseDown, location: CGPoint(x: 100, y: 100)),
+            in: .init(device: nil)
+        ))
+        XCTAssertNil(try transformer.transform(
+            mouseEvent(type: .otherMouseDragged, location: CGPoint(x: 105, y: 100)),
+            in: .init(device: nil)
+        ))
+        XCTAssertNil(transformer.transform(up, in: .init(device: nil)))
+
+        XCTAssertEqual(replayedEvents, [.otherMouseDown, .otherMouseDragged, .otherMouseUp])
+        XCTAssertFalse(transformer.isAutoscrollActive)
+    }
+
+    func testToggleOnlyModeActivatesAfterDraggingPressableElement() throws {
+        var trigger = Mapping()
+        trigger.button = .mouse(2)
+        var replayedEvents = [CGEventType]()
+        let activationHitProvider: AutoScrollTransformer.ActivationHitProvider = { _ in
+            .pressable(path: ["AXLink"])
+        }
+        let transformer = AutoScrollTransformer(
+            trigger: trigger,
+            modes: [.toggle],
+            speed: 1,
+            activationHitProvider: activationHitProvider
+        ) { replayedEvents.append($0.type) }
+
+        XCTAssertNil(try transformer.transform(
+            mouseEvent(type: .otherMouseDown, location: CGPoint(x: 100, y: 100)),
+            in: .init(device: nil)
+        ))
+        XCTAssertNil(try transformer.transform(
+            mouseEvent(type: .otherMouseDragged, location: CGPoint(x: 120, y: 100)),
+            in: .init(device: nil)
+        ))
+        XCTAssertTrue(transformer.isAutoscrollActive)
+        XCTAssertNil(try transformer.transform(
+            mouseEvent(type: .otherMouseUp, location: CGPoint(x: 120, y: 100)),
+            in: .init(device: nil)
+        ))
+
+        XCTAssertTrue(transformer.isAutoscrollActive)
+        XCTAssertEqual(replayedEvents, [])
+        transformer.deactivate()
+    }
+
+    private func pressableElementTransformer(
+        eventSink: @escaping (CGEvent) -> Void
+    ) -> AutoScrollTransformer {
+        var trigger = Mapping()
+        trigger.button = .mouse(2)
+        return AutoScrollTransformer(
+            trigger: trigger,
+            modes: [.toggle, .hold],
+            speed: 1,
+            activationHitProvider: { _ in .pressable(path: ["AXLink"]) },
+            eventSink: eventSink
+        )
+    }
+
+    private func mouseEvent(type: CGEventType, location: CGPoint) throws -> CGEvent {
+        let event = try XCTUnwrap(CGEvent(
+            mouseEventSource: nil,
+            mouseType: type,
+            mouseCursorPosition: location,
+            mouseButton: .center
+        ))
+        event.setIntegerValueField(.mouseEventButtonNumber, value: 2)
+        return event
     }
 }


### PR DESCRIPTION
## Summary

- distinguish native middle clicks from Auto Scroll drags that begin over clickable elements
- preserve short clicks by replaying the complete native event stream through the remaining transformers
- activate Auto Scroll once dragging exceeds the existing dead zone
- avoid adding another configuration option

## Testing

- Auto Scroll transformer tests repeated 5 times
- full `xcodebuild test` suite
- SwiftFormat and strict SwiftLint

Fixes #1339