### PR TITLE
Fix hold-only autoscroll swallowing clicks

### DIFF
--- a/LinearMouse/EventTransformer/AutoScrollTransformer.swift
+++ b/LinearMouse/EventTransformer/AutoScrollTransformer.swift
@@ -161,6 +161,11 @@ extension AutoScrollTransformer: EventTransformer, DeferredEventTransformer {
             return event
         }
 
+        if isHoldOnlyMode {
+            beginPendingActivation(with: event, in: context)
+            return nil
+        }
+
         let activationHitResult: AutoScrollActivationHit?
         if let activationHitProvider {
             activationHitResult = activationHitProvider(event)
@@ -170,10 +175,7 @@ extension AutoScrollTransformer: EventTransformer, DeferredEventTransformer {
         guard Self.shouldStartAutoScroll(for: activationHitResult) else {
             // Delay the native stream only until movement distinguishes a click from
             // an Auto Scroll drag. A click replays the complete stream in order.
-            state = .pending(.init(
-                anchor: pointerLocation(for: event),
-                bufferedEvents: [deferredEvent(event, in: context)]
-            ))
+            beginPendingActivation(with: event, in: context)
             return nil
         }
 
@@ -225,20 +227,24 @@ extension AutoScrollTransformer: EventTransformer, DeferredEventTransformer {
     private func handlePointerMoved(_ event: CGEvent, in context: EventTransformerContext) -> CGEvent? {
         switch state {
         case var .pending(pending):
-            guard event.type == triggerMouseDraggedEventType,
-                  matchesTriggerButton(event) else {
+            let isTriggerDrag = event.type == triggerMouseDraggedEventType
+                && matchesTriggerButton(event)
+            let isLogitechMove = triggerIsLogitechControl && event.type == .mouseMoved
+            guard isTriggerDrag || isLogitechMove else {
                 return event
             }
 
             let point = pointerLocation(for: event)
             guard exceedsDeadZone(from: pending.anchor, to: point) else {
-                pending.bufferedEvents.append(deferredEvent(event, in: context))
+                if isTriggerDrag {
+                    pending.bufferedEvents.append(deferredEvent(event, in: context))
+                }
                 state = .pending(pending)
-                return nil
+                return isTriggerDrag ? nil : event
             }
 
             activate(at: pending.anchor, session: activationSession)
-            suppressTriggerUp = true
+            suppressTriggerUp = isTriggerDrag
             return handlePointerMoved(event, in: context)
 
         case let .active(anchor, _, session):
@@ -292,6 +298,13 @@ extension AutoScrollTransformer: EventTransformer, DeferredEventTransformer {
             event: event.copy() ?? event,
             sink: context.deferredEventSink ?? fallbackEventSink
         )
+    }
+
+    private func beginPendingActivation(with event: CGEvent, in context: EventTransformerContext) {
+        state = .pending(.init(
+            anchor: pointerLocation(for: event),
+            bufferedEvents: [deferredEvent(event, in: context)]
+        ))
     }
 
     private func replayPendingActivation(including finalEvent: DeferredEvent? = nil) {
@@ -434,6 +447,10 @@ extension AutoScrollTransformer: EventTransformer, DeferredEventTransformer {
         modes.contains(.hold)
     }
 
+    private var isHoldOnlyMode: Bool {
+        hasHoldMode && !hasToggleMode
+    }
+
     private var activationSession: Session {
         switch (hasToggleMode, hasHoldMode) {
         case (true, true):
@@ -542,11 +559,19 @@ extension AutoScrollTransformer: LogitechControlEventHandling {
                 return .notHandled
             }
 
+            if isHoldOnlyMode {
+                state = .pending(.init(anchor: context.mouseLocation, bufferedEvents: []))
+                return .handledDeferringSyntheticFallback
+            }
+
             activate(at: context.mouseLocation, session: activationSession)
             return .handled
         }
 
         switch state {
+        case .pending:
+            state = .idle
+            return .notHandled
         case let .active(anchor, current, session):
             switch session {
             case .hold:
@@ -573,7 +598,7 @@ extension AutoScrollTransformer: LogitechControlInteractionCanceling {
     func cancelLogitechControlInteraction(_ context: LogitechEventContext) -> Bool {
         guard let triggerLogitechControl = trigger.button?.logitechControl,
               context.matches(triggerLogitechControl),
-              isAutoscrollActive else {
+              hasPendingActivation || isAutoscrollActive else {
             return false
         }
 

--- a/LinearMouseUnitTests/EventTransformer/AutoScrollTransformerTests.swift
+++ b/LinearMouseUnitTests/EventTransformer/AutoScrollTransformerTests.swift
@@ -63,7 +63,7 @@ final class AutoScrollTransformerTests: XCTestCase {
         XCTAssertFalse(transformer.isAutoscrollActive)
     }
 
-    func testCancelingLostLogitechHoldStopsAutoScroll() {
+    func testCancelingLostLogitechHoldStopsAutoScroll() throws {
         let identity = LogitechControlIdentity(controlID: 0xC4)
         var trigger = Scheme.Buttons.Mapping()
         trigger.button = .logitechControl(identity)
@@ -82,10 +82,123 @@ final class AutoScrollTransformerTests: XCTestCase {
             modifierFlags: []
         )
 
-        XCTAssertEqual(transformer.handleLogitechControlEvent(context), .handled)
+        XCTAssertEqual(transformer.handleLogitechControlEvent(context), .handledDeferringSyntheticFallback)
+        XCTAssertFalse(transformer.isAutoscrollActive)
+
+        try XCTAssertNotNil(transformer.transform(
+            XCTUnwrap(CGEvent(
+                mouseEventSource: nil,
+                mouseType: .mouseMoved,
+                mouseCursorPosition: CGPoint(x: 11, y: 0),
+                mouseButton: .center
+            )),
+            in: .init(device: nil)
+        ))
         XCTAssertTrue(transformer.isAutoscrollActive)
 
         XCTAssertTrue(transformer.cancelLogitechControlInteraction(context))
+        XCTAssertFalse(transformer.isAutoscrollActive)
+    }
+
+    func testReleasingLogitechHoldWithinDeadZoneDoesNotActivateAutoScroll() {
+        let identity = LogitechControlIdentity(controlID: 0xC4)
+        var trigger = Scheme.Buttons.Mapping()
+        trigger.button = .logitechControl(identity)
+        let transformer = AutoScrollTransformer(
+            trigger: trigger,
+            modes: [.hold],
+            speed: 1
+        )
+        let press = LogitechEventContext(
+            device: nil,
+            pid: nil,
+            display: nil,
+            mouseLocation: .zero,
+            controlIdentity: identity,
+            isPressed: true,
+            modifierFlags: []
+        )
+        let release = LogitechEventContext(
+            device: nil,
+            pid: nil,
+            display: nil,
+            mouseLocation: .zero,
+            controlIdentity: identity,
+            isPressed: false,
+            modifierFlags: []
+        )
+
+        XCTAssertEqual(transformer.handleLogitechControlEvent(press), .handledDeferringSyntheticFallback)
+        XCTAssertFalse(transformer.isAutoscrollActive)
+        XCTAssertEqual(transformer.handleLogitechControlEvent(release), .notHandled)
+        XCTAssertFalse(transformer.isAutoscrollActive)
+    }
+
+    func testHoldOnlyClickReplaysNativeClickWithoutAccessibilityHitTest() throws {
+        var replayedEvents = [CGEventType]()
+        var trigger = Mapping()
+        trigger.button = .mouse(2)
+        let transformer = AutoScrollTransformer(
+            trigger: trigger,
+            modes: [.hold],
+            speed: 1,
+            activationHitProvider: { _ in
+                XCTFail("Hold-only activation should not depend on accessibility hit testing")
+                return .nonPressable(diagnostic: nil, path: [])
+            }
+        ) { replayedEvents.append($0.type) }
+
+        XCTAssertNil(try transformer.transform(
+            mouseEvent(type: .otherMouseDown, location: CGPoint(x: 100, y: 100)),
+            in: .init(device: nil)
+        ))
+        XCTAssertFalse(transformer.isAutoscrollActive)
+
+        XCTAssertNil(try transformer.transform(
+            mouseEvent(type: .otherMouseUp, location: CGPoint(x: 100, y: 100)),
+            in: .init(device: nil)
+        ))
+
+        XCTAssertEqual(replayedEvents, [.otherMouseDown, .otherMouseUp])
+        XCTAssertFalse(transformer.isAutoscrollActive)
+    }
+
+    func testHoldOnlyDragActivatesAfterDeadZone() throws {
+        var replayedEvents = [CGEventType]()
+        var trigger = Mapping()
+        trigger.button = .mouse(2)
+        let transformer = AutoScrollTransformer(
+            trigger: trigger,
+            modes: [.hold],
+            speed: 1,
+            activationHitProvider: { _ in
+                XCTFail("Hold-only activation should not depend on accessibility hit testing")
+                return nil
+            }
+        ) { replayedEvents.append($0.type) }
+
+        XCTAssertNil(try transformer.transform(
+            mouseEvent(type: .otherMouseDown, location: CGPoint(x: 100, y: 100)),
+            in: .init(device: nil)
+        ))
+        XCTAssertNil(try transformer.transform(
+            mouseEvent(type: .otherMouseDragged, location: CGPoint(x: 105, y: 100)),
+            in: .init(device: nil)
+        ))
+        XCTAssertFalse(transformer.isAutoscrollActive)
+
+        XCTAssertNil(try transformer.transform(
+            mouseEvent(type: .otherMouseDragged, location: CGPoint(x: 111, y: 100)),
+            in: .init(device: nil)
+        ))
+        XCTAssertTrue(transformer.isAutoscrollActive)
+
+        XCTAssertNil(try transformer.transform(
+            mouseEvent(type: .otherMouseUp, location: CGPoint(x: 111, y: 100)),
+            in: .init(device: nil)
+        ))
+
+        XCTAssertEqual(replayedEvents, [])
         XCTAssertFalse(transformer.isAutoscrollActive)
     }
 

--- a/LinearMouseUnitTests/EventTransformer/EventTransformerManagerTests.swift
+++ b/LinearMouseUnitTests/EventTransformer/EventTransformerManagerTests.swift
@@ -890,8 +890,16 @@ final class EventTransformerManagerTests: XCTestCase {
         )
         XCTAssertEqual(
             manager.handleLogitechControlEvent(logitech(autoScrollIdentity, pressed: true, display: "Display A")),
-            .handled
+            .handledDeferringSyntheticFallback
         )
+        XCTAssertFalse(autoScroll.isAutoscrollActive)
+
+        let move = try mouseEvent(
+            type: .mouseMoved,
+            button: .center,
+            location: CGPoint(x: 11, y: 0)
+        )
+        XCTAssertNotNil(route.transform(move, in: .init(device: nil)))
         XCTAssertTrue(autoScroll.isAutoscrollActive)
 
         XCTAssertEqual(
@@ -922,8 +930,16 @@ final class EventTransformerManagerTests: XCTestCase {
 
         XCTAssertEqual(
             manager.handleLogitechControlEvent(logitech(identity, pressed: true, display: "Display A")),
-            .handled
+            .handledDeferringSyntheticFallback
         )
+        XCTAssertFalse(autoScroll.isAutoscrollActive)
+
+        let move = try mouseEvent(
+            type: .mouseMoved,
+            button: .center,
+            location: CGPoint(x: 11, y: 0)
+        )
+        XCTAssertNotNil(route.transform(move, in: .init(device: nil)))
         XCTAssertTrue(autoScroll.isAutoscrollActive)
 
         XCTAssertTrue(manager.cancelLogitechControlInteraction(
@@ -1739,11 +1755,15 @@ final class EventTransformerManagerTests: XCTestCase {
         )
     }
 
-    private func mouseEvent(type: CGEventType, button: CGMouseButton) throws -> CGEvent {
+    private func mouseEvent(
+        type: CGEventType,
+        button: CGMouseButton,
+        location: CGPoint = .zero
+    ) throws -> CGEvent {
         let event = try XCTUnwrap(CGEvent(
             mouseEventSource: nil,
             mouseType: type,
-            mouseCursorPosition: .zero,
+            mouseCursorPosition: location,
             mouseButton: button
         ))
         event.setIntegerValueField(.mouseEventButtonNumber, value: Int64(button.rawValue))


### PR DESCRIPTION
## Summary

- Activate hold-only autoscroll only after pointer movement exceeds the dead zone
- Replay the native click when the trigger is released within the dead zone
- Apply the same behavior to Logitech controls using deferred synthetic fallback
- Avoid accessibility hit testing in hold-only mode

## Testing

- `make test`
- 541 tests passed