### PR TITLE
Add long-press activation to Auto Scroll toggle mode

### DIFF
--- a/Documentation/Configuration.d.ts
+++ b/Documentation/Configuration.d.ts
@@ -503,8 +503,15 @@ declare namespace Scheme {
       enabled?: boolean;
 
       /**
+       * @title Toggle activation
+       * @description Choose whether toggle mode activates with a short press or after the same long-press threshold used by button mappings. This does not affect hold mode.
+       * @default "shortPress"
+       */
+      toggleActivation?: AutoScroll.ToggleActivation;
+
+      /**
        * @title Activation mode
-       * @description Use \"toggle\" to click once and move until clicking again, \"hold\" to scroll only while the trigger stays pressed, or provide both to support both behaviors.
+       * @description Use \"toggle\" to keep scrolling active until the trigger is pressed again, \"hold\" to scroll only while the trigger stays pressed, or provide both to support both behaviors.
        */
       mode?: SingleValueOrArray<AutoScroll.Mode>;
 
@@ -523,7 +530,19 @@ declare namespace Scheme {
 
     namespace AutoScroll {
       /**
-       * @description Click once to enter auto scroll and click again to exit.
+       * @description Activate toggle mode with a short press.
+       */
+      type ShortPress = "shortPress";
+
+      /**
+       * @description Activate toggle mode after the button mapping long-press threshold.
+       */
+      type LongPress = "longPress";
+
+      type ToggleActivation = ShortPress | LongPress;
+
+      /**
+       * @description Keep auto scroll active until the trigger is pressed again. The toggleActivation setting controls whether activation requires a short or long press.
        */
       type Toggle = "toggle";
 

--- a/Documentation/Configuration.json
+++ b/Documentation/Configuration.json
@@ -166,13 +166,19 @@
         },
         "mode": {
           "$ref": "#/definitions/SingleValueOrArray%3CScheme.Buttons.AutoScroll.Mode%3E",
-          "description": "Use \\\"toggle\\\" to click once and move until clicking again, \\\"hold\\\" to scroll only while the trigger stays pressed, or provide both to support both behaviors.",
+          "description": "Use \\\"toggle\\\" to keep scrolling active until the trigger is pressed again, \\\"hold\\\" to scroll only while the trigger stays pressed, or provide both to support both behaviors.",
           "title": "Activation mode"
         },
         "speed": {
           "default": 1,
           "description": "Adjust the auto scroll speed multiplier.",
           "type": "number"
+        },
+        "toggleActivation": {
+          "$ref": "#/definitions/Scheme.Buttons.AutoScroll.ToggleActivation",
+          "default": "shortPress",
+          "description": "Choose whether toggle mode activates with a short press or after the same long-press threshold used by button mappings. This does not affect hold mode.",
+          "title": "Toggle activation"
         },
         "trigger": {
           "$ref": "#/definitions/Scheme.Buttons.AutoScroll.Trigger",
@@ -187,6 +193,11 @@
       "description": "Auto scroll is active only while the trigger button remains pressed.",
       "type": "string"
     },
+    "Scheme.Buttons.AutoScroll.LongPress": {
+      "const": "longPress",
+      "description": "Activate toggle mode after the button mapping long-press threshold.",
+      "type": "string"
+    },
     "Scheme.Buttons.AutoScroll.Mode": {
       "anyOf": [
         {
@@ -197,10 +208,25 @@
         }
       ]
     },
+    "Scheme.Buttons.AutoScroll.ShortPress": {
+      "const": "shortPress",
+      "description": "Activate toggle mode with a short press.",
+      "type": "string"
+    },
     "Scheme.Buttons.AutoScroll.Toggle": {
       "const": "toggle",
-      "description": "Click once to enter auto scroll and click again to exit.",
+      "description": "Keep auto scroll active until the trigger is pressed again. The toggleActivation setting controls whether activation requires a short or long press.",
       "type": "string"
+    },
+    "Scheme.Buttons.AutoScroll.ToggleActivation": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/Scheme.Buttons.AutoScroll.ShortPress"
+        },
+        {
+          "$ref": "#/definitions/Scheme.Buttons.AutoScroll.LongPress"
+        }
+      ]
     },
     "Scheme.Buttons.AutoScroll.Trigger": {
       "additionalProperties": false,

--- a/LinearMouse/EventTransformer/AutoScrollTransformer.swift
+++ b/LinearMouse/EventTransformer/AutoScrollTransformer.swift
@@ -7,6 +7,7 @@ import os.log
 
 final class AutoScrollTransformer {
     typealias ActivationHitProvider = (CGEvent) -> AutoScrollActivationHit?
+    typealias LongPressTimerScheduler = (TimeInterval, @escaping () -> Void) -> (() -> Void)?
 
     static let log = OSLog(subsystem: Bundle.main.bundleIdentifier!, category: "AutoScroll")
 
@@ -16,7 +17,9 @@ final class AutoScrollTransformer {
 
     private let trigger: Scheme.Buttons.Mapping
     private let modes: [Scheme.Buttons.AutoScroll.Mode]
+    private let toggleActivation: Scheme.Buttons.AutoScroll.ToggleActivation
     private let speed: Double
+    private let scheduleLongPressTimer: LongPressTimerScheduler
     private let activationHitProvider: ActivationHitProvider?
     private let fallbackEventSink: (CGEvent) -> Void
 
@@ -31,9 +34,32 @@ final class AutoScrollTransformer {
         var sink: (CGEvent) -> Void
     }
 
+    private enum PendingActivationStrategy {
+        case movement(Session)
+        case longPress(Session)
+        case movementOrLongPress
+
+        var schedulesLongPress: Bool {
+            switch self {
+            case .longPress, .movementOrLongPress:
+                return true
+            case .movement:
+                return false
+            }
+        }
+    }
+
+    private enum PendingActivationCause {
+        case movement
+        case longPress
+    }
+
     private struct PendingActivation {
         var anchor: CGPoint
+        var current: CGPoint
         var bufferedEvents: [DeferredEvent]
+        var strategy: PendingActivationStrategy
+        var isPhysicalTrigger: Bool
     }
 
     private enum State {
@@ -45,6 +71,8 @@ final class AutoScrollTransformer {
     private var state: State = .idle
     private var suppressTriggerUp = false
     private var suppressedExitMouseButton: CGMouseButton?
+    private var longPressTimerCancellation: (() -> Void)?
+    private var longPressTimerGeneration: UInt64 = 0
     private var timer: EventThreadTimer?
     private let indicatorController = AutoScrollIndicatorWindowController()
     private let accessibilityActivationClassifier = AutoScrollAccessibilityActivationClassifier()
@@ -56,18 +84,24 @@ final class AutoScrollTransformer {
     init(
         trigger: Scheme.Buttons.Mapping,
         modes: [Scheme.Buttons.AutoScroll.Mode],
+        toggleActivation: Scheme.Buttons.AutoScroll.ToggleActivation = .shortPress,
         speed: Double,
+        longPressTimerScheduler: @escaping LongPressTimerScheduler = AutoScrollTransformer
+            .scheduleEventThreadLongPressTimer,
         activationHitProvider: ActivationHitProvider? = nil,
         eventSink: @escaping (CGEvent) -> Void = { $0.post(tap: .cgSessionEventTap) }
     ) {
         self.trigger = trigger
         self.modes = modes
+        self.toggleActivation = toggleActivation
         self.speed = speed
+        scheduleLongPressTimer = longPressTimerScheduler
         self.activationHitProvider = activationHitProvider
         fallbackEventSink = eventSink
     }
 
     deinit {
+        longPressTimerCancellation?()
         DispatchQueue.main.async { [indicatorController] in
             indicatorController.hide()
         }
@@ -161,8 +195,20 @@ extension AutoScrollTransformer: EventTransformer, DeferredEventTransformer {
             return event
         }
 
+        if usesLongPressToggle {
+            let strategy: PendingActivationStrategy = hasHoldMode
+                ? .movementOrLongPress
+                : .longPress(.toggle)
+            beginPendingActivation(
+                with: event,
+                in: context,
+                strategy: strategy
+            )
+            return nil
+        }
+
         if isHoldOnlyMode {
-            beginPendingActivation(with: event, in: context)
+            beginPendingActivation(with: event, in: context, strategy: .movement(.hold))
             return nil
         }
 
@@ -175,7 +221,11 @@ extension AutoScrollTransformer: EventTransformer, DeferredEventTransformer {
         guard Self.shouldStartAutoScroll(for: activationHitResult) else {
             // Delay the native stream only until movement distinguishes a click from
             // an Auto Scroll drag. A click replays the complete stream in order.
-            beginPendingActivation(with: event, in: context)
+            beginPendingActivation(
+                with: event,
+                in: context,
+                strategy: .movement(activationSession)
+            )
             return nil
         }
 
@@ -235,17 +285,18 @@ extension AutoScrollTransformer: EventTransformer, DeferredEventTransformer {
             }
 
             let point = pointerLocation(for: event)
-            guard exceedsDeadZone(from: pending.anchor, to: point) else {
-                if isTriggerDrag {
-                    pending.bufferedEvents.append(deferredEvent(event, in: context))
-                }
-                state = .pending(pending)
-                return isTriggerDrag ? nil : event
+            pending.current = point
+            if isTriggerDrag {
+                pending.bufferedEvents.append(deferredEvent(event, in: context))
+            }
+            state = .pending(pending)
+
+            if exceedsDeadZone(from: pending.anchor, to: point),
+               activatePending(for: .movement) {
+                return handlePointerMoved(event, in: context)
             }
 
-            activate(at: pending.anchor, session: activationSession)
-            suppressTriggerUp = isTriggerDrag
-            return handlePointerMoved(event, in: context)
+            return isTriggerDrag ? nil : event
 
         case let .active(anchor, _, session):
             let point = pointerLocation(for: event)
@@ -300,11 +351,38 @@ extension AutoScrollTransformer: EventTransformer, DeferredEventTransformer {
         )
     }
 
-    private func beginPendingActivation(with event: CGEvent, in context: EventTransformerContext) {
+    private func beginPendingActivation(
+        with event: CGEvent,
+        in context: EventTransformerContext,
+        strategy: PendingActivationStrategy
+    ) {
+        let point = pointerLocation(for: event)
+        beginPendingActivation(
+            at: point,
+            bufferedEvents: [deferredEvent(event, in: context)],
+            strategy: strategy,
+            isPhysicalTrigger: true
+        )
+    }
+
+    private func beginPendingActivation(
+        at point: CGPoint,
+        bufferedEvents: [DeferredEvent],
+        strategy: PendingActivationStrategy,
+        isPhysicalTrigger: Bool
+    ) {
+        cancelLongPressTimer()
         state = .pending(.init(
-            anchor: pointerLocation(for: event),
-            bufferedEvents: [deferredEvent(event, in: context)]
+            anchor: point,
+            current: point,
+            bufferedEvents: bufferedEvents,
+            strategy: strategy,
+            isPhysicalTrigger: isPhysicalTrigger
         ))
+
+        if strategy.schedulesLongPress {
+            schedulePendingLongPressActivation()
+        }
     }
 
     private func replayPendingActivation(including finalEvent: DeferredEvent? = nil) {
@@ -313,12 +391,85 @@ extension AutoScrollTransformer: EventTransformer, DeferredEventTransformer {
         }
 
         state = .idle
+        cancelLongPressTimer()
         var events = pending.bufferedEvents
         if let finalEvent {
             events.append(finalEvent)
         }
         for event in events {
             event.sink(event.event)
+        }
+    }
+
+    @discardableResult
+    private func activatePending(for cause: PendingActivationCause) -> Bool {
+        guard case let .pending(pending) = state else {
+            return false
+        }
+
+        let session: Session
+        switch (pending.strategy, cause) {
+        case let (.movement(pendingSession), .movement),
+             let (.longPress(pendingSession), .longPress):
+            session = pendingSession
+        case (.movementOrLongPress, .movement):
+            session = .hold
+        case (.movementOrLongPress, .longPress):
+            session = .pendingToggleOrHold
+        default:
+            return false
+        }
+
+        cancelLongPressTimer()
+        suppressTriggerUp = pending.isPhysicalTrigger
+        activate(
+            at: pending.anchor,
+            current: pending.current,
+            session: session
+        )
+        return true
+    }
+
+    private func schedulePendingLongPressActivation() {
+        longPressTimerGeneration &+= 1
+        let generation = longPressTimerGeneration
+        longPressTimerCancellation = scheduleLongPressTimer(
+            ButtonMappingPolicy.default.longPressDuration
+        ) { [weak self] in
+            self?.longPressThresholdReached(generation: generation)
+        }
+    }
+
+    private func longPressThresholdReached(generation: UInt64) {
+        guard generation == longPressTimerGeneration,
+              case .pending = state else {
+            return
+        }
+
+        longPressTimerCancellation = nil
+        activatePending(for: .longPress)
+    }
+
+    private func cancelLongPressTimer() {
+        longPressTimerGeneration &+= 1
+        longPressTimerCancellation?()
+        longPressTimerCancellation = nil
+    }
+
+    private static func scheduleEventThreadLongPressTimer(
+        interval: TimeInterval,
+        handler: @escaping () -> Void
+    ) -> (() -> Void)? {
+        guard let timer = EventThread.shared.scheduleTimer(
+            interval: interval,
+            repeats: false,
+            handler: handler
+        ) else {
+            return nil
+        }
+
+        return {
+            timer.invalidate()
         }
     }
 
@@ -360,7 +511,7 @@ extension AutoScrollTransformer: EventTransformer, DeferredEventTransformer {
         }
     }
 
-    private func activate(at point: CGPoint, session: Session) {
+    private func activate(at point: CGPoint, current: CGPoint? = nil, session: Session) {
         os_log(
             "Auto scroll activated (modes=%{public}@, button=%{public}d)",
             log: Self.log,
@@ -370,10 +521,12 @@ extension AutoScrollTransformer: EventTransformer, DeferredEventTransformer {
         )
 
         suppressedExitMouseButton = nil
-        state = .active(anchor: point, current: point, session: session)
+        let current = current ?? point
+        state = .active(anchor: point, current: current, session: session)
+        let delta = CGVector(dx: current.x - point.x, dy: current.y - point.y)
         DispatchQueue.main.async { [indicatorController] in
             indicatorController.show(at: point)
-            indicatorController.update(delta: .zero)
+            indicatorController.update(delta: delta)
         }
         startTimerIfNeeded()
     }
@@ -449,6 +602,10 @@ extension AutoScrollTransformer: EventTransformer, DeferredEventTransformer {
 
     private var isHoldOnlyMode: Bool {
         hasHoldMode && !hasToggleMode
+    }
+
+    private var usesLongPressToggle: Bool {
+        hasToggleMode && toggleActivation == .longPress
     }
 
     private var activationSession: Session {
@@ -559,8 +716,26 @@ extension AutoScrollTransformer: LogitechControlEventHandling {
                 return .notHandled
             }
 
+            if usesLongPressToggle {
+                let strategy: PendingActivationStrategy = hasHoldMode
+                    ? .movementOrLongPress
+                    : .longPress(.toggle)
+                beginPendingActivation(
+                    at: context.mouseLocation,
+                    bufferedEvents: [],
+                    strategy: strategy,
+                    isPhysicalTrigger: false
+                )
+                return .handledDeferringSyntheticFallback
+            }
+
             if isHoldOnlyMode {
-                state = .pending(.init(anchor: context.mouseLocation, bufferedEvents: []))
+                beginPendingActivation(
+                    at: context.mouseLocation,
+                    bufferedEvents: [],
+                    strategy: .movement(.hold),
+                    isPhysicalTrigger: false
+                )
                 return .handledDeferringSyntheticFallback
             }
 
@@ -570,7 +745,7 @@ extension AutoScrollTransformer: LogitechControlEventHandling {
 
         switch state {
         case .pending:
-            state = .idle
+            replayPendingActivation()
             return .notHandled
         case let .active(anchor, current, session):
             switch session {
@@ -610,6 +785,7 @@ extension AutoScrollTransformer: LogitechControlInteractionCanceling {
 extension AutoScrollTransformer: Deactivatable {
     func deactivate() {
         replayPendingActivation()
+        cancelLongPressTimer()
 
         if isAutoscrollActive {
             os_log("Auto scroll deactivated", log: Self.log, type: .info)
@@ -630,10 +806,12 @@ extension AutoScrollTransformer {
     func matchesConfiguration(
         trigger: Scheme.Buttons.Mapping,
         modes: [Scheme.Buttons.AutoScroll.Mode],
+        toggleActivation: Scheme.Buttons.AutoScroll.ToggleActivation,
         speed: Double
     ) -> Bool {
         self.trigger == trigger &&
             self.modes == modes &&
+            self.toggleActivation == toggleActivation &&
             abs(self.speed - speed) < 0.0001
     }
 }

--- a/LinearMouse/EventTransformer/EventTransformerManager.swift
+++ b/LinearMouse/EventTransformer/EventTransformerManager.swift
@@ -948,12 +948,14 @@ class EventTransformerManager {
         }
 
         let modes = autoScroll.normalizedModes
+        let toggleActivation = autoScroll.normalizedToggleActivation
         let speed = autoScroll.speed?.asTruncatedDouble ?? 1
 
         if let sharedAutoScrollTransformer,
            sharedAutoScrollTransformer.matchesConfiguration(
                trigger: trigger,
                modes: modes,
+               toggleActivation: toggleActivation,
                speed: speed
            ) {
             return sharedAutoScrollTransformer
@@ -964,6 +966,7 @@ class EventTransformerManager {
         let transformer = AutoScrollTransformer(
             trigger: trigger,
             modes: modes,
+            toggleActivation: toggleActivation,
             speed: speed
         )
         sharedAutoScrollTransformer = transformer

--- a/LinearMouse/Localizable.xcstrings
+++ b/LinearMouse/Localizable.xcstrings
@@ -14013,6 +14013,7 @@
     },
     "Click once to toggle" : {
       "comment" : "Autoscroll mode label. One click turns the mode on or off.",
+      "extractionState" : "stale",
       "localizations" : {
         "af" : {
           "stringUnit" : {
@@ -35041,6 +35042,29 @@
         }
       }
     },
+    "Keep scrolling after release" : {
+      "comment" : "Checkbox label for keeping autoscroll active after releasing its trigger.",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "松开后保持滚动"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "放開後保持捲動"
+          }
+        },
+        "zh-Hant-HK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "放開後保持捲動"
+          }
+        }
+      }
+    },
     "Launchpad" : {
       "localizations" : {
         "af" : {
@@ -36706,6 +36730,29 @@
         }
       }
     },
+    "Long press" : {
+      "comment" : "Autoscroll toggle activation option.",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "长按"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "長按"
+          }
+        },
+        "zh-Hant-HK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "長按"
+          }
+        }
+      }
+    },
     "Long Press %@" : {
       "comment" : "Recorded gesture token",
       "localizations" : {
@@ -37327,6 +37374,52 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "長按："
+          }
+        }
+      }
+    },
+    "Long-press and release to keep autoscroll active, or drag beyond the dead zone to scroll only until you let go." : {
+      "comment" : "Autoscroll description when long-press toggle and hold modes are enabled.",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "长按并松开可保持自动滚动，或拖动超过死区，仅在按住期间滚动。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "長按並放開可保持自動捲動，或拖動超過死區，僅在按住期間捲動。"
+          }
+        },
+        "zh-Hant-HK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "長按並放開可保持自動捲動，或拖動超過死區，只在按住期間捲動。"
+          }
+        }
+      }
+    },
+    "Long-press the trigger to enter autoscroll, move in any direction to scroll, then click again to exit." : {
+      "comment" : "Autoscroll description when toggle mode requires a long press.",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "长按触发按钮以进入自动滚动，向任意方向移动以滚动，然后再次单击退出。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "長按觸發按鈕以進入自動捲動，向任意方向移動以捲動，然後再次點按退出。"
+          }
+        },
+        "zh-Hant-HK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "長按觸發按鈕以進入自動捲動，向任何方向移動以捲動，然後再按一下退出。"
           }
         }
       }
@@ -60470,6 +60563,29 @@
         }
       }
     },
+    "Short press" : {
+      "comment" : "Autoscroll toggle activation option.",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "短按"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "短按"
+          }
+        },
+        "zh-Hant-HK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "短按"
+          }
+        }
+      }
+    },
     "Short press action" : {
       "localizations" : {
         "af" : {
@@ -70872,6 +70988,29 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "當你想自行微調手感時，請使用這個選項。"
+          }
+        }
+      }
+    },
+    "Uses the same long-press threshold as button mappings." : {
+      "comment" : "Explains the autoscroll long-press timing.",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "使用与按钮映射相同的长按阈值。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "使用與按鈕映射相同的長按閾值。"
+          }
+        },
+        "zh-Hant-HK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "使用與按鈕映射相同的長按閾值。"
           }
         }
       }

--- a/LinearMouse/Model/Configuration/Scheme/Buttons/AutoScroll/AutoScroll.swift
+++ b/LinearMouse/Model/Configuration/Scheme/Buttons/AutoScroll/AutoScroll.swift
@@ -5,6 +5,15 @@ import Foundation
 
 extension Scheme.Buttons {
     struct AutoScroll: Equatable, ImplicitInitable {
+        enum ToggleActivation: String, Codable, Equatable, CaseIterable, Identifiable {
+            var id: Self {
+                self
+            }
+
+            case shortPress
+            case longPress
+        }
+
         enum Mode: String, Codable, Equatable, CaseIterable, Identifiable {
             var id: Self {
                 self
@@ -15,6 +24,7 @@ extension Scheme.Buttons {
         }
 
         var enabled: Bool?
+        var toggleActivation: ToggleActivation?
         var modes: [Mode]?
         var speed: Decimal?
         var trigger: Mapping?
@@ -26,6 +36,7 @@ extension Scheme.Buttons {
 extension Scheme.Buttons.AutoScroll: Codable {
     private enum CodingKeys: String, CodingKey {
         case enabled
+        case toggleActivation
         case mode
         case speed
         case trigger
@@ -35,6 +46,7 @@ extension Scheme.Buttons.AutoScroll: Codable {
         let container = try decoder.container(keyedBy: CodingKeys.self)
 
         enabled = try container.decodeIfPresent(Bool.self, forKey: .enabled)
+        toggleActivation = try container.decodeIfPresent(ToggleActivation.self, forKey: .toggleActivation)
         modes = try container.decodeIfPresent(SingleValueOrArray<Mode>.self, forKey: .mode)?.wrappedValue
         speed = try container.decodeIfPresent(Decimal.self, forKey: .speed)
         trigger = try container.decodeIfPresent(Scheme.Buttons.Mapping.self, forKey: .trigger)
@@ -44,6 +56,7 @@ extension Scheme.Buttons.AutoScroll: Codable {
         var container = encoder.container(keyedBy: CodingKeys.self)
 
         try container.encodeIfPresent(enabled, forKey: .enabled)
+        try container.encodeIfPresent(toggleActivation, forKey: .toggleActivation)
         try container.encode(SingleValueOrArray(wrappedValue: modes), forKey: .mode)
         try container.encodeIfPresent(speed, forKey: .speed)
         try container.encodeIfPresent(trigger, forKey: .trigger)
@@ -51,6 +64,10 @@ extension Scheme.Buttons.AutoScroll: Codable {
 }
 
 extension Scheme.Buttons.AutoScroll {
+    var normalizedToggleActivation: ToggleActivation {
+        toggleActivation ?? .shortPress
+    }
+
     var normalizedModes: [Mode] {
         let orderedModes = Mode.allCases.filter { modes?.contains($0) == true }
         return orderedModes.isEmpty ? [.toggle] : orderedModes
@@ -67,6 +84,10 @@ extension Scheme.Buttons.AutoScroll {
     func merge(into autoScroll: inout Self) {
         if let enabled {
             autoScroll.enabled = enabled
+        }
+
+        if let toggleActivation {
+            autoScroll.toggleActivation = toggleActivation
         }
 
         if let modes {

--- a/LinearMouse/UI/ButtonsSettings/AutoScrollSection/AutoScrollSection.swift
+++ b/LinearMouse/UI/ButtonsSettings/AutoScrollSection/AutoScrollSection.swift
@@ -22,10 +22,31 @@ struct AutoScrollSection: View {
                     Text("Modes")
                         .font(.headline)
 
-                    Toggle("Click once to toggle", isOn: $state.autoScrollToggleModeEnabled.animation())
+                    HStack(spacing: 12) {
+                        Toggle(
+                            "Keep scrolling after release",
+                            isOn: $state.autoScrollToggleModeEnabled.animation()
+                        )
+                        .toggleStyle(.checkbox)
                         .disabled(state.autoScrollToggleModeEnabled && !state.autoScrollHoldModeEnabled)
 
+                        Spacer(minLength: 12)
+
+                        if state.autoScrollToggleModeEnabled {
+                            Picker(String(""), selection: $state.autoScrollToggleActivation) {
+                                Text("Short press")
+                                    .tag(Scheme.Buttons.AutoScroll.ToggleActivation.shortPress)
+                                Text("Long press")
+                                    .tag(Scheme.Buttons.AutoScroll.ToggleActivation.longPress)
+                            }
+                            .labelsHidden()
+                            .fixedSize()
+                            .modifier(PickerViewModifier())
+                        }
+                    }
+
                     Toggle("Hold to scroll", isOn: $state.autoScrollHoldModeEnabled.animation())
+                        .toggleStyle(.checkbox)
                         .disabled(state.autoScrollHoldModeEnabled && !state.autoScrollToggleModeEnabled)
                 }
 
@@ -59,6 +80,12 @@ struct AutoScrollSection: View {
                 Text(modeDescription)
                     .settingsDescriptionStyle()
                     .padding(.top, 4)
+
+                if state.autoScrollToggleModeEnabled,
+                   state.autoScrollToggleActivation == .longPress {
+                    Text("Uses the same long-press threshold as button mappings.")
+                        .settingsDescriptionStyle()
+                }
             }
         }
         .modifier(SectionViewModifier())
@@ -66,6 +93,15 @@ struct AutoScrollSection: View {
 
     private var modeDescription: LocalizedStringKey {
         let modes = Set(state.autoScrollModes)
+
+        if state.autoScrollToggleModeEnabled,
+           state.autoScrollToggleActivation == .longPress {
+            if modes == [.toggle] {
+                return "Long-press the trigger to enter autoscroll, move in any direction to scroll, then click again to exit."
+            }
+
+            return "Long-press and release to keep autoscroll active, or drag beyond the dead zone to scroll only until you let go."
+        }
 
         if modes == [.toggle] {
             return "Click the trigger once to enter autoscroll, move in any direction to scroll, then click again to exit."

--- a/LinearMouse/UI/ButtonsSettings/ButtonsSettingsState.swift
+++ b/LinearMouse/UI/ButtonsSettings/ButtonsSettingsState.swift
@@ -180,6 +180,15 @@ extension ButtonsSettingsState {
         }
     }
 
+    var autoScrollToggleActivation: Scheme.Buttons.AutoScroll.ToggleActivation {
+        get {
+            mergedScheme.buttons.autoScroll.normalizedToggleActivation
+        }
+        set {
+            scheme.buttons.autoScroll.toggleActivation = newValue
+        }
+    }
+
     var autoScrollToggleModeEnabled: Bool {
         get {
             autoScrollModes.contains(.toggle)

--- a/LinearMouseUnitTests/EventTransformer/AutoScrollTransformerTests.swift
+++ b/LinearMouseUnitTests/EventTransformer/AutoScrollTransformerTests.swift
@@ -134,6 +134,51 @@ final class AutoScrollTransformerTests: XCTestCase {
         XCTAssertFalse(transformer.isAutoscrollActive)
     }
 
+    func testLongPressLogitechToggleRestoresShortClickFallback() {
+        let timer = LongPressTimerHarness()
+        let identity = LogitechControlIdentity(controlID: 0xC4)
+        var trigger = Mapping()
+        trigger.button = .logitechControl(identity)
+        let transformer = AutoScrollTransformer(
+            trigger: trigger,
+            modes: [.toggle],
+            toggleActivation: .longPress,
+            speed: 1,
+            longPressTimerScheduler: timer.schedule
+        )
+        let press = logitechContext(identity: identity, pressed: true)
+        let release = logitechContext(identity: identity, pressed: false)
+
+        XCTAssertEqual(transformer.handleLogitechControlEvent(press), .handledDeferringSyntheticFallback)
+        XCTAssertFalse(transformer.isAutoscrollActive)
+        XCTAssertEqual(transformer.handleLogitechControlEvent(release), .notHandled)
+        XCTAssertEqual(timer.cancellationCount, 1)
+        XCTAssertFalse(transformer.isAutoscrollActive)
+    }
+
+    func testLongPressLogitechToggleSuppressesFallbackAfterThreshold() {
+        let timer = LongPressTimerHarness()
+        let identity = LogitechControlIdentity(controlID: 0xC4)
+        var trigger = Mapping()
+        trigger.button = .logitechControl(identity)
+        let transformer = AutoScrollTransformer(
+            trigger: trigger,
+            modes: [.toggle],
+            toggleActivation: .longPress,
+            speed: 1,
+            longPressTimerScheduler: timer.schedule
+        )
+        let press = logitechContext(identity: identity, pressed: true)
+        let release = logitechContext(identity: identity, pressed: false)
+
+        XCTAssertEqual(transformer.handleLogitechControlEvent(press), .handledDeferringSyntheticFallback)
+        timer.fire()
+        XCTAssertTrue(transformer.isAutoscrollActive)
+        XCTAssertEqual(transformer.handleLogitechControlEvent(release), .handled)
+        XCTAssertTrue(transformer.isAutoscrollActive)
+        transformer.deactivate()
+    }
+
     func testHoldOnlyClickReplaysNativeClickWithoutAccessibilityHitTest() throws {
         var replayedEvents = [CGEventType]()
         var trigger = Mapping()
@@ -200,6 +245,160 @@ final class AutoScrollTransformerTests: XCTestCase {
 
         XCTAssertEqual(replayedEvents, [])
         XCTAssertFalse(transformer.isAutoscrollActive)
+    }
+
+    func testLongPressToggleReplaysShortClick() throws {
+        let timer = LongPressTimerHarness()
+        var replayedEvents = [CGEventType]()
+        var trigger = Mapping()
+        trigger.button = .mouse(2)
+        let transformer = AutoScrollTransformer(
+            trigger: trigger,
+            modes: [.toggle],
+            toggleActivation: .longPress,
+            speed: 1,
+            longPressTimerScheduler: timer.schedule,
+            activationHitProvider: { _ in
+                XCTFail("Long-press toggle should not depend on accessibility hit testing")
+                return nil
+            }
+        ) { replayedEvents.append($0.type) }
+
+        XCTAssertNil(try transformer.transform(
+            mouseEvent(type: .otherMouseDown, location: CGPoint(x: 100, y: 100)),
+            in: .init(device: nil)
+        ))
+        XCTAssertEqual(timer.interval, ButtonMappingPolicy.default.longPressDuration)
+        XCTAssertFalse(transformer.isAutoscrollActive)
+
+        XCTAssertNil(try transformer.transform(
+            mouseEvent(type: .otherMouseUp, location: CGPoint(x: 100, y: 100)),
+            in: .init(device: nil)
+        ))
+
+        XCTAssertEqual(replayedEvents, [.otherMouseDown, .otherMouseUp])
+        XCTAssertEqual(timer.cancellationCount, 1)
+        XCTAssertFalse(transformer.isAutoscrollActive)
+    }
+
+    func testLongPressToggleActivatesAtButtonMappingThreshold() throws {
+        let timer = LongPressTimerHarness()
+        var replayedEvents = [CGEventType]()
+        var trigger = Mapping()
+        trigger.button = .mouse(2)
+        let transformer = AutoScrollTransformer(
+            trigger: trigger,
+            modes: [.toggle],
+            toggleActivation: .longPress,
+            speed: 1,
+            longPressTimerScheduler: timer.schedule
+        ) { replayedEvents.append($0.type) }
+
+        XCTAssertNil(try transformer.transform(
+            mouseEvent(type: .otherMouseDown, location: CGPoint(x: 100, y: 100)),
+            in: .init(device: nil)
+        ))
+        timer.fire()
+        XCTAssertTrue(transformer.isAutoscrollActive)
+
+        XCTAssertNil(try transformer.transform(
+            mouseEvent(type: .otherMouseUp, location: CGPoint(x: 100, y: 100)),
+            in: .init(device: nil)
+        ))
+
+        XCTAssertEqual(replayedEvents, [])
+        XCTAssertTrue(transformer.isAutoscrollActive)
+        transformer.deactivate()
+    }
+
+    func testLongPressToggleSettingDoesNotDelayHoldOnlyMode() throws {
+        let timer = LongPressTimerHarness()
+        var trigger = Mapping()
+        trigger.button = .mouse(2)
+        let transformer = AutoScrollTransformer(
+            trigger: trigger,
+            modes: [.hold],
+            toggleActivation: .longPress,
+            speed: 1,
+            longPressTimerScheduler: timer.schedule
+        )
+
+        XCTAssertNil(try transformer.transform(
+            mouseEvent(type: .otherMouseDown, location: CGPoint(x: 100, y: 100)),
+            in: .init(device: nil)
+        ))
+        XCTAssertNil(timer.interval)
+
+        XCTAssertNil(try transformer.transform(
+            mouseEvent(type: .otherMouseDragged, location: CGPoint(x: 111, y: 100)),
+            in: .init(device: nil)
+        ))
+        XCTAssertTrue(transformer.isAutoscrollActive)
+
+        XCTAssertNil(try transformer.transform(
+            mouseEvent(type: .otherMouseUp, location: CGPoint(x: 111, y: 100)),
+            in: .init(device: nil)
+        ))
+        XCTAssertFalse(transformer.isAutoscrollActive)
+    }
+
+    func testCombinedLongPressModeStillActivatesHoldAfterDeadZone() throws {
+        let timer = LongPressTimerHarness()
+        var trigger = Mapping()
+        trigger.button = .mouse(2)
+        let transformer = AutoScrollTransformer(
+            trigger: trigger,
+            modes: [.toggle, .hold],
+            toggleActivation: .longPress,
+            speed: 1,
+            longPressTimerScheduler: timer.schedule
+        )
+
+        XCTAssertNil(try transformer.transform(
+            mouseEvent(type: .otherMouseDown, location: CGPoint(x: 100, y: 100)),
+            in: .init(device: nil)
+        ))
+        XCTAssertNotNil(timer.interval)
+
+        XCTAssertNil(try transformer.transform(
+            mouseEvent(type: .otherMouseDragged, location: CGPoint(x: 111, y: 100)),
+            in: .init(device: nil)
+        ))
+        XCTAssertEqual(timer.cancellationCount, 1)
+        XCTAssertTrue(transformer.isAutoscrollActive)
+
+        XCTAssertNil(try transformer.transform(
+            mouseEvent(type: .otherMouseUp, location: CGPoint(x: 111, y: 100)),
+            in: .init(device: nil)
+        ))
+        XCTAssertFalse(transformer.isAutoscrollActive)
+    }
+
+    func testCombinedLongPressModeTogglesAfterThresholdWithoutDrag() throws {
+        let timer = LongPressTimerHarness()
+        var trigger = Mapping()
+        trigger.button = .mouse(2)
+        let transformer = AutoScrollTransformer(
+            trigger: trigger,
+            modes: [.toggle, .hold],
+            toggleActivation: .longPress,
+            speed: 1,
+            longPressTimerScheduler: timer.schedule
+        )
+
+        XCTAssertNil(try transformer.transform(
+            mouseEvent(type: .otherMouseDown, location: CGPoint(x: 100, y: 100)),
+            in: .init(device: nil)
+        ))
+        timer.fire()
+        XCTAssertTrue(transformer.isAutoscrollActive)
+
+        XCTAssertNil(try transformer.transform(
+            mouseEvent(type: .otherMouseUp, location: CGPoint(x: 100, y: 100)),
+            in: .init(device: nil)
+        ))
+        XCTAssertTrue(transformer.isAutoscrollActive)
+        transformer.deactivate()
     }
 
     func testDraggingPressableElementBeyondDeadZoneActivatesAutoScroll() throws {
@@ -355,5 +554,41 @@ final class AutoScrollTransformerTests: XCTestCase {
         ))
         event.setIntegerValueField(.mouseEventButtonNumber, value: 2)
         return event
+    }
+
+    private func logitechContext(
+        identity: LogitechControlIdentity,
+        pressed: Bool
+    ) -> LogitechEventContext {
+        .init(
+            device: nil,
+            pid: nil,
+            display: nil,
+            mouseLocation: .zero,
+            controlIdentity: identity,
+            isPressed: pressed,
+            modifierFlags: []
+        )
+    }
+
+    private final class LongPressTimerHarness {
+        private(set) var interval: TimeInterval?
+        private(set) var cancellationCount = 0
+        private var handler: (() -> Void)?
+
+        func schedule(_ interval: TimeInterval, _ handler: @escaping () -> Void) -> (() -> Void)? {
+            self.interval = interval
+            self.handler = handler
+            return { [weak self] in
+                self?.cancellationCount += 1
+                self?.handler = nil
+            }
+        }
+
+        func fire() {
+            let handler = handler
+            self.handler = nil
+            handler?()
+        }
     }
 }

--- a/LinearMouseUnitTests/Model/ConfigurationTests.swift
+++ b/LinearMouseUnitTests/Model/ConfigurationTests.swift
@@ -123,9 +123,12 @@ final class ConfigurationTests: XCTestCase {
         trigger.shift = true
         scheme.buttons.autoScroll.trigger = trigger
 
-        Scheme().merge(into: &scheme)
+        var override = Scheme()
+        override.buttons.autoScroll.toggleActivation = .longPress
+        override.merge(into: &scheme)
 
         XCTAssertEqual(scheme.buttons.autoScroll.enabled, true)
+        XCTAssertEqual(scheme.buttons.autoScroll.toggleActivation, .longPress)
         XCTAssertEqual(scheme.buttons.autoScroll.modes, [.hold])
         XCTAssertEqual(scheme.buttons.autoScroll.trigger?.button, .mouse(4))
         XCTAssertEqual(scheme.buttons.autoScroll.trigger?.modifierFlags.contains(.maskShift), true)
@@ -134,6 +137,7 @@ final class ConfigurationTests: XCTestCase {
     func testMergeAutoScrollPreservesInheritedFields() {
         var scheme = Scheme()
         scheme.buttons.autoScroll.enabled = true
+        scheme.buttons.autoScroll.toggleActivation = .longPress
         scheme.buttons.autoScroll.modes = [.toggle]
         scheme.buttons.autoScroll.speed = 1
 
@@ -148,6 +152,7 @@ final class ConfigurationTests: XCTestCase {
         override.merge(into: &scheme)
 
         XCTAssertEqual(scheme.buttons.autoScroll.enabled, true)
+        XCTAssertEqual(scheme.buttons.autoScroll.toggleActivation, .longPress)
         XCTAssertEqual(scheme.buttons.autoScroll.modes, [.toggle, .hold])
         XCTAssertEqual(scheme.buttons.autoScroll.speed, 2)
         XCTAssertEqual(scheme.buttons.autoScroll.trigger?.button, .mouse(2))
@@ -289,6 +294,30 @@ final class ConfigurationTests: XCTestCase {
 
         XCTAssertEqual(autoScroll.modes, [.toggle, .hold])
         XCTAssertEqual(autoScroll.normalizedModes, [.toggle, .hold])
+    }
+
+    func testDecodeAutoScrollDefaultsToShortPressToggleActivation() throws {
+        let autoScroll = try JSONDecoder().decode(
+            Scheme.Buttons.AutoScroll.self,
+            from: XCTUnwrap(#"{"enabled":true}"#.data(using: .utf8))
+        )
+
+        XCTAssertNil(autoScroll.toggleActivation)
+        XCTAssertEqual(autoScroll.normalizedToggleActivation, .shortPress)
+    }
+
+    func testAutoScrollLongPressToggleActivationRoundTrips() throws {
+        let autoScroll = try JSONDecoder().decode(
+            Scheme.Buttons.AutoScroll.self,
+            from: XCTUnwrap(#"{"toggleActivation":"longPress"}"#.data(using: .utf8))
+        )
+
+        XCTAssertEqual(autoScroll.toggleActivation, .longPress)
+        XCTAssertEqual(autoScroll.normalizedToggleActivation, .longPress)
+
+        let encoded = try JSONEncoder().encode(autoScroll)
+        let object = try XCTUnwrap(JSONSerialization.jsonObject(with: encoded) as? [String: Any])
+        XCTAssertEqual(object["toggleActivation"] as? String, "longPress")
     }
 
     func testDecodeAutoScrollIgnoresRemovedPreserveNativeMiddleClickOption() throws {


### PR DESCRIPTION
## Summary

- Add short-press and long-press activation options for Auto Scroll toggle mode
- Reuse the existing button mapping long-press threshold
- Keep Hold to Scroll independent and activated only after crossing the dead zone
- Preserve short clicks when the long-press threshold is not reached
- Support both regular mouse buttons and Logitech controls
- Add the configuration schema, settings UI, and localized copy

## Testing

- All 550 unit tests pass
- SwiftFormat and SwiftLint pass with no serious violations