### PR TITLE
Fix AutoScroll accessibility hit-test latency and reliability

### DIFF
--- a/LinearMouse/Accessibility/AutoScrollAccessibilityActivationClassifier.swift
+++ b/LinearMouse/Accessibility/AutoScrollAccessibilityActivationClassifier.swift
@@ -3,11 +3,11 @@
 
 import ApplicationServices
 import CoreGraphics
+import Foundation
 
 struct AutoScrollAccessibilityActivationClassifier {
     private static let domClassListAttribute = "AXDOMClassList" as CFString
     private static let maxParentDepth = 20
-    private static let probeRadius: CGFloat = 4
     private static let standardWindowButtonAttributes = [
         kAXCloseButtonAttribute as CFString,
         kAXMinimizeButtonAttribute as CFString,
@@ -47,21 +47,30 @@ struct AutoScrollAccessibilityActivationClassifier {
 
     private let elementQuery: AccessibilityElementQuerying
     private let bypassRuleMatcher: AccessibilityBypassRuleMatcher
+    private let accessibilityHitTestRetryDelay: () -> Void
 
     init(
         elementQuery: AccessibilityElementQuerying = AccessibilityElementQuery(),
         bypassRuleMatcher: AccessibilityBypassRuleMatcher = AccessibilityBypassRuleMatcher(
             rules: AccessibilityBypassRule.autoScrollRules,
             scrollableRoles: Self.webContentRoles
-        )
+        ),
+        accessibilityHitTestRetryDelay: @escaping () -> Void = {
+            Thread.sleep(forTimeInterval: 0.005)
+        }
     ) {
         self.elementQuery = elementQuery
         self.bypassRuleMatcher = bypassRuleMatcher
+        self.accessibilityHitTestRetryDelay = accessibilityHitTestRetryDelay
     }
 
     func classify(at point: CGPoint) -> AutoScrollActivationClassification {
-        let initialProbe = AutoScrollActivationProbe(point: point, hit: hitAccessibilityElement(at: point))
-        let resolvedProbe = refineActivationProbe(from: initialProbe)
+        let initialResult = hitAccessibilityElement(at: point)
+        let initialProbe = AutoScrollActivationProbe(point: point, hit: initialResult.hit)
+        let resolvedProbe = refineActivationProbe(
+            from: initialProbe,
+            shouldRetryAtSamePoint: initialResult.shouldRetryAtSamePoint
+        )
         return AutoScrollActivationClassification(initial: initialProbe, resolved: resolvedProbe)
     }
 
@@ -78,61 +87,54 @@ struct AutoScrollAccessibilityActivationClassifier {
         return actions.contains(kAXPressAction as String)
     }
 
-    private func refineActivationProbe(from initialProbe: AutoScrollActivationProbe) -> AutoScrollActivationProbe {
-        guard initialProbe.hit.requiresAdditionalSampling else {
+    private func refineActivationProbe(
+        from initialProbe: AutoScrollActivationProbe,
+        shouldRetryAtSamePoint: Bool
+    ) -> AutoScrollActivationProbe {
+        guard shouldRetryAtSamePoint,
+              initialProbe.hit.requiresRetry else {
             return initialProbe
         }
 
-        // Browser accessibility trees can return a generic container chain for a point that
-        // is visually still inside a pressable element. Probe nearby points and preserve the
-        // native event if any sample resolves as pressable.
-        for point in accessibilityProbePoints(around: initialProbe.point) {
-            let sampledProbe = AutoScrollActivationProbe(point: point, hit: hitAccessibilityElement(at: point))
-            if sampledProbe.hit.isPressable {
-                return sampledProbe
-            }
-        }
-
-        return initialProbe
+        // Chromium documents that its first synchronous hit test can be approximate and
+        // that a subsequent hit test can use the asynchronously resolved renderer result:
+        // https://chromium.googlesource.com/chromium/src/+/main/docs/accessibility/browser/how_a11y_works_3.md#Hit-testing
+        // Chromium's regression test expects the first cached hit test to miss and the
+        // second hit test at the same point to return the correct element:
+        // https://chromium.googlesource.com/chromium/src/+/HEAD/content/browser/accessibility/hit_testing_browsertest.cc#710
+        // Safari also returned a transient kAXErrorNotImplemented during cold-start testing.
+        // Give either result a small window, then retry the original point so an adjacent
+        // control cannot change the activation decision.
+        accessibilityHitTestRetryDelay()
+        return AutoScrollActivationProbe(
+            point: initialProbe.point,
+            hit: hitAccessibilityElement(at: initialProbe.point).hit
+        )
     }
 
-    private func accessibilityProbePoints(around point: CGPoint) -> [CGPoint] {
-        let offsets = [
-            CGPoint.zero,
-            CGPoint(x: -Self.probeRadius, y: 0),
-            CGPoint(x: Self.probeRadius, y: 0),
-            CGPoint(x: 0, y: -Self.probeRadius),
-            CGPoint(x: 0, y: Self.probeRadius),
-            CGPoint(x: -Self.probeRadius, y: -Self.probeRadius),
-            CGPoint(x: -Self.probeRadius, y: Self.probeRadius),
-            CGPoint(x: Self.probeRadius, y: -Self.probeRadius),
-            CGPoint(x: Self.probeRadius, y: Self.probeRadius)
-        ]
-
-        return offsets.map { offset in
-            CGPoint(x: point.x + offset.x, y: point.y + offset.y)
-        }
-    }
-
-    private func hitAccessibilityElement(at point: CGPoint) -> AutoScrollActivationHit {
+    private func hitAccessibilityElement(at point: CGPoint) -> AccessibilityHitTestResult {
         let hitElement: AXUIElement?
         switch elementQuery.systemWideElement(at: point) {
         case let .success(value):
             hitElement = value
         case let .failure(error):
-            return .nonPressable(diagnostic: "hitTest.\(error.linearMouseDescription)", path: [])
+            return Self.failedQueryResult(stage: "hitTest", error: error, path: [])
         }
 
         guard let hitElement else {
-            return .nonPressable(diagnostic: nil, path: [])
+            return .certain(.nonPressable(diagnostic: nil, path: []))
         }
 
         var currentElement: AXUIElement? = hitElement
         var path: [String] = []
         var isInsideWebContent = false
+        var hasBrowserAccessibilitySignal = false
         for depth in 0 ..< Self.maxParentDepth {
             guard let element = currentElement else {
-                return .nonPressable(diagnostic: nil, path: path)
+                return .init(
+                    hit: .nonPressable(diagnostic: nil, path: path),
+                    shouldRetryAtSamePoint: hasBrowserAccessibilitySignal
+                )
             }
 
             let role: String?
@@ -140,7 +142,7 @@ struct AutoScrollAccessibilityActivationClassifier {
             case let .success(value):
                 role = value
             case let .failure(error):
-                return .nonPressable(diagnostic: "role.\(error.linearMouseDescription)", path: path)
+                return Self.failedQueryResult(stage: "role", error: error, path: path)
             }
 
             let subrole: String?
@@ -148,56 +150,89 @@ struct AutoScrollAccessibilityActivationClassifier {
             case let .success(value):
                 subrole = value
             case let .failure(error):
-                return .nonPressable(diagnostic: "subrole.\(error.linearMouseDescription)", path: path)
+                return Self.failedQueryResult(stage: "subrole", error: error, path: path)
             }
 
             let actions: [String]
-            switch elementQuery.optionalActionNames(of: element) {
-            case let .success(value):
-                actions = value
-            case let .failure(error):
-                return .nonPressable(diagnostic: "actions.\(error.linearMouseDescription)", path: path)
+            if Self.requiresActionNames(role: role, depth: depth) {
+                switch elementQuery.optionalActionNames(of: element) {
+                case let .success(value):
+                    actions = value
+                case let .failure(error):
+                    return Self.failedQueryResult(stage: "actions", error: error, path: path)
+                }
+            } else {
+                actions = []
             }
 
             path.append(Self.pathEntry(role: role, subrole: subrole, actions: actions))
 
+            if let role, Self.webContentRoles.contains(role) {
+                isInsideWebContent = true
+                if role == "AXWebArea" {
+                    hasBrowserAccessibilitySignal = true
+                }
+            }
+
+            // Native controls can return before querying browser-only AX attributes.
+            if !isInsideWebContent,
+               Self.isExcludedActivationElement(role: role, subrole: subrole) {
+                return .certain(.pressable(path: path))
+            }
+
+            if Self.isPressableActivationElement(role: role, actions: actions) {
+                return .certain(.pressable(path: path))
+            }
+
+            let domClassList = domClassList(of: element)
+            hasBrowserAccessibilitySignal = hasBrowserAccessibilitySignal || !domClassList.isEmpty
             if matchingBypassRule(
                 element,
                 depth: depth,
                 role: role,
                 subrole: subrole,
                 actions: actions,
+                domClassList: domClassList,
                 at: point
             ) != nil {
-                return .pressable(path: path)
-            }
-
-            if let role, Self.webContentRoles.contains(role) {
-                isInsideWebContent = true
-            }
-
-            // Once we have entered web content, ignore higher-level browser chrome ancestors
-            // like tab groups or toolbars. Safari and Chromium often expose those above the
-            // page content, and treating them as excluded chrome would block autoscroll on
-            // normal page clicks.
-            if !isInsideWebContent,
-               Self.isExcludedActivationElement(role: role, subrole: subrole) {
-                return .pressable(path: path)
-            }
-
-            if Self.isPressableActivationElement(role: role, actions: actions) {
-                return .pressable(path: path)
+                return .certain(.pressable(path: path))
             }
 
             switch elementQuery.optionalElementValue(of: kAXParentAttribute as CFString, on: element) {
             case let .success(value):
                 currentElement = value
             case let .failure(error):
-                return .nonPressable(diagnostic: "parent.\(error.linearMouseDescription)", path: path)
+                return Self.failedQueryResult(stage: "parent", error: error, path: path)
             }
         }
 
-        return .nonPressable(diagnostic: "depthLimit", path: path)
+        return .uncertain(.nonPressable(diagnostic: "depthLimit", path: path))
+    }
+
+    private static func failedQueryResult(
+        stage: String,
+        error: AXError,
+        path: [String]
+    ) -> AccessibilityHitTestResult {
+        let hit = AutoScrollActivationHit.nonPressable(
+            diagnostic: "\(stage).\(error.linearMouseDescription)",
+            path: path
+        )
+
+        switch error {
+        case .cannotComplete, .notImplemented:
+            return .uncertain(hit)
+        default:
+            return .certain(hit)
+        }
+    }
+
+    private static func requiresActionNames(role: String?, depth: Int) -> Bool {
+        guard let role else {
+            return false
+        }
+
+        return pressableRoles.contains(role) || (depth == 0 && role == "AXGroup")
     }
 
     private static func isExcludedActivationElement(role: String?, subrole: String?) -> Bool {
@@ -218,6 +253,7 @@ struct AutoScrollAccessibilityActivationClassifier {
         role: String?,
         subrole: String?,
         actions: [String],
+        domClassList: [String],
         at point: CGPoint
     ) -> AccessibilityBypassRule? {
         bypassRuleMatcher.firstMatchingRule(
@@ -226,7 +262,8 @@ struct AutoScrollAccessibilityActivationClassifier {
                 depth: depth,
                 role: role,
                 subrole: subrole,
-                actions: actions
+                actions: actions,
+                domClassList: domClassList
             ),
             in: AccessibilityBypassRuleContext(
                 point: point
@@ -239,23 +276,33 @@ struct AutoScrollAccessibilityActivationClassifier {
         depth: Int,
         role: String?,
         subrole: String?,
-        actions: [String]
+        actions: [String],
+        domClassList: [String]
     ) -> AccessibilityBypassElementSnapshot {
-        let parent = optionalParent(of: element)
+        let needsFullWindowGroupSnapshot = depth == 0
+            && role == "AXGroup"
+            && subrole == nil
+            && actions.isEmpty
+        let needsWindowSnapshot = role == "AXWindow"
+        // Geometry, child enumeration, and scrollbar queries cross the process boundary.
+        // Fetch them only when the cheap rule conditions leave a possible match.
+        let parent = needsFullWindowGroupSnapshot ? optionalParent(of: element) : nil
 
         return AccessibilityBypassElementSnapshot(
             depth: depth,
             role: role,
             subrole: subrole,
             actions: actions,
-            frame: frame(of: element),
+            frame: needsFullWindowGroupSnapshot || needsWindowSnapshot ? frame(of: element) : nil,
             parentRole: parent.flatMap { self.role(of: $0) },
             parentFrame: parent.flatMap { frame(of: $0) },
-            children: immediateChildren(of: element).map(childSnapshot),
-            hasVerticalScrollBar: hasAttributeValue(kAXVerticalScrollBarAttribute as CFString, on: element),
-            hasHorizontalScrollBar: hasAttributeValue(kAXHorizontalScrollBarAttribute as CFString, on: element),
-            domClassList: domClassList(of: element),
-            standardWindowButtonFrames: role == "AXWindow" ? standardWindowButtonFrames(of: element) : []
+            children: needsFullWindowGroupSnapshot ? immediateChildren(of: element).map(childSnapshot) : [],
+            hasVerticalScrollBar: needsFullWindowGroupSnapshot
+                && hasAttributeValue(kAXVerticalScrollBarAttribute as CFString, on: element),
+            hasHorizontalScrollBar: needsFullWindowGroupSnapshot
+                && hasAttributeValue(kAXHorizontalScrollBarAttribute as CFString, on: element),
+            domClassList: domClassList,
+            standardWindowButtonFrames: needsWindowSnapshot ? standardWindowButtonFrames(of: element) : []
         )
     }
 
@@ -368,6 +415,19 @@ struct AutoScrollActivationProbe {
     let hit: AutoScrollActivationHit
 }
 
+private struct AccessibilityHitTestResult {
+    let hit: AutoScrollActivationHit
+    let shouldRetryAtSamePoint: Bool
+
+    static func certain(_ hit: AutoScrollActivationHit) -> Self {
+        .init(hit: hit, shouldRetryAtSamePoint: false)
+    }
+
+    static func uncertain(_ hit: AutoScrollActivationHit) -> Self {
+        .init(hit: hit, shouldRetryAtSamePoint: true)
+    }
+}
+
 enum AutoScrollActivationHit {
     case pressable(path: [String])
     case nonPressable(diagnostic: String?, path: [String])
@@ -397,7 +457,7 @@ enum AutoScrollActivationHit {
         return false
     }
 
-    var requiresAdditionalSampling: Bool {
+    var requiresRetry: Bool {
         !isPressable
     }
 }

--- a/LinearMouseUnitTests/Accessibility/AutoScrollAccessibilityActivationClassifierTests.swift
+++ b/LinearMouseUnitTests/Accessibility/AutoScrollAccessibilityActivationClassifierTests.swift
@@ -6,11 +6,11 @@ import ApplicationServices
 import XCTest
 
 final class AutoScrollAccessibilityActivationClassifierTests: XCTestCase {
-    func testPressableHitPreservesNativeEventWithoutAdditionalSampling() {
+    func testPressableHitPreservesNativeEventWithoutRetry() {
         let hit = AutoScrollActivationHit.pressable(path: ["AXButton[press]"])
 
         XCTAssertTrue(hit.isPressable)
-        XCTAssertFalse(hit.requiresAdditionalSampling)
+        XCTAssertFalse(hit.requiresRetry)
         XCTAssertEqual(hit.summary, "pressable")
     }
 
@@ -21,7 +21,7 @@ final class AutoScrollAccessibilityActivationClassifierTests: XCTestCase {
         )
 
         XCTAssertFalse(hit.isPressable)
-        XCTAssertTrue(hit.requiresAdditionalSampling)
+        XCTAssertTrue(hit.requiresRetry)
         XCTAssertEqual(hit.summary, "nonPressable.role.cannotComplete")
     }
 
@@ -69,5 +69,193 @@ final class AutoScrollAccessibilityActivationClassifierTests: XCTestCase {
             role: nil,
             actions: [kAXPressAction as String]
         ))
+    }
+
+    func testNativeNonPressableHitDoesNotRetry() {
+        let elementQuery = AccessibilityElementQuerySpy(role: "AXStaticText")
+        let classifier = AutoScrollAccessibilityActivationClassifier(elementQuery: elementQuery)
+
+        let classification = classifier.classify(at: CGPoint(x: 100, y: 100))
+
+        XCTAssertFalse(classification.resolved.hit.isPressable)
+        XCTAssertEqual(elementQuery.hitTestCount, 1)
+        XCTAssertEqual(elementQuery.actionNamesCount, 0)
+    }
+
+    func testNativeScrollAreaDoesNotTriggerBrowserRetry() {
+        let elementQuery = AccessibilityElementQuerySpy(role: "AXScrollArea")
+        let classifier = AutoScrollAccessibilityActivationClassifier(elementQuery: elementQuery)
+
+        let classification = classifier.classify(at: CGPoint(x: 100, y: 100))
+
+        XCTAssertFalse(classification.resolved.hit.isPressable)
+        XCTAssertEqual(elementQuery.hitTestCount, 1)
+    }
+
+    func testWebContentNonPressableHitRetriesOriginalPointOnce() {
+        let elementQuery = AccessibilityElementQuerySpy(role: "AXWebArea")
+        var retryDelayCount = 0
+        let classifier = AutoScrollAccessibilityActivationClassifier(
+            elementQuery: elementQuery
+        ) {
+            retryDelayCount += 1
+        }
+        let point = CGPoint(x: 100, y: 100)
+
+        let classification = classifier.classify(at: point)
+
+        XCTAssertFalse(classification.resolved.hit.isPressable)
+        XCTAssertEqual(elementQuery.hitTestCount, 2)
+        XCTAssertEqual(elementQuery.hitTestPoints, [point, point])
+        XCTAssertEqual(retryDelayCount, 1)
+        XCTAssertEqual(elementQuery.actionNamesCount, 0)
+    }
+
+    func testWebContentRetryCanResolvePressableAtOriginalPoint() {
+        let elementQuery = AccessibilityElementQuerySpy(rolesByHit: ["AXWebArea", "AXLink"])
+        let point = CGPoint(x: 100, y: 100)
+        let classifier = AutoScrollAccessibilityActivationClassifier(
+            elementQuery: elementQuery
+        ) {}
+
+        let classification = classifier.classify(at: point)
+
+        XCTAssertFalse(classification.initial.hit.isPressable)
+        XCTAssertTrue(classification.resolved.hit.isPressable)
+        XCTAssertEqual(classification.resolved.point, point)
+        XCTAssertEqual(elementQuery.hitTestPoints, [point, point])
+    }
+
+    func testTransientHitTestFailureRetriesOriginalPoint() {
+        let elementQuery = AccessibilityElementQuerySpy(
+            role: "AXLink",
+            initialHitTestFailure: .notImplemented
+        )
+        let point = CGPoint(x: 100, y: 100)
+        let classifier = AutoScrollAccessibilityActivationClassifier(
+            elementQuery: elementQuery
+        ) {}
+
+        let classification = classifier.classify(at: point)
+
+        XCTAssertEqual(classification.initial.hit.summary, "nonPressable.hitTest.notImplemented")
+        XCTAssertTrue(classification.resolved.hit.isPressable)
+        XCTAssertEqual(elementQuery.hitTestPoints, [point, point])
+    }
+
+    func testCannotCompleteHitTestFailureRetriesOriginalPoint() {
+        let elementQuery = AccessibilityElementQuerySpy(
+            role: "AXLink",
+            initialHitTestFailure: .cannotComplete
+        )
+        let point = CGPoint(x: 100, y: 100)
+        let classifier = AutoScrollAccessibilityActivationClassifier(
+            elementQuery: elementQuery
+        ) {}
+
+        let classification = classifier.classify(at: point)
+
+        XCTAssertEqual(classification.initial.hit.summary, "nonPressable.hitTest.cannotComplete")
+        XCTAssertTrue(classification.resolved.hit.isPressable)
+        XCTAssertEqual(elementQuery.hitTestPoints, [point, point])
+    }
+
+    func testPermanentHitTestFailureDoesNotRetry() {
+        let elementQuery = AccessibilityElementQuerySpy(
+            role: "AXLink",
+            initialHitTestFailure: .invalidUIElement
+        )
+        var retryDelayCount = 0
+        let point = CGPoint(x: 100, y: 100)
+        let classifier = AutoScrollAccessibilityActivationClassifier(
+            elementQuery: elementQuery
+        ) {
+            retryDelayCount += 1
+        }
+
+        let classification = classifier.classify(at: point)
+
+        XCTAssertEqual(classification.resolved.hit.summary, "nonPressable.hitTest.invalidUIElement")
+        XCTAssertEqual(elementQuery.hitTestPoints, [point])
+        XCTAssertEqual(retryDelayCount, 0)
+    }
+}
+
+private final class AccessibilityElementQuerySpy: AccessibilityElementQuerying {
+    private let element = AXUIElementCreateSystemWide()
+    private let rolesByHit: [String]
+    private let initialHitTestFailure: AXError?
+
+    private(set) var hitTestCount = 0
+    private(set) var hitTestPoints: [CGPoint] = []
+    private(set) var actionNamesCount = 0
+
+    init(role: String, initialHitTestFailure: AXError? = nil) {
+        rolesByHit = [role]
+        self.initialHitTestFailure = initialHitTestFailure
+    }
+
+    init(rolesByHit: [String]) {
+        self.rolesByHit = rolesByHit
+        initialHitTestFailure = nil
+    }
+
+    func systemWideElement(at point: CGPoint) -> AccessibilityQueryResult<AXUIElement?> {
+        hitTestCount += 1
+        hitTestPoints.append(point)
+        if hitTestCount == 1, let initialHitTestFailure {
+            return .failure(initialHitTestFailure)
+        }
+        return .success(element)
+    }
+
+    func element(at _: CGPoint, in _: AXUIElement) -> AccessibilityQueryResult<AXUIElement?> {
+        XCTFail("Unexpected rooted hit test")
+        return .success(nil)
+    }
+
+    func requiredStringValue(of attribute: CFString, on _: AXUIElement) -> AccessibilityQueryResult<String?> {
+        XCTAssertEqual(attribute, kAXRoleAttribute as CFString)
+        let roleIndex = min(max(hitTestCount - 1, 0), rolesByHit.count - 1)
+        return .success(rolesByHit[roleIndex])
+    }
+
+    func optionalStringValue(of _: CFString, on _: AXUIElement) -> AccessibilityQueryResult<String?> {
+        .success(nil)
+    }
+
+    func optionalElementValue(of _: CFString, on _: AXUIElement) -> AccessibilityQueryResult<AXUIElement?> {
+        .success(nil)
+    }
+
+    // swiftlint:disable discouraged_optional_collection
+    func optionalElementArrayValue(
+        of _: CFString,
+        on _: AXUIElement
+    ) -> AccessibilityQueryResult<[AXUIElement]?> {
+        .success(nil)
+    }
+
+    // swiftlint:enable discouraged_optional_collection
+
+    func optionalAttributeValue(of _: CFString, on _: AXUIElement) -> AccessibilityQueryResult<CFTypeRef?> {
+        .success(nil)
+    }
+
+    func optionalPointValue(of _: CFString, on _: AXUIElement) -> AccessibilityQueryResult<CGPoint?> {
+        .success(nil)
+    }
+
+    func optionalSizeValue(of _: CFString, on _: AXUIElement) -> AccessibilityQueryResult<CGSize?> {
+        .success(nil)
+    }
+
+    func optionalFrameValue(of _: AXUIElement) -> AccessibilityQueryResult<CGRect?> {
+        .success(nil)
+    }
+
+    func optionalActionNames(of _: AXUIElement) -> AccessibilityQueryResult<[String]> {
+        actionNamesCount += 1
+        return .success([])
     }
 }


### PR DESCRIPTION
## Summary

- Avoid unnecessary cross-process accessibility queries while classifying native UI elements.
- Replace nearby-point sampling with a single retry at the original click position.
- Retry only for browser accessibility signals or recoverable AX errors (`cannotComplete` and `notImplemented`).
- Lazily collect expensive action, geometry, child, and scrollbar information only when required.

## Background

PR #1340 first identified that `AutoScrollAccessibilityActivationClassifier`
performed nearby-point resampling for every non-pressable hit. Because Auto Scroll
normally starts on non-pressable areas, native views such as Finder could perform up
to nine additional synchronous AX hit tests before showing the Auto Scroll indicator.

#1340 addressed the latency by restricting nearby sampling to web content and stopping
ancestor traversal at list containers. This PR supersedes that approach with a more
targeted implementation:

- Native non-pressable elements return immediately without additional hit tests.
- Full ancestor traversal is preserved so list containers do not change classification
  semantics.
- Expensive AX attributes are queried lazily instead of truncating the ancestor walk.
- Nearby coordinates are no longer sampled, avoiding decisions based on adjacent
  controls.
- Browser uncertainty is handled by waiting 5 ms and retrying the original position
  once.

Chromium documents that its first synchronous accessibility hit test can be an
approximate bounding-box result while the renderer resolves the precise result
asynchronously. Its regression test likewise expects the first cached hit test to miss
and the second hit test at the same point to succeed.

- Architecture documentation:
  https://chromium.googlesource.com/chromium/src/+/main/docs/accessibility/browser/how_a11y_works_3.md#Hit-testing
- Chromium regression test:
  https://chromium.googlesource.com/chromium/src/+/HEAD/content/browser/accessibility/hit_testing_browsertest.cc#710

Safari was also observed returning a transient `kAXErrorNotImplemented` during a cold
web accessibility hit test. The retry is therefore limited to browser signals and
recoverable AX errors. Permanent errors such as `invalidUIElement` retain their
diagnostics and return immediately.

The `activateOverPressableElements` option proposed by #1340 is intentionally not
included. The press-and-drag workflow from #1339 has since been addressed separately
by #1348 using long-press activation, without restoring a native middle-click override.

Thanks to @gilang-gunawan for identifying the unconditional AX resampling bottleneck,
providing measurements, and proposing the original fix in #1340.

## Testing

- Verified Auto Scroll classification in the current Finder list view.
  - Steady-state classification decreased from approximately 480–500 ms to 1.2–1.4 ms.
  - Native non-pressable elements perform one hit test without the retry delay.
- Verified a cold Chrome hit changes from a generic non-pressable container to an
  `AXLink` after retrying the same position.
- Verified a cold Safari hit changes from `hitTest.notImplemented` to an `AXLink`
  after retrying the same position.
- Verified `cannotComplete` and `notImplemented` retry.
- Verified permanent AX errors do not retry.
- All 557 unit tests pass.
- Strict SwiftLint passes with no violations.

Closes #1340