### PR TITLE
Fix right-click fallback for button gesture mappings

### DIFF
--- a/LinearMouse/EventTransformer/ButtonMappingTransformer.swift
+++ b/LinearMouse/EventTransformer/ButtonMappingTransformer.swift
@@ -9,6 +9,8 @@ final class ButtonMappingTransformer: EventTransformer, DeferredEventTransformer
     typealias Mapping = Scheme.Buttons.Mapping
     typealias TimerScheduler = (TimeInterval, @escaping () -> Void) -> TimerToken?
     typealias MonotonicClock = () -> UInt64
+    typealias AsyncScheduler = (@escaping () -> Void) -> Void
+    typealias DelayedScheduler = (TimeInterval, @escaping () -> Void) -> Void
 
     final class TimerToken {
         private var invalidateHandler: (() -> Void)?
@@ -30,6 +32,13 @@ final class ButtonMappingTransformer: EventTransformer, DeferredEventTransformer
     private struct DeferredEvent {
         var event: CGEvent
         var sink: (CGEvent) -> Void
+    }
+
+    private struct SyntheticClickRequest {
+        var button: CGMouseButton
+        var location: CGPoint
+        var flags: CGEventFlags
+        var clickState: Int64
     }
 
     private final class RecognitionLane {
@@ -57,6 +66,7 @@ final class ButtonMappingTransformer: EventTransformer, DeferredEventTransformer
         subsystem: Bundle.main.bundleIdentifier!,
         category: "ButtonMapping"
     )
+    private static let syntheticClickReleaseDelay: TimeInterval = 0.015
 
     let mappings: [Mapping]
     let universalBackForward: Scheme.Buttons.UniversalBackForward?
@@ -64,6 +74,9 @@ final class ButtonMappingTransformer: EventTransformer, DeferredEventTransformer
     private let scheduleTimer: TimerScheduler
     private let monotonicClock: MonotonicClock
     private let fallbackEventSink: (CGEvent) -> Void
+    private let syntheticClickScheduler: AsyncScheduler
+    private let syntheticClickReleaseScheduler: DelayedScheduler
+    private let syntheticClickEventSink: (CGEvent) -> Void
     private let swapsPrimaryAndSecondaryButtons: Bool
     private let gestureTransformer: GestureButtonTransformer?
     private let policy: ButtonMappingPolicy
@@ -83,7 +96,12 @@ final class ButtonMappingTransformer: EventTransformer, DeferredEventTransformer
         monotonicClock: @escaping MonotonicClock = { DispatchTime.now().uptimeNanoseconds },
         keySimulator: KeySimulating? = nil,
         gestureTransformer: GestureButtonTransformer? = nil,
-        eventSink: @escaping (CGEvent) -> Void = { $0.post(tap: .cgSessionEventTap) }
+        eventSink: @escaping (CGEvent) -> Void = { $0.post(tap: .cgSessionEventTap) },
+        syntheticClickScheduler: @escaping AsyncScheduler = ButtonMappingTransformer
+            .scheduleSyntheticClickReplay,
+        syntheticClickReleaseScheduler: @escaping DelayedScheduler = ButtonMappingTransformer
+            .scheduleSyntheticClickRelease,
+        syntheticClickEventSink: @escaping (CGEvent) -> Void = { $0.post(tap: .cghidEventTap) }
     ) {
         self.mappings = mappings
         self.universalBackForward = universalBackForward
@@ -95,6 +113,9 @@ final class ButtonMappingTransformer: EventTransformer, DeferredEventTransformer
         self.scheduleTimer = scheduleTimer
         self.monotonicClock = monotonicClock
         fallbackEventSink = eventSink
+        self.syntheticClickScheduler = syntheticClickScheduler
+        self.syntheticClickReleaseScheduler = syntheticClickReleaseScheduler
+        self.syntheticClickEventSink = syntheticClickEventSink
         self.swapsPrimaryAndSecondaryButtons = swapsPrimaryAndSecondaryButtons
         self.gestureTransformer = gestureTransformer
     }
@@ -437,12 +458,103 @@ final class ButtonMappingTransformer: EventTransformer, DeferredEventTransformer
         if output.replaysBufferedEvents {
             let events = lane?.bufferedEvents ?? []
             lane?.bufferedEvents.removeAll()
-            for deferredEvent in events {
-                deferredEvent.sink(deferredEvent.event)
+            if let request = syntheticClickRequest(from: events) {
+                replaySyntheticClick(request)
+            } else {
+                for deferredEvent in events {
+                    deferredEvent.sink(deferredEvent.event)
+                }
             }
         } else if output.discardsBufferedEvents {
             lane?.bufferedEvents.removeAll()
         }
+    }
+
+    /// A completed fallback is a semantic click, not a delayed copy of the
+    /// physical stream. Rebuild it at delivery time so stale timestamps,
+    /// annotations, and sub-threshold drag events do not reach the target app.
+    private func syntheticClickRequest(from events: [DeferredEvent]) -> SyntheticClickRequest? {
+        guard events.count >= 2,
+              let down = events.first?.event,
+              let up = events.last?.event,
+              let button = MouseEventView(down).mouseButton,
+              down.type == button.fixedCGEventType(of: .otherMouseDown),
+              up.type == button.fixedCGEventType(of: .otherMouseUp),
+              MouseEventView(up).mouseButton == button else {
+            return nil
+        }
+
+        let draggedType = button.fixedCGEventType(of: .otherMouseDragged)
+        guard events.dropFirst().dropLast().allSatisfy({ deferredEvent in
+            deferredEvent.event.type == draggedType &&
+                MouseEventView(deferredEvent.event).mouseButton == button
+        }) else {
+            return nil
+        }
+
+        return .init(
+            button: button,
+            location: down.location,
+            flags: down.flags,
+            clickState: down.getIntegerValueField(.mouseEventClickState)
+        )
+    }
+
+    private func replaySyntheticClick(_ request: SyntheticClickRequest) {
+        let eventSink = syntheticClickEventSink
+        let releaseScheduler = syntheticClickReleaseScheduler
+        syntheticClickScheduler {
+            guard let source = CGEventSource(stateID: .hidSystemState),
+                  let down = Self.makeSyntheticClickEvent(request, source: source, pressed: true) else {
+                os_log("Failed to create synthetic fallback mouse down", log: Self.log, type: .error)
+                return
+            }
+
+            eventSink(down)
+            releaseScheduler(Self.syntheticClickReleaseDelay) {
+                guard let up = Self.makeSyntheticClickEvent(request, source: source, pressed: false) else {
+                    os_log("Failed to create synthetic fallback mouse up", log: Self.log, type: .error)
+                    return
+                }
+                eventSink(up)
+            }
+        }
+    }
+
+    private static func scheduleSyntheticClickReplay(_ handler: @escaping () -> Void) {
+        if !EventThread.shared.perform(handler) {
+            DispatchQueue.main.async(execute: handler)
+        }
+    }
+
+    private static func scheduleSyntheticClickRelease(
+        after delay: TimeInterval,
+        _ handler: @escaping () -> Void
+    ) {
+        DispatchQueue.main.asyncAfter(deadline: .now() + delay, execute: handler)
+    }
+
+    private static func makeSyntheticClickEvent(
+        _ request: SyntheticClickRequest,
+        source: CGEventSource,
+        pressed: Bool
+    ) -> CGEvent? {
+        guard let event = CGEvent(
+            mouseEventSource: source,
+            mouseType: request.button.fixedCGEventType(
+                of: pressed ? .otherMouseDown : .otherMouseUp
+            ),
+            mouseCursorPosition: request.location,
+            mouseButton: request.button
+        ) else {
+            return nil
+        }
+
+        event.flags = request.flags
+        event.setIntegerValueField(.mouseEventButtonNumber, value: Int64(request.button.rawValue))
+        event.setIntegerValueField(.mouseEventClickState, value: request.clickState)
+        event.isLinearMouseSyntheticEvent = true
+        return event
     }
 
     private func cancelCompetingGestureIfNeeded(

--- a/LinearMouse/EventTransformer/SwitchPrimaryAndSecondaryButtonsTransformer.swift
+++ b/LinearMouse/EventTransformer/SwitchPrimaryAndSecondaryButtonsTransformer.swift
@@ -15,6 +15,11 @@ class SwitchPrimaryAndSecondaryButtonsTransformer {
 
 extension SwitchPrimaryAndSecondaryButtonsTransformer: EventTransformer {
     func transform(_ event: CGEvent, in _: EventTransformerContext) -> CGEvent? {
+        // Replayed clicks have already passed through this transformer once.
+        guard !event.isLinearMouseSyntheticEvent else {
+            return event
+        }
+
         let mouseEventView = MouseEventView(event)
 
         guard var mouseButton = mouseEventView.mouseButton else {

--- a/LinearMouseUnitTests/EventTransformer/ButtonMappingTransformerTests.swift
+++ b/LinearMouseUnitTests/EventTransformer/ButtonMappingTransformerTests.swift
@@ -373,6 +373,60 @@ final class ButtonMappingTransformerTests: XCTestCase {
         XCTAssertEqual(replayed, [.otherMouseDown, .otherMouseUp])
     }
 
+    func testUndefinedShortPressRebuildsFreshClickAfterCallbackAndDropsDrag() throws {
+        let scheduler = ButtonMappingTestTimerScheduler()
+        var scheduledReplay: (() -> Void)?
+        var scheduledRelease: (() -> Void)?
+        var scheduledReleaseDelay: TimeInterval?
+        var replayed = [CGEvent]()
+        let mapping = Mapping(
+            trigger: .init(input: .button(.mouse(1)), modifiers: [.shift]),
+            outcomes: .init(longPress: .arg0(.none))
+        )
+        let transformer = ButtonMappingTransformer(
+            mappings: [mapping],
+            scheduleTimer: scheduler.schedule,
+            monotonicClock: { scheduler.now },
+            syntheticClickScheduler: { scheduledReplay = $0 },
+            syntheticClickReleaseScheduler: { delay, handler in
+                scheduledReleaseDelay = delay
+                scheduledRelease = handler
+            },
+            syntheticClickEventSink: { replayed.append($0) }
+        )
+
+        let down = try buttonEvent(button: 1, pressed: true)
+        down.location = .init(x: 120, y: 80)
+        down.flags = [.maskShift]
+        down.setIntegerValueField(.mouseEventClickState, value: 2)
+        let drag = try draggedEvent(button: 1, deltaX: 3)
+        let up = try buttonEvent(button: 1, pressed: false)
+
+        XCTAssertNil(transformer.transform(down, in: .init(device: nil)))
+        XCTAssertNil(transformer.transform(drag, in: .init(device: nil)))
+        XCTAssertNil(transformer.transform(up, in: .init(device: nil)))
+        XCTAssertTrue(replayed.isEmpty)
+
+        try XCTUnwrap(scheduledReplay)()
+
+        XCTAssertEqual(replayed.map(\.type), [.rightMouseDown])
+        XCTAssertEqual(try XCTUnwrap(scheduledReleaseDelay), 0.015, accuracy: 0.000001)
+
+        try XCTUnwrap(scheduledRelease)()
+
+        XCTAssertEqual(replayed.map(\.type), [.rightMouseDown, .rightMouseUp])
+        XCTAssertNotIdentical(replayed[0], down)
+        XCTAssertNotIdentical(replayed[1], up)
+        XCTAssertEqual(replayed.map { MouseEventView($0).mouseButton }, [.right, .right])
+        XCTAssertEqual(replayed.map(\.location), [down.location, down.location])
+        XCTAssertEqual(replayed.map(\.flags), [down.flags, down.flags])
+        XCTAssertEqual(
+            replayed.map { $0.getIntegerValueField(.mouseEventClickState) },
+            [2, 2]
+        )
+        XCTAssertTrue(replayed.allSatisfy(\.isLinearMouseSyntheticEvent))
+    }
+
     func testCommittedLongPressDoesNotLeakIntoIndependentFallbackStream() throws {
         let scheduler = ButtonMappingTestTimerScheduler()
         var deliveredEvents = [CGEvent]()
@@ -1233,7 +1287,10 @@ final class ButtonMappingTransformerTests: XCTestCase {
             monotonicClock: { scheduler.now },
             keySimulator: keySimulator,
             gestureTransformer: gestureTransformer,
-            eventSink: eventSink
+            eventSink: eventSink,
+            syntheticClickScheduler: { $0() },
+            syntheticClickReleaseScheduler: { _, handler in handler() },
+            syntheticClickEventSink: eventSink
         )
     }
 


### PR DESCRIPTION
## Summary

- Rebuild completed button-mapping fallback clicks as fresh `CGEvent` instances instead of replaying the buffered physical events.
- Replay the click after the current Event Tap callback and post it through the HID event tap.
- Deliver mouse-up asynchronously 15 ms after mouse-down, giving applications an observable pressed state without blocking the Event Tap thread.
- Drop sub-threshold drag events while preserving the original button, location, flags, and click state.
- Prevent replayed events from being processed by the primary/secondary button swap transformer a second time.

## Background

When a mouse button is configured as a gesture trigger, its down, drag, and up events are buffered until the gesture is resolved. If movement remains below the gesture threshold, the interaction should fall back to a normal click.

Previously, the buffered event objects were replayed together through the session event tap. This worked in most applications, but right-click fallback could be ignored by applications such as Messages.

The fallback now creates a new semantic click after the original callback has completed. Mouse-down and mouse-up are created at their respective delivery times and separated by a non-blocking 15 ms interval.

Incomplete buffered streams used by chord and remap handling continue to use the existing replay path.

## Testing

- Verified right-click context menus in Messages with a right-button drag gesture mapping configured.
- Added coverage confirming that fallback clicks:
  - are delivered after the original callback
  - use newly created mouse-down and mouse-up events
  - omit buffered sub-threshold drag events
  - preserve click metadata
  - separate mouse-down and mouse-up by 15 ms
- All 558 unit tests pass.
- SwiftFormat and strict SwiftLint pass for the changed files.
- `git diff --check`