### PR TITLE
Restore the pointer-speed schema minimum a JSDoc typo dropped

### DIFF
--- a/Documentation/Configuration.d.ts
+++ b/Documentation/Configuration.d.ts
@@ -419,7 +419,7 @@ declare namespace Scheme {
     /**
      * @title Pointer speed
      * @description A number to set speed, or "unset" to restore device default. If omitted, the previous/merged value applies.
-     * @minimal 0
+     * @minimum 0
      * @maximum 1
      */
     speed?: number | Unset;

--- a/Documentation/Configuration.json
+++ b/Documentation/Configuration.json
@@ -1447,6 +1447,7 @@
           ],
           "description": "A number to set speed, or \"unset\" to restore device default. If omitted, the previous/merged value applies.",
           "maximum": 1,
+          "minimum": 0,
           "title": "Pointer speed"
         }
       },

--- a/LinearMouseUnitTests/Model/ConfigurationSchemaTests.swift
+++ b/LinearMouseUnitTests/Model/ConfigurationSchemaTests.swift
@@ -1,0 +1,62 @@
+// MIT License
+// Copyright (c) 2021-2026 LinearMouse
+
+import Foundation
+import XCTest
+
+final class ConfigurationSchemaTests: XCTestCase {
+    /// The committed JSON schema is generated from `Documentation/Configuration.d.ts`
+    /// and lives outside the test bundle. Resolve it by walking up from this source
+    /// file to the repository root, which stays valid regardless of the checkout path.
+    private func configurationSchemaURL() throws -> URL {
+        var url = URL(fileURLWithPath: #filePath).deletingLastPathComponent()
+        for _ in 0 ..< 10 {
+            let candidate = url.appendingPathComponent("Documentation/Configuration.json")
+            if FileManager.default.fileExists(atPath: candidate.path) {
+                return candidate
+            }
+            url = url.deletingLastPathComponent()
+        }
+        throw NSError(
+            domain: "ConfigurationSchemaTests",
+            code: 1,
+            userInfo: [NSLocalizedDescriptionKey: "Could not locate Documentation/Configuration.json from \(#filePath)"]
+        )
+    }
+
+    private func definition(
+        named name: String,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) throws -> [String: Any] {
+        let url = try configurationSchemaURL()
+        let data = try Data(contentsOf: url)
+        let json = try JSONSerialization.jsonObject(with: data) as? [String: Any]
+        let definitions = try XCTUnwrap(json?["definitions"] as? [String: Any], file: file, line: line)
+        return try XCTUnwrap(definitions[name] as? [String: Any], "Missing definition \(name)", file: file, line: line)
+    }
+
+    /// The Pointer speed field clamps to `0 ... 1` in the Swift runtime
+    /// (`Scheme.Speed.range`). The JSDoc tag producing the lower bound was
+    /// misspelled `@minimal` instead of `@minimum`, so the schema generator
+    /// dropped it: the published schema admitted negative speeds while the
+    /// runtime rejected them. Pin both bounds so the schema keeps tracking the
+    /// runtime clamp.
+    func testPointerSpeedDeclaresBothBounds() throws {
+        let pointer = try definition(named: "Scheme.Pointer")
+        let properties = try XCTUnwrap(pointer["properties"] as? [String: Any])
+        let speed = try XCTUnwrap(properties["speed"] as? [String: Any], "Missing Pointer.speed property")
+
+        let minimum = try XCTUnwrap(
+            (speed["minimum"] as? NSNumber)?.doubleValue,
+            "Pointer speed must declare a minimum bound matching the runtime clamp (0 ... 1)."
+        )
+        let maximum = try XCTUnwrap(
+            (speed["maximum"] as? NSNumber)?.doubleValue,
+            "Pointer speed must keep its maximum bound (regression guard)."
+        )
+
+        XCTAssertEqual(minimum, 0, accuracy: 1e-9, "Pointer speed minimum should be 0.")
+        XCTAssertEqual(maximum, 1, accuracy: 1e-9, "Pointer speed maximum should be 1.")
+    }
+}


### PR DESCRIPTION
## Summary

`Scheme.Pointer.speed` clamps to `0 ... 1` in the Swift runtime (`Scheme.Speed.range`), but the JSON-schema tag documenting the lower bound was misspelled `@minimal` instead of `@minimum`. `ts-json-schema-generator` silently dropped an unknown tag, so the published `Documentation/Configuration.json` admitted negative speeds while the runtime rejected them.

## Root Cause

`Documentation/Configuration.d.ts` line ~422: `@minimal 0` → the generator emits `minimum` only for `@minimum`; `@minimal` is ignored, so the lower bound never reached the schema.

## Changes

- `Documentation/Configuration.d.ts`: `@minimal 0` -> `@minimum 0`.
- `Documentation/Configuration.json`: regenerated (the pre-commit hook does this from the `.d.ts` source of truth).
- `LinearMouseUnitTests/Model/ConfigurationSchemaTests.swift`: new `ConfigurationSchemaTests` pinning both `Pointer.speed` bounds (`minimum == 0`, `maximum == 1`) as a regression guard, so the schema cannot silently drift from the runtime clamp again.

## Verification

`make configure clean lint test XCODEBUILD_ARGS="CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY= DEVELOPMENT_TEAM="`:
- `swiftformat --lint .` — no new violations vs `main`
- `swiftlint .` — 0 serious
- New `ConfigurationSchemaTests/testPointerSpeedDeclaresBothBounds` passes