### PR TITLE
Accept a zero gesture dead-zone instead of disabling all gestures

### DIFF
--- a/LinearMouse/EventTransformer/GestureButtonTransformer.swift
+++ b/LinearMouse/EventTransformer/GestureButtonTransformer.swift
@@ -249,7 +249,7 @@ extension GestureButtonTransformer: EventTransformer {
         // Determine dominant axis
         if absDeltaX > absDeltaY {
             // Horizontal gesture
-            guard absDeltaY < deadZone else {
+            guard absDeltaY <= deadZone else {
 //                os_log(
 //                    "Horizontal gesture rejected: absDeltaY=%.1f >= deadZone=%.1f",
 //                    log: Self.log,
@@ -263,7 +263,7 @@ extension GestureButtonTransformer: EventTransformer {
             return deltaX > 0 ? (actions.right ?? .spaceRight) : (actions.left ?? .spaceLeft)
         }
         // Vertical gesture
-        guard absDeltaX < deadZone else {
+        guard absDeltaX <= deadZone else {
 //                os_log(
 //                    "Vertical gesture rejected: absDeltaX=%.1f >= deadZone=%.1f",
 //                    log: Self.log,

--- a/LinearMouseUnitTests/EventTransformer/GestureButtonTransformerTests.swift
+++ b/LinearMouseUnitTests/EventTransformer/GestureButtonTransformerTests.swift
@@ -29,12 +29,13 @@ private func makeLogitechGestureTransformer(
     trigger: Scheme.Buttons.Mapping = .init(
         button: .logitechControl(.init(controlID: testLogitechControlID))
     ),
+    deadZone: Double = testGestureDeadZone,
     cooldownMs: Int = testGestureCooldownMs
 ) -> GestureButtonTransformer {
     GestureButtonTransformer(
         trigger: trigger,
         threshold: testGestureThreshold,
-        deadZone: testGestureDeadZone,
+        deadZone: deadZone,
         cooldownMs: cooldownMs,
         actions: .init(right: Scheme.Buttons.Gesture.GestureAction.none)
     )
@@ -175,5 +176,39 @@ final class GestureButtonTransformerTests: XCTestCase {
             transformer.handleLogitechControlEvent(logitechContext(pressed: false)),
             .handled
         )
+    }
+
+    func testZeroDeadZoneAcceptsPerfectlyAxialGesture() throws {
+        // deadZone 0 is valid (`@minimum 0`, default 40) and must mean "only
+        // perfectly axial gestures are accepted", not "all gestures disabled".
+        let transformer = makeLogitechGestureTransformer(deadZone: 0)
+
+        XCTAssertEqual(
+            transformer.handleLogitechControlEvent(logitechContext(pressed: true)),
+            .handledDeferringSyntheticFallback
+        )
+        // Perfectly axial horizontal drag: deltaX reaches the threshold, deltaY
+        // is exactly 0. With deadZone == 0 this MUST be detected as a gesture,
+        // consuming the mouseMoved event (transform returns nil).
+        XCTAssertNil(try transformer.transform(
+            makeMouseMovedEvent(deltaX: testGestureThreshold, deltaY: 0),
+            in: EventTransformerContext(device: nil)
+        ))
+    }
+
+    func testZeroDeadZoneRejectsOffAxisGesture() throws {
+        let transformer = makeLogitechGestureTransformer(deadZone: 0)
+
+        XCTAssertEqual(
+            transformer.handleLogitechControlEvent(logitechContext(pressed: true)),
+            .handledDeferringSyntheticFallback
+        )
+        // Off-axis horizontal drag: deltaY == 5 exceeds the 0 dead zone, so the
+        // gesture is rejected and the mouseMoved event passes through (transform
+        // returns the non-nil event).
+        XCTAssertNotNil(try transformer.transform(
+            makeMouseMovedEvent(deltaX: testGestureThreshold, deltaY: 5),
+            in: EventTransformerContext(device: nil)
+        ))
     }
 }


### PR DESCRIPTION
## Summary
`GestureButtonTransformer.detectGesture` guarded the axial-tolerance check with strict `< deadZone`, so a valid `deadZone` of 0 (`@minimum 0`, default 40) made `absDelta < 0` always false and disabled every side-button gesture. A 0 dead zone should mean "only perfectly axial gestures are accepted", not "gestures off".

## Root Cause
`LinearMouse/EventTransformer/GestureButtonTransformer.swift`, `detectGesture`: strict `<` instead of inclusive `<=` on the dead-zone comparison (the file already uses inclusive `magnitude >= threshold` comparisons elsewhere).

## Changes
- `< deadZone` -> `<= deadZone` on the Y (and X) dead-zone comparisons in `detectGesture`.
- `GestureButtonTransformerTests`: a perfectly axial drag at `deadZone == 0` is now detected (red before, green after); an off-axis drag is still rejected at `deadZone == 0`.

## Verification
- `make lint` — no new violations vs main.
- `GestureButtonTransformerTests` passes (targeted run, headless, code signing disabled). CI runs the full suite.

## Notes
1-px boundary shift for non-zero dead zones (negligible, strictly more correct: a tolerance of N px accepts drift 0..N inclusive).