### PR TITLE
Bypass Homerow-generated events

### DIFF
--- a/LinearMouse/EventTransformer/EventTransformerManager.swift
+++ b/LinearMouse/EventTransformer/EventTransformerManager.swift
@@ -117,9 +117,14 @@ class EventTransformerManager {
         forceResetState()
     }
 
-    private let sourceBundleIdentifierBypassSet: Set<String> = [
-        "cc.ffitch.shottr"
+    private static let sourceBundleIdentifierBypassSet: Set<String> = [
+        "cc.ffitch.shottr",
+        "com.superultra.Homerow"
     ]
+
+    static func shouldBypassSourceApplication(_ bundleIdentifier: String) -> Bool {
+        sourceBundleIdentifierBypassSet.contains(bundleIdentifier)
+    }
 
     func resolve(
         withCGEvent cgEvent: CGEvent,
@@ -222,7 +227,7 @@ class EventTransformerManager {
             return .init(transformer: [], context: .init(device: nil))
         }
         if let sourceBundleIdentifier = sourcePid?.bundleIdentifier,
-           sourceBundleIdentifierBypassSet.contains(sourceBundleIdentifier) {
+           Self.shouldBypassSourceApplication(sourceBundleIdentifier) {
             if let (interactionKey, interaction) = activeInteraction,
                interactionOwnsContinuation(cgEvent, interaction: interaction) {
                 return drainingResolution(

--- a/LinearMouseUnitTests/EventTransformer/EventTransformerManagerTests.swift
+++ b/LinearMouseUnitTests/EventTransformer/EventTransformerManagerTests.swift
@@ -717,6 +717,22 @@ final class EventTransformerManagerTests: XCTestCase {
         XCTAssertEqual(deliveredEventTypes, [.leftMouseDown, .leftMouseDragged, .leftMouseUp])
     }
 
+    func testShottrSourceApplicationIsBypassed() {
+        XCTAssertTrue(EventTransformerManager.shouldBypassSourceApplication("cc.ffitch.shottr"))
+    }
+
+    func testHomerowSourceApplicationIsBypassed() {
+        XCTAssertTrue(EventTransformerManager.shouldBypassSourceApplication("com.superultra.Homerow"))
+    }
+
+    func testUnknownSourceApplicationIsNotBypassed() {
+        XCTAssertFalse(EventTransformerManager.shouldBypassSourceApplication("com.example.Unknown"))
+    }
+
+    func testEmptySourceApplicationIsNotBypassed() {
+        XCTAssertFalse(EventTransformerManager.shouldBypassSourceApplication(""))
+    }
+
     func testOwnedReleaseTakesPriorityOverSourceBypass() throws {
         let mapping = Scheme.Buttons.Mapping(
             trigger: .init(input: .button(.mouse(4))),


### PR DESCRIPTION
## Summary

* Preserve Homerow-configured scroll speed and Dash acceleration when LinearMouse is running.
* Bypass only events generated by Homerow instead of requiring users to enable the global bypass setting.
* Add regression coverage for Homerow, the existing Shottr compatibility rule, and non-bypassed source identifiers.

Related to https://github.com/nchudleigh/homerow/issues/109

## User impact

Homerow implements keyboard scrolling by posting synthetic scroll-wheel events. When LinearMouse processes those events again, the visible Homerow settings remain unchanged but their runtime effect is lost.

| Action | Before | After |
| --- | --- | --- |
| Regular H/J/K/L scrolling | LinearMouse can rescale the generated deltas, making Homerow scrolling slower than configured | Preserve Homerow scroll speed |
| Shift-H/J/K/L Dash scrolling | LinearMouse can replace the larger Dash deltas, making Dash appear ineffective | Preserve the configured Dash multiplier |
| LinearMouse global bypass option | Must be enabled as a workaround, bypassing events from every other application | Remains optional; Homerow is handled automatically |

## Root cause

`GlobalEventTap` reads the originating PID from the `eventSourceUnixProcessID` field on each captured event and passes it to `EventTransformerManager`. The manager resolves that PID to an application bundle identifier.

Unless the global bypass option is enabled or the source bundle identifier is in the compatibility bypass set, LinearMouse routes the event through its normal transformation pipeline. That behavior is correct for physical input, but it also transforms the scroll events that Homerow has already calculated from its `scroll-px-per-ms` and `dash-speed-multiplier` settings.

The global **Bypass events from other applications** setting fixes the symptom because it returns a no-op transformer for all source-tagged events. Requiring that broad setting is unnecessary because the conflict is specific and the manager already has a targeted bypass mechanism for applications such as Shottr.

## Resolution

Add `com.superultra.Homerow` to the existing source-application bypass set. Homerow-generated events then use the no-op transformer path and retain their original scroll deltas.

Extract the bundle-identifier decision into a named predicate and cover these cases:

* Preserve the existing `cc.ffitch.shottr` bypass.
* Bypass `com.superultra.Homerow`.
* Continue processing unknown bundle identifiers.
* Continue processing an empty bundle identifier.

## Scope and compatibility

* Keep physical mouse and trackpad events unchanged because they do not resolve to the Homerow source bundle identifier.
* Keep synthetic events from other applications in the LinearMouse pipeline unless users enable the global bypass option.
* Preserve existing configuration files and UI behavior; no migration or new setting is required.
* Reuse the established source-application compatibility path rather than introducing a Homerow-specific event format or transformer.