### PR TITLE
Re-apply pointer settings while the system settles after waking

### DIFF
--- a/LinearMouse/AppDelegate.swift
+++ b/LinearMouse/AppDelegate.swift
@@ -127,6 +127,7 @@ extension AppDelegate {
             os_log("System did wake", log: Self.log, type: .info)
             self?.sleeping = false
             self?.restartIfAllowed()
+            self?.reapplyPointerSpeedAfterWake()
             self?.requestLogitechControlsReconfigurationAfterWake()
         }
     }
@@ -142,6 +143,17 @@ extension AppDelegate {
     func restartIfAllowed() {
         stop()
         startIfAllowed()
+    }
+
+    /// `restartIfAllowed()` applies the pointer settings as soon as the wake notification arrives,
+    /// which is before macOS has finished restoring its own HID properties. Keep re-applying them
+    /// until the system has settled.
+    func reapplyPointerSpeedAfterWake() {
+        guard sessionActive, !sleeping else {
+            return
+        }
+
+        DeviceManager.shared.reapplyPointerSpeedAfterWake()
     }
 
     func requestLogitechControlsReconfigurationAfterWake() {

--- a/LinearMouse/Device/DeviceManager.swift
+++ b/LinearMouse/Device/DeviceManager.swift
@@ -14,6 +14,7 @@ class DeviceManager: ObservableObject {
 
     private let manager = PointerDeviceManager()
     private let receiverMonitor = ReceiverMonitor()
+    private let wakeReapplyScheduler = WakeReapplyScheduler()
 
     private var pointerDeviceToDevice = [PointerDevice: Device]()
     @Published private(set) var receiverPairedDeviceIdentities = [Int: [ReceiverLogicalDeviceIdentity]]()
@@ -70,6 +71,8 @@ class DeviceManager: ObservableObject {
     private var activateApplicationObserver: Any?
 
     func stop() {
+        wakeReapplyScheduler.cancel()
+
         guard state == .running else {
             return
         }
@@ -384,6 +387,26 @@ class DeviceManager: ObservableObject {
         }
 
         device.applyConfiguredHighResolutionWheel(highResolutionWheel)
+    }
+
+    /// Re-applies the pointer settings across the window in which macOS restores its own HID
+    /// properties after a wake.
+    ///
+    /// The settings applied while handling `NSWorkspace.didWakeNotification` are overwritten by the
+    /// system shortly afterwards, leaving the pointer on the macOS defaults until something
+    /// unrelated (a frontmost-app change, a configuration edit) happens to call
+    /// `updatePointerSpeed()` again. See `WakeReapplyScheduler`.
+    func reapplyPointerSpeedAfterWake() {
+        os_log(
+            "Re-applying pointer settings for the %{public}.0fs after wake",
+            log: Self.log,
+            type: .info,
+            wakeReapplyScheduler.duration
+        )
+
+        wakeReapplyScheduler.restart { [weak self] in
+            self?.updatePointerSpeed()
+        }
     }
 
     func restorePointerSpeedToInitialValue() {

--- a/LinearMouse/Device/WakeReapplyScheduler.swift
+++ b/LinearMouse/Device/WakeReapplyScheduler.swift
@@ -1,0 +1,64 @@
+// MIT License
+// Copyright (c) 2021-2026 LinearMouse
+
+import Foundation
+
+/// Repeats a block across the window in which macOS restores its own HID properties after a wake.
+///
+/// Waking is not a single moment. `NSWorkspace.didWakeNotification` fires before the HID stack has
+/// finished restoring device properties, so anything written while handling it is overwritten
+/// shortly afterwards. Repeating the write over the settle window keeps the configured values in
+/// place instead of leaving them to be restored by an unrelated event.
+///
+/// The cadence is deliberately flat rather than backed off: the reset can land at any point in the
+/// window, and the interval is the worst case for how long the pointer stays wrong before it is
+/// corrected.
+///
+/// Each `restart` cancels the pending series, so overlapping wakes do not stack up.
+final class WakeReapplyScheduler {
+    /// How long to wait between re-applies.
+    static let defaultInterval: TimeInterval = 1
+
+    /// How many times to re-apply. With the default interval this covers the 30 seconds after a
+    /// wake, which is enough for a receiver behind a dock or a device reconnecting over Bluetooth.
+    static let defaultAttempts = 30
+
+    typealias Schedule = (TimeInterval, @escaping () -> Void) -> DispatchWorkItem
+
+    private let delays: [TimeInterval]
+    private let schedule: Schedule
+    private var pending: [DispatchWorkItem] = []
+
+    init(
+        interval: TimeInterval = defaultInterval,
+        attempts: Int = defaultAttempts,
+        schedule: @escaping Schedule = { delay, block in
+            let workItem = DispatchWorkItem(block: block)
+            DispatchQueue.main.asyncAfter(deadline: .now() + delay, execute: workItem)
+            return workItem
+        }
+    ) {
+        delays = (1 ... max(attempts, 1)).map { TimeInterval($0) * interval }
+        self.schedule = schedule
+    }
+
+    deinit {
+        pending.forEach { $0.cancel() }
+    }
+
+    /// The window this scheduler covers, for logging.
+    var duration: TimeInterval {
+        delays.last ?? 0
+    }
+
+    /// Cancels any pending run and schedules a fresh series of `block` runs.
+    func restart(_ block: @escaping () -> Void) {
+        cancel()
+        pending = delays.map { schedule($0, block) }
+    }
+
+    func cancel() {
+        pending.forEach { $0.cancel() }
+        pending.removeAll()
+    }
+}

--- a/LinearMouseUnitTests/Device/WakeReapplySchedulerTests.swift
+++ b/LinearMouseUnitTests/Device/WakeReapplySchedulerTests.swift
@@ -1,0 +1,88 @@
+// MIT License
+// Copyright (c) 2021-2026 LinearMouse
+
+@testable import LinearMouse
+import XCTest
+
+final class WakeReapplySchedulerTests: XCTestCase {
+    /// Collects the work items a scheduler hands out so a test can fire them by hand.
+    private final class ScheduleRecorder {
+        private(set) var delays: [TimeInterval] = []
+        private(set) var workItems: [DispatchWorkItem] = []
+
+        func schedule(_ delay: TimeInterval, _ block: @escaping () -> Void) -> DispatchWorkItem {
+            let workItem = DispatchWorkItem(block: block)
+            delays.append(delay)
+            workItems.append(workItem)
+            return workItem
+        }
+
+        /// Runs every work item that has not been cancelled, the way the main queue would.
+        func fireAll() {
+            for workItem in workItems where !workItem.isCancelled {
+                workItem.perform()
+            }
+        }
+    }
+
+    func testRestartSchedulesOneRunPerAttemptAtAFlatInterval() {
+        let recorder = ScheduleRecorder()
+        let scheduler = WakeReapplyScheduler(interval: 1, attempts: 3, schedule: recorder.schedule)
+
+        var runCount = 0
+        scheduler.restart { runCount += 1 }
+
+        XCTAssertEqual(recorder.delays, [1, 2, 3])
+        XCTAssertEqual(runCount, 0, "Nothing should run before the delays elapse")
+
+        recorder.fireAll()
+
+        XCTAssertEqual(runCount, 3)
+    }
+
+    func testDurationCoversTheWholeSettleWindow() {
+        let scheduler = WakeReapplyScheduler(interval: 1, attempts: 30) { _, block in
+            DispatchWorkItem(block: block)
+        }
+
+        XCTAssertEqual(scheduler.duration, 30)
+    }
+
+    func testRestartCancelsThePendingSeries() {
+        let recorder = ScheduleRecorder()
+        let scheduler = WakeReapplyScheduler(interval: 1, attempts: 2, schedule: recorder.schedule)
+
+        var firstWakeRuns = 0
+        scheduler.restart { firstWakeRuns += 1 }
+
+        var secondWakeRuns = 0
+        scheduler.restart { secondWakeRuns += 1 }
+
+        recorder.fireAll()
+
+        XCTAssertEqual(firstWakeRuns, 0, "A second wake should supersede the pending series")
+        XCTAssertEqual(secondWakeRuns, 2)
+    }
+
+    func testCancelStopsPendingRuns() {
+        let recorder = ScheduleRecorder()
+        let scheduler = WakeReapplyScheduler(interval: 1, attempts: 2, schedule: recorder.schedule)
+
+        var runCount = 0
+        scheduler.restart { runCount += 1 }
+        scheduler.cancel()
+
+        recorder.fireAll()
+
+        XCTAssertEqual(runCount, 0)
+    }
+
+    func testDefaultsRetryOftenEnoughToBoundTheWrongPointerFeel() {
+        XCTAssertEqual(WakeReapplyScheduler.defaultInterval, 1)
+        XCTAssertGreaterThan(WakeReapplyScheduler.defaultAttempts, 1)
+
+        let scheduler = WakeReapplyScheduler()
+
+        XCTAssertEqual(scheduler.duration, 30)
+    }
+}


### PR DESCRIPTION
## The bug

After the Mac wakes from sleep, the pointer runs on macOS's own acceleration curve instead of the configured scheme. With `"pointer": { "disableAcceleration": true }` this is very noticeable — the mouse feels slow and mushy at low speeds. The app is still running and its UI works fine.

It fixes itself the moment something unrelated happens. From #1204:

> LinearMouse seems inactive until I open the "LinearMouse Settings" panel. [...] Observe mouse is slow without LinearMouse acceleration and speed settings.

and #1047:

> On wakeup, mouse has reverted to MacOS acceleration (i.e. very slow). The mouse acceleration stays slow **until I click on the desktop**. After doing that the mouse returns to being accelerated by LinearMouse. This is reproducible every time.

Fixes #1204. Very likely also fixes #1047 (same symptom and same self-heal trigger, though that one was reported against v0.10.2, before the regression below existed).

## The fix

- Add `WakeReapplyScheduler`, which re-runs a block once a second for 30 seconds and cancels the pending series when another wake arrives.

The cadence is flat rather than backed off. The reset can land anywhere in the settle window, so the interval is the worst case for how long the pointer stays wrong before it is corrected — a backoff would leave a multi-second gap late in the window, which is exactly when a slow receiver or a Bluetooth reconnect finishes. A flat 1s poll is also the shape `AccessibilityPermission.pollingUntilEnabled` already uses. `updatePointerSpeed()` only writes IOKit properties and already runs on every frontmost-app change, so 30 extra calls spread over 30 seconds is well inside normal operating load.
- `DeviceManager.reapplyPointerSpeedAfterWake()` uses it to re-run `updatePointerSpeed()`, and `DeviceManager.stop()` cancels any pending series so nothing fires while the app is stopped.
- `AppDelegate` calls it from the `didWake` handler, next to the existing `requestLogitechControlsReconfigurationAfterWake()`.

`updateHardwareDPI()` and `updateHighResolutionWheel()` are deliberately left out of the repeated pass: they send real HID++ traffic to the device, and they already have their own post-wake and reconnect handling from #1256. `updatePointerSpeed()` is idempotent and only writes IOKit properties, so re-running it a few times costs nothing.

## Why it happens

Waking is not a single moment. `NSWorkspace.didWakeNotification` fires before the HID stack has finished restoring device properties. `AppDelegate` handles it synchronously — `restartIfAllowed()` → `DeviceManager.start()` → `updatePointerSpeed()` — so LinearMouse writes `HIDPointerResolution` / `HIDUseLinearScalingMouseAcceleration` into a device that is not ready to keep them, and the values are gone moments later. Nothing re-applies them.

What makes this stick rather than self-correct is that the app has already put the device back on the macOS defaults itself. #1182 added a `willSleepNotification` handler that calls `stop()`, and `DeviceManager.stop()` calls `restorePointerSpeedToInitialValue()`. So the sequence across a sleep is:

1. `willSleep` → `stop()` → every device is written back to the macOS system values.
2. `didWake` → `start()` → the configured values are written straight back, too early to survive.
3. Nothing else runs, so the device keeps the system values from step 1.

Before #1182 there was no sleep or wake handling at all, so step 1 never happened and the configured values simply stayed on the device across most sleeps. That makes this a regression in v0.11.2 — and it matches #1204, which was filed against v0.11.2 and guessed as much ("Possibly related to #1177 or an unintended side effect of the recent bugfix").

The recovery in both reports is incidental. Every other caller of `updatePointerSpeed()` is an unrelated trigger:

| Trigger | Wired in |
| --- | --- |
| frontmost app changed | `didActivateApplicationNotification` observer |
| config file edited | `ConfigurationState.$configuration` sink |
| current display changed | `ScreenManager.$currentScreenName` sink |
| device (re)appeared | `deviceAdded` |

Clicking the desktop activates Finder (row 1). Opening the settings window activates LinearMouse (row 1). A device that happens to re-enumerate across sleep recovers via row 4, which is why the bug looks intermittent and hardware-dependent.

The property observers registered in `DeviceManager.init` do not cover this case: `IOHIDEventSystemClientRegisterPropertyChangedCallback` watches event-system-level properties — what System Settings → Mouse writes — not the per-service `HIDEventServiceProperties` that get reset here.

This is the same shape as #1256, which fixed the high-resolution wheel not surviving wake by retrying while the HID++ feature was unavailable. Pointer speed and acceleration were the remaining piece.

## Test plan

- `make lint` (swiftformat + swiftlint) passes.
- `make test` passes; `WakeReapplySchedulerTests` adds 4 cases covering the schedule, coalescing of overlapping wakes, cancellation, and the shape of the default delays.
- Manual, on macOS 26.5 with a Logitech Unifying receiver behind a Thunderbolt dock and a scheme setting `pointer.disableAcceleration: true`. Read the applied value back from the pointer event service (the receiver publishes two; the pointer one carries `HIDPointerAccelerationType = HIDMouseAcceleration`):

  ```
  ioreg -r -c IOHIDEventService -l | grep -o 'HIDUseLinearScalingMouseAcceleration"=[0-9]*'
  ```

  Before: after wake the value reads `0` and stays there until the frontmost app changes. After: it returns to `1` within the settle window without any interaction.
