### PR TITLE
Fix pointer speed and acceleration being lost after waking from sleep

### DIFF
--- a/LinearMouse/AppDelegate.swift
+++ b/LinearMouse/AppDelegate.swift
@@ -127,6 +127,7 @@ extension AppDelegate {
             os_log("System did wake", log: Self.log, type: .info)
             self?.sleeping = false
             self?.restartIfAllowed()
+            self?.reapplyPointerSpeedAfterWake()
             self?.requestLogitechControlsReconfigurationAfterWake()
         }
     }
@@ -142,6 +143,17 @@ extension AppDelegate {
     func restartIfAllowed() {
         stop()
         startIfAllowed()
+    }
+
+    /// `restartIfAllowed()` applies the pointer settings as soon as the wake notification arrives,
+    /// which is before macOS has finished restoring its own HID properties. Keep re-applying them
+    /// until the system has settled.
+    func reapplyPointerSpeedAfterWake() {
+        guard sessionActive, !sleeping else {
+            return
+        }
+
+        DeviceManager.shared.reapplyPointerSpeedAfterWake()
     }
 
     func requestLogitechControlsReconfigurationAfterWake() {

--- a/LinearMouse/Device/DeviceManager.swift
+++ b/LinearMouse/Device/DeviceManager.swift
@@ -14,6 +14,7 @@ class DeviceManager: ObservableObject {
 
     private let manager = PointerDeviceManager()
     private let receiverMonitor = ReceiverMonitor()
+    private let wakeReapplyScheduler = WakeReapplyScheduler()
 
     private var pointerDeviceToDevice = [PointerDevice: Device]()
     @Published private(set) var receiverPairedDeviceIdentities = [Int: [ReceiverLogicalDeviceIdentity]]()
@@ -70,6 +71,8 @@ class DeviceManager: ObservableObject {
     private var activateApplicationObserver: Any?
 
     func stop() {
+        wakeReapplyScheduler.cancel()
+
         guard state == .running else {
             return
         }
@@ -384,6 +387,26 @@ class DeviceManager: ObservableObject {
         }
 
         device.applyConfiguredHighResolutionWheel(highResolutionWheel)
+    }
+
+    /// Re-applies the pointer settings across the window in which macOS restores its own HID
+    /// properties after a wake.
+    ///
+    /// The settings applied while handling `NSWorkspace.didWakeNotification` are overwritten by the
+    /// system shortly afterwards, leaving the pointer on the macOS defaults until something
+    /// unrelated (a frontmost-app change, a configuration edit) happens to call
+    /// `updatePointerSpeed()` again. See `WakeReapplyScheduler`.
+    func reapplyPointerSpeedAfterWake() {
+        os_log(
+            "Re-applying pointer settings for the %{public}.0fs after wake",
+            log: Self.log,
+            type: .info,
+            wakeReapplyScheduler.duration
+        )
+
+        wakeReapplyScheduler.restart { [weak self] in
+            self?.updatePointerSpeed()
+        }
     }
 
     func restorePointerSpeedToInitialValue() {

--- a/LinearMouse/Device/WakeReapplyScheduler.swift
+++ b/LinearMouse/Device/WakeReapplyScheduler.swift
@@ -1,0 +1,64 @@
+// MIT License
+// Copyright (c) 2021-2026 LinearMouse
+
+import Foundation
+
+/// Repeats a block across the window in which macOS restores its own HID properties after a wake.
+///
+/// Waking is not a single moment. `NSWorkspace.didWakeNotification` fires before the HID stack has
+/// finished restoring device properties, so anything written while handling it is overwritten
+/// shortly afterwards. Repeating the write over the settle window keeps the configured values in
+/// place instead of leaving them to be restored by an unrelated event.
+///
+/// The cadence is deliberately flat rather than backed off: the reset can land at any point in the
+/// window, and the interval is the worst case for how long the pointer stays wrong before it is
+/// corrected.
+///
+/// Each `restart` cancels the pending series, so overlapping wakes do not stack up.
+final class WakeReapplyScheduler {
+    /// How long to wait between re-applies.
+    static let defaultInterval: TimeInterval = 1
+
+    /// How many times to re-apply. With the default interval this covers the 30 seconds after a
+    /// wake, which is enough for a receiver behind a dock or a device reconnecting over Bluetooth.
+    static let defaultAttempts = 30
+
+    typealias Schedule = (TimeInterval, @escaping () -> Void) -> DispatchWorkItem
+
+    private let delays: [TimeInterval]
+    private let schedule: Schedule
+    private var pending: [DispatchWorkItem] = []
+
+    init(
+        interval: TimeInterval = defaultInterval,
+        attempts: Int = defaultAttempts,
+        schedule: @escaping Schedule = { delay, block in
+            let workItem = DispatchWorkItem(block: block)
+            DispatchQueue.main.asyncAfter(deadline: .now() + delay, execute: workItem)
+            return workItem
+        }
+    ) {
+        delays = (1 ... max(attempts, 1)).map { TimeInterval($0) * interval }
+        self.schedule = schedule
+    }
+
+    deinit {
+        pending.forEach { $0.cancel() }
+    }
+
+    /// The window this scheduler covers, for logging.
+    var duration: TimeInterval {
+        delays.last ?? 0
+    }
+
+    /// Cancels any pending run and schedules a fresh series of `block` runs.
+    func restart(_ block: @escaping () -> Void) {
+        cancel()
+        pending = delays.map { schedule($0, block) }
+    }
+
+    func cancel() {
+        pending.forEach { $0.cancel() }
+        pending.removeAll()
+    }
+}

--- a/LinearMouseUnitTests/Device/WakeReapplySchedulerTests.swift
+++ b/LinearMouseUnitTests/Device/WakeReapplySchedulerTests.swift
@@ -1,0 +1,88 @@
+// MIT License
+// Copyright (c) 2021-2026 LinearMouse
+
+@testable import LinearMouse
+import XCTest
+
+final class WakeReapplySchedulerTests: XCTestCase {
+    /// Collects the work items a scheduler hands out so a test can fire them by hand.
+    private final class ScheduleRecorder {
+        private(set) var delays: [TimeInterval] = []
+        private(set) var workItems: [DispatchWorkItem] = []
+
+        func schedule(_ delay: TimeInterval, _ block: @escaping () -> Void) -> DispatchWorkItem {
+            let workItem = DispatchWorkItem(block: block)
+            delays.append(delay)
+            workItems.append(workItem)
+            return workItem
+        }
+
+        /// Runs every work item that has not been cancelled, the way the main queue would.
+        func fireAll() {
+            for workItem in workItems where !workItem.isCancelled {
+                workItem.perform()
+            }
+        }
+    }
+
+    func testRestartSchedulesOneRunPerAttemptAtAFlatInterval() {
+        let recorder = ScheduleRecorder()
+        let scheduler = WakeReapplyScheduler(interval: 1, attempts: 3, schedule: recorder.schedule)
+
+        var runCount = 0
+        scheduler.restart { runCount += 1 }
+
+        XCTAssertEqual(recorder.delays, [1, 2, 3])
+        XCTAssertEqual(runCount, 0, "Nothing should run before the delays elapse")
+
+        recorder.fireAll()
+
+        XCTAssertEqual(runCount, 3)
+    }
+
+    func testDurationCoversTheWholeSettleWindow() {
+        let scheduler = WakeReapplyScheduler(interval: 1, attempts: 30) { _, block in
+            DispatchWorkItem(block: block)
+        }
+
+        XCTAssertEqual(scheduler.duration, 30)
+    }
+
+    func testRestartCancelsThePendingSeries() {
+        let recorder = ScheduleRecorder()
+        let scheduler = WakeReapplyScheduler(interval: 1, attempts: 2, schedule: recorder.schedule)
+
+        var firstWakeRuns = 0
+        scheduler.restart { firstWakeRuns += 1 }
+
+        var secondWakeRuns = 0
+        scheduler.restart { secondWakeRuns += 1 }
+
+        recorder.fireAll()
+
+        XCTAssertEqual(firstWakeRuns, 0, "A second wake should supersede the pending series")
+        XCTAssertEqual(secondWakeRuns, 2)
+    }
+
+    func testCancelStopsPendingRuns() {
+        let recorder = ScheduleRecorder()
+        let scheduler = WakeReapplyScheduler(interval: 1, attempts: 2, schedule: recorder.schedule)
+
+        var runCount = 0
+        scheduler.restart { runCount += 1 }
+        scheduler.cancel()
+
+        recorder.fireAll()
+
+        XCTAssertEqual(runCount, 0)
+    }
+
+    func testDefaultsRetryOftenEnoughToBoundTheWrongPointerFeel() {
+        XCTAssertEqual(WakeReapplyScheduler.defaultInterval, 1)
+        XCTAssertGreaterThan(WakeReapplyScheduler.defaultAttempts, 1)
+
+        let scheduler = WakeReapplyScheduler()
+
+        XCTAssertEqual(scheduler.duration, 30)
+    }
+}


### PR DESCRIPTION
## The bug

After the Mac wakes from sleep, the pointer runs on macOS's own acceleration curve instead of the configured scheme. With `"pointer": { "disableAcceleration": true }` it is very noticeable — the mouse feels slow and mushy at low speeds. The app is still running and its UI works fine.

It fixes itself the moment something unrelated happens. From #1204:

> LinearMouse seems inactive until I open the "LinearMouse Settings" panel. [...] Observe mouse is slow without LinearMouse acceleration and speed settings.

and #1047:

> On wakeup, mouse has reverted to MacOS acceleration (i.e. very slow). The mouse acceleration stays slow **until I click on the desktop**. After doing that the mouse returns to being accelerated by LinearMouse. This is reproducible every time.

Fixes #1204. Very likely also fixes #1047 (same symptom, same self-heal trigger, though that one was reported against v0.10.2, before the regression below existed).

## Why it happens

`NSWorkspace.didWakeNotification` fires before the HID stack has settled. `AppDelegate` handles it synchronously — `restartIfAllowed()` → `DeviceManager.start()` → `updatePointerSpeed()` — so the configured values are written into a device that does not keep them, and nothing writes them again.

What makes it stick rather than self-correct is that the app has already put the device back on the macOS defaults itself. #1182 added a `willSleepNotification` handler that calls `stop()`, and `DeviceManager.stop()` calls `restorePointerSpeedToInitialValue()`. Across a sleep that gives:

1. `willSleep` → `stop()` → every device is written back to the macOS system values.
2. `didWake` → `start()` → the configured values are written straight back, too early to survive.
3. Nothing else runs, so the device keeps the system values from step 1.

Before #1182 there was no sleep or wake handling at all, so step 1 never happened. That makes this a regression in v0.11.2, which matches #1204 being filed against v0.11.2 and guessing as much ("Possibly related to #1177 or an unintended side effect of the recent bugfix" — #1177 being the issue #1182 fixed).

Recovery in both reports is incidental. Every other caller of `updatePointerSpeed()` is an unrelated trigger:

| Trigger | Wired in |
| --- | --- |
| frontmost app changed | `didActivateApplicationNotification` observer |
| config file edited | `ConfigurationState.$configuration` sink |
| current display changed | `ScreenManager.$currentScreenName` sink |
| device (re)appeared | `deviceAdded` |

Clicking the desktop activates Finder (row 1). Opening the settings window activates LinearMouse (row 1).

The property observers registered in `DeviceManager.init` do not help here. `IOHIDEventSystemClientRegisterPropertyChangedCallback` is scoped to the event system — it catches what System Settings → Mouse writes, not the per-service `HIDEventServiceProperties` involved here.

### What the device actually does across a sleep

Measured with a small IOKit probe registering `kIOGeneralInterest` on the pointer's `IOHIDEventService` (Logitech Unifying receiver, `046d:c54d`, behind a Thunderbolt dock):

```
20:38:34.495  kIOMessageDeviceWillPowerOff
20:38:34.495  kIOMessageServiceIsTerminated
```

The service is destroyed on sleep and a **new** one is published on wake, so `deviceAdded` does fire and does apply the scheme — it just does not survive. Whether that is because the fresh service will not retain the write yet, or because the system pushes its own preference-derived parameters afterwards (the service carries `UserPreferences = Yes` and `HIDDefaultParameters = Yes`), I have not been able to pin down. Either way the fix is the same, but see the open question below.

## The fix

- Add `WakeReapplyScheduler`, which re-runs a block once a second for 30 seconds and cancels the pending series when another wake arrives.
- `DeviceManager.reapplyPointerSpeedAfterWake()` uses it to re-run `updatePointerSpeed()`; `DeviceManager.stop()` cancels any pending series so nothing fires while the app is stopped.
- `AppDelegate` calls it from the `didWake` handler, beside the existing `requestLogitechControlsReconfigurationAfterWake()`.

The cadence is flat rather than backed off. The reset can land anywhere in the settle window, so the interval is the worst case for how long the pointer stays wrong before it is corrected — a backoff leaves a multi-second gap late in the window, which is exactly when a slow receiver or a Bluetooth reconnect finishes. A flat 1s poll is also the shape `AccessibilityPermission.pollingUntilEnabled` already uses, and #1293 uses bounded retries for the same class of problem on hardware DPI. `updatePointerSpeed()` only writes IOKit properties and already runs on every frontmost-app change, so 30 extra calls spread over 30 seconds is well inside normal operating load.

`updateHardwareDPI()` and `updateHighResolutionWheel()` are deliberately left out of the repeated pass: they send real HID++ traffic, and they already have their own post-wake and reconnect handling from #1256 and #1293.

## Open questions

Happy to rework any of these — they need your knowledge of the intent behind #1182.

1. **Should the sleep teardown restore pointer speed at all?** #1182's stated goal was restoring BLE HID++ diversion before sleep; writing the macOS pointer defaults onto every device looks like it came along for free from reusing `stop()`, which was built for app quit (where restoring is clearly right). If sleep does not need that, splitting `stop()` into sleep-teardown and quit-teardown would shrink the broken window considerably, and might be the better fix to pair this with.
2. **Does the unlock path need the same treatment?** `sessionDidBecomeActive` → `startIfAllowed()` → one immediate apply, exactly like wake. #1292 was the unlock analogue for hardware DPI. If locking resets HID properties the way sleeping does, this should fire there too.
3. **Is there a deterministic signal to hook instead of repeating?** Polling is not elegant. `kIOBusyInterest` on the new service, or `kIOMessageServicePropertyChange`, would let us apply exactly once at the right moment. I have not yet confirmed either fires here.
4. **Should `requestLogitechControlsReconfigurationAfterWake()` share this scheduler?** It is a single shot at exactly +2s, which is the same fragility class.

## Test plan

- `make lint` (swiftformat + swiftlint) passes.
- `make test` passes. `WakeReapplySchedulerTests` adds 5 cases covering the schedule, coalescing of overlapping wakes, cancellation, and the default window.
- Manual, macOS 26.5, Logitech Unifying receiver behind a Thunderbolt dock, scheme setting `pointer.disableAcceleration: true`. Read the value back from the pointer event service (the receiver publishes two; the pointer one carries `HIDPointerAccelerationType = HIDMouseAcceleration`):

  ```
  ioreg -r -c IOHIDEventService -l | grep -o 'HIDUseLinearScalingMouseAcceleration"=[0-9]*' | sort | uniq -c
  ```

  Before this change, after a wake the value reads `0` and stays there until the frontmost app changes. With it:

  ```
  20:24:26  AppDelegate    System will sleep
  20:24:42  AppDelegate    System did wake
  20:24:43  DeviceManager  Re-applying pointer settings for the 30s after wake
  ```

  and the value is back to `1` without any interaction. The re-applies were confirmed to run at 1/second and stop at the end of the window.
