### PR TITLE
Post simulated key events with HID system state to keep input state intact

### DIFF
--- a/Modules/KeyKit/Sources/KeyKit/CGEvent+HardwareLikeKeyEvent.swift
+++ b/Modules/KeyKit/Sources/KeyKit/CGEvent+HardwareLikeKeyEvent.swift
@@ -1,0 +1,24 @@
+// MIT License
+// Copyright (c) 2021-2026 LinearMouse
+
+import CoreGraphics
+import Foundation
+
+extension CGEvent {
+    /// Creates a key event that is indistinguishable from a hardware key press.
+    ///
+    /// Events created without a source carry no HID system state, a zero timestamp and no keyboard type.
+    /// Some event consumers (e.g. Wine's mouse-capture and modifier tracking in games) treat such events
+    /// as foreign and mistrack input state around them. The keyboard type is read from the event source
+    /// rather than `LMGetKbdType()`, which is not thread-safe and would race with `KeyCodeResolver`.
+    static func makeHardwareLikeKeyEvent(virtualKey: CGKeyCode, keyDown: Bool) -> CGEvent? {
+        guard let source = CGEventSource(stateID: .hidSystemState),
+              let event = CGEvent(keyboardEventSource: source, virtualKey: virtualKey, keyDown: keyDown) else {
+            return nil
+        }
+
+        event.timestamp = CGEventTimestamp(DispatchTime.now().uptimeNanoseconds)
+        event.setIntegerValueField(.keyboardEventKeyboardType, value: Int64(source.keyboardType))
+        return event
+    }
+}

--- a/Modules/KeyKit/Sources/KeyKit/KeySimulator.swift
+++ b/Modules/KeyKit/Sources/KeyKit/KeySimulator.swift
@@ -2,6 +2,7 @@
 // Copyright (c) 2021-2026 LinearMouse
 
 import AppKit
+import Carbon
 import os
 
 public enum KeySimulatorError: Error {
@@ -46,6 +47,12 @@ public class KeySimulator: KeySimulating {
             NX_DEVICERCMDKEYMASK
     ))
     private static let keyboardModifierFlags = genericModifierFlags.union(deviceSpecificModifierFlags)
+
+    /// Events created without a source carry no HID system state, a zero
+    /// timestamp and no keyboard type. Some event consumers (e.g. Wine's
+    /// mouse-capture handling in games) treat such events as foreign and
+    /// break held-button state, so mimic hardware-generated events.
+    private static let eventSource = CGEventSource(stateID: .hidSystemState)
 
     private let keyCodeResolver = KeyCodeResolver()
     private let eventSourceUserData: Int64?
@@ -114,11 +121,17 @@ public class KeySimulator: KeySimulating {
             throw KeySimulatorError.unsupportedKey
         }
 
-        guard let event = CGEvent(keyboardEventSource: nil, virtualKey: keyCode, keyDown: keyDown) else {
+        guard let event = CGEvent(
+            keyboardEventSource: Self.eventSource,
+            virtualKey: keyCode,
+            keyDown: keyDown
+        ) else {
             return
         }
 
         event.flags = Self.replacingKeyboardModifierFlags(in: event.flags, with: eventFlags)
+        event.timestamp = CGEventTimestamp(DispatchTime.now().uptimeNanoseconds)
+        event.setIntegerValueField(.keyboardEventKeyboardType, value: Int64(LMGetKbdType()))
 
         if !flagsToToggle.isEmpty {
             event.type = .flagsChanged
@@ -202,11 +215,17 @@ public class KeySimulator: KeySimulating {
             return
         }
 
-        guard let event = CGEvent(keyboardEventSource: nil, virtualKey: keyCode, keyDown: true) else {
+        guard let event = CGEvent(
+            keyboardEventSource: Self.eventSource,
+            virtualKey: keyCode,
+            keyDown: true
+        ) else {
             return
         }
 
         event.type = .flagsChanged
+        event.timestamp = CGEventTimestamp(DispatchTime.now().uptimeNanoseconds)
+        event.setIntegerValueField(.keyboardEventKeyboardType, value: Int64(LMGetKbdType()))
         event.flags = Self.replacingKeyboardModifierFlags(
             in: event.flags,
             with: restoringModifierFlags

--- a/Modules/KeyKit/Sources/KeyKit/KeySimulator.swift
+++ b/Modules/KeyKit/Sources/KeyKit/KeySimulator.swift
@@ -2,7 +2,6 @@
 // Copyright (c) 2021-2026 LinearMouse
 
 import AppKit
-import Carbon
 import os
 
 public enum KeySimulatorError: Error {
@@ -47,12 +46,6 @@ public class KeySimulator: KeySimulating {
             NX_DEVICERCMDKEYMASK
     ))
     private static let keyboardModifierFlags = genericModifierFlags.union(deviceSpecificModifierFlags)
-
-    /// Events created without a source carry no HID system state, a zero
-    /// timestamp and no keyboard type. Some event consumers (e.g. Wine's
-    /// mouse-capture handling in games) treat such events as foreign and
-    /// break held-button state, so mimic hardware-generated events.
-    private static let eventSource = CGEventSource(stateID: .hidSystemState)
 
     private let keyCodeResolver = KeyCodeResolver()
     private let eventSourceUserData: Int64?
@@ -121,17 +114,11 @@ public class KeySimulator: KeySimulating {
             throw KeySimulatorError.unsupportedKey
         }
 
-        guard let event = CGEvent(
-            keyboardEventSource: Self.eventSource,
-            virtualKey: keyCode,
-            keyDown: keyDown
-        ) else {
+        guard let event = CGEvent.makeHardwareLikeKeyEvent(virtualKey: keyCode, keyDown: keyDown) else {
             return
         }
 
         event.flags = Self.replacingKeyboardModifierFlags(in: event.flags, with: eventFlags)
-        event.timestamp = CGEventTimestamp(DispatchTime.now().uptimeNanoseconds)
-        event.setIntegerValueField(.keyboardEventKeyboardType, value: Int64(LMGetKbdType()))
 
         if !flagsToToggle.isEmpty {
             event.type = .flagsChanged
@@ -215,17 +202,11 @@ public class KeySimulator: KeySimulating {
             return
         }
 
-        guard let event = CGEvent(
-            keyboardEventSource: Self.eventSource,
-            virtualKey: keyCode,
-            keyDown: true
-        ) else {
+        guard let event = CGEvent.makeHardwareLikeKeyEvent(virtualKey: keyCode, keyDown: true) else {
             return
         }
 
         event.type = .flagsChanged
-        event.timestamp = CGEventTimestamp(DispatchTime.now().uptimeNanoseconds)
-        event.setIntegerValueField(.keyboardEventKeyboardType, value: Int64(LMGetKbdType()))
         event.flags = Self.replacingKeyboardModifierFlags(
             in: event.flags,
             with: restoringModifierFlags

--- a/Modules/KeyKit/Sources/KeyKit/SymbolicHotKey.swift
+++ b/Modules/KeyKit/Sources/KeyKit/SymbolicHotKey.swift
@@ -1,8 +1,28 @@
 // MIT License
 // Copyright (c) 2021-2026 LinearMouse
 
+import Carbon
 import CoreFoundation
+import CoreGraphics
 import KeyKitC
+
+/// See `KeySimulator`: events without HID system state, a timestamp and a
+/// keyboard type are treated as foreign by some event consumers (e.g. Wine's
+/// modifier tracking), which leaves modifiers stuck. Mimic hardware events.
+private let symbolicHotKeyEventSource = CGEventSource(stateID: .hidSystemState)
+
+private func makeHardwareLikeKeyEvent(virtualKey: CGKeyCode, keyDown: Bool) -> CGEvent? {
+    guard let event = CGEvent(
+        keyboardEventSource: symbolicHotKeyEventSource,
+        virtualKey: virtualKey,
+        keyDown: keyDown
+    ) else {
+        return nil
+    }
+    event.timestamp = CGEventTimestamp(DispatchTime.now().uptimeNanoseconds)
+    event.setIntegerValueField(.keyboardEventKeyboardType, value: Int64(LMGetKbdType()))
+    return event
+}
 
 public enum SymbolicHotKey: UInt32 {
     /// full keyboard access hotkeys
@@ -124,15 +144,15 @@ public func postSymbolicHotKey(_ hotkey: SymbolicHotKey) throws {
     var accumulated = CGEventFlags()
     for (flag, keyCode) in activeModifiers {
         accumulated.insert(flag)
-        let event = CGEvent(keyboardEventSource: nil, virtualKey: keyCode, keyDown: true)!
+        let event = makeHardwareLikeKeyEvent(virtualKey: keyCode, keyDown: true)!
         event.type = .flagsChanged
         event.flags = accumulated
         event.post(tap: .cgSessionEventTap)
     }
 
-    let keyDown = CGEvent(keyboardEventSource: nil, virtualKey: virtualKeyCode, keyDown: true)!
+    let keyDown = makeHardwareLikeKeyEvent(virtualKey: virtualKeyCode, keyDown: true)!
     keyDown.flags = flags
-    let keyUp = CGEvent(keyboardEventSource: nil, virtualKey: virtualKeyCode, keyDown: false)!
+    let keyUp = makeHardwareLikeKeyEvent(virtualKey: virtualKeyCode, keyDown: false)!
     keyUp.flags = flags
 
     keyDown.post(tap: .cgSessionEventTap)
@@ -140,7 +160,7 @@ public func postSymbolicHotKey(_ hotkey: SymbolicHotKey) throws {
 
     for (flag, keyCode) in activeModifiers.reversed() {
         accumulated.remove(flag)
-        let event = CGEvent(keyboardEventSource: nil, virtualKey: keyCode, keyDown: false)!
+        let event = makeHardwareLikeKeyEvent(virtualKey: keyCode, keyDown: false)!
         event.type = .flagsChanged
         event.flags = accumulated
         event.post(tap: .cgSessionEventTap)

--- a/Modules/KeyKit/Sources/KeyKit/SymbolicHotKey.swift
+++ b/Modules/KeyKit/Sources/KeyKit/SymbolicHotKey.swift
@@ -1,28 +1,9 @@
 // MIT License
 // Copyright (c) 2021-2026 LinearMouse
 
-import Carbon
 import CoreFoundation
 import CoreGraphics
 import KeyKitC
-
-/// See `KeySimulator`: events without HID system state, a timestamp and a
-/// keyboard type are treated as foreign by some event consumers (e.g. Wine's
-/// modifier tracking), which leaves modifiers stuck. Mimic hardware events.
-private let symbolicHotKeyEventSource = CGEventSource(stateID: .hidSystemState)
-
-private func makeHardwareLikeKeyEvent(virtualKey: CGKeyCode, keyDown: Bool) -> CGEvent? {
-    guard let event = CGEvent(
-        keyboardEventSource: symbolicHotKeyEventSource,
-        virtualKey: virtualKey,
-        keyDown: keyDown
-    ) else {
-        return nil
-    }
-    event.timestamp = CGEventTimestamp(DispatchTime.now().uptimeNanoseconds)
-    event.setIntegerValueField(.keyboardEventKeyboardType, value: Int64(LMGetKbdType()))
-    return event
-}
 
 public enum SymbolicHotKey: UInt32 {
     /// full keyboard access hotkeys
@@ -144,15 +125,15 @@ public func postSymbolicHotKey(_ hotkey: SymbolicHotKey) throws {
     var accumulated = CGEventFlags()
     for (flag, keyCode) in activeModifiers {
         accumulated.insert(flag)
-        let event = makeHardwareLikeKeyEvent(virtualKey: keyCode, keyDown: true)!
+        let event = CGEvent.makeHardwareLikeKeyEvent(virtualKey: keyCode, keyDown: true)!
         event.type = .flagsChanged
         event.flags = accumulated
         event.post(tap: .cgSessionEventTap)
     }
 
-    let keyDown = makeHardwareLikeKeyEvent(virtualKey: virtualKeyCode, keyDown: true)!
+    let keyDown = CGEvent.makeHardwareLikeKeyEvent(virtualKey: virtualKeyCode, keyDown: true)!
     keyDown.flags = flags
-    let keyUp = makeHardwareLikeKeyEvent(virtualKey: virtualKeyCode, keyDown: false)!
+    let keyUp = CGEvent.makeHardwareLikeKeyEvent(virtualKey: virtualKeyCode, keyDown: false)!
     keyUp.flags = flags
 
     keyDown.post(tap: .cgSessionEventTap)
@@ -160,7 +141,7 @@ public func postSymbolicHotKey(_ hotkey: SymbolicHotKey) throws {
 
     for (flag, keyCode) in activeModifiers.reversed() {
         accumulated.remove(flag)
-        let event = makeHardwareLikeKeyEvent(virtualKey: keyCode, keyDown: false)!
+        let event = CGEvent.makeHardwareLikeKeyEvent(virtualKey: keyCode, keyDown: false)!
         event.type = .flagsChanged
         event.flags = accumulated
         event.post(tap: .cgSessionEventTap)

--- a/Modules/KeyKit/Tests/KeyKitTests/KeySimulatorEventFieldsTests.swift
+++ b/Modules/KeyKit/Tests/KeyKitTests/KeySimulatorEventFieldsTests.swift
@@ -1,0 +1,34 @@
+// MIT License
+// Copyright (c) 2021-2026 LinearMouse
+
+import Carbon
+@testable import KeyKit
+import XCTest
+
+final class KeySimulatorEventFieldsTests: XCTestCase {
+    /// Simulated key events must be indistinguishable from hardware ones:
+    /// events without HID system state, with a zero timestamp or without a
+    /// keyboard type break mouse capture in some event consumers (e.g. Wine
+    /// games holding a mouse button to rotate the camera).
+    func testSimulatedKeyEventsMimicHardwareEvents() throws {
+        var recordedEvents: [CGEvent] = []
+        let simulator = KeySimulator { event, _ in
+            recordedEvents.append(event)
+        }
+
+        try simulator.press(keys: [.f1], tap: nil)
+
+        XCTAssertEqual(recordedEvents.map(\.type), [.keyDown, .keyUp])
+        for event in recordedEvents {
+            XCTAssertEqual(
+                event.getIntegerValueField(.eventSourceStateID),
+                Int64(CGEventSourceStateID.hidSystemState.rawValue)
+            )
+            XCTAssertNotEqual(event.timestamp, 0)
+            XCTAssertEqual(
+                event.getIntegerValueField(.keyboardEventKeyboardType),
+                Int64(LMGetKbdType())
+            )
+        }
+    }
+}

--- a/Modules/KeyKit/Tests/KeyKitTests/KeySimulatorEventFieldsTests.swift
+++ b/Modules/KeyKit/Tests/KeyKitTests/KeySimulatorEventFieldsTests.swift
@@ -16,7 +16,9 @@ final class KeySimulatorEventFieldsTests: XCTestCase {
             recordedEvents.append(event)
         }
 
+        let before = DispatchTime.now().uptimeNanoseconds
         try simulator.press(keys: [.f1], tap: nil)
+        let after = DispatchTime.now().uptimeNanoseconds
 
         XCTAssertEqual(recordedEvents.map(\.type), [.keyDown, .keyUp])
         for event in recordedEvents {
@@ -24,7 +26,8 @@ final class KeySimulatorEventFieldsTests: XCTestCase {
                 event.getIntegerValueField(.eventSourceStateID),
                 Int64(CGEventSourceStateID.hidSystemState.rawValue)
             )
-            XCTAssertNotEqual(event.timestamp, 0)
+            XCTAssertGreaterThanOrEqual(event.timestamp, before)
+            XCTAssertLessThanOrEqual(event.timestamp, after)
             XCTAssertEqual(
                 event.getIntegerValueField(.keyboardEventKeyboardType),
                 Int64(LMGetKbdType())


### PR DESCRIPTION
This is the follow-up fix. Similar situation to [#1369](https://github.com/linearmouse/linearmouse/pull/1369).
In this case CrossOver + MX Master 4. Side wheel remapped to keyboard buttons F1/F2. If hold RBM and spin side wheel for triggering F1/F2, RBM still in hold state but no action until release and press it again.

Summary

Key events created without an event source carry no HID system state, a zero timestamp and no keyboard type. Some event consumers treat such events as foreign and mistrack input state around them - e.g. Wine applications drop a held-button mouse capture when a key press arrives, and Wine's modifier tracking leaves Control stuck after a space-switch symbolic hotkey (Control+Arrow) fires mid focus change, turning later game input into Control-modified keys. Create simulated events (both KeySimulator key presses and symbolic hotkey sequences) from a hidSystemState source and stamp a real timestamp and keyboard type so they are indistinguishable from hardware key presses.

Covered by a KeySimulator test recording posted events and asserting the HID system state, timestamp and keyboard type fields.