### PR TITLE
Add option to prevent pointer movement during gestures

### DIFF
--- a/Documentation/Configuration.d.ts
+++ b/Documentation/Configuration.d.ts
@@ -1236,6 +1236,13 @@ declare namespace Scheme {
       cooldownMs?: Int;
 
       /**
+       * @title Prevent pointer movement
+       * @description Keep the pointer in place while the gesture trigger is held.
+       * @default false
+       */
+      suppressPointerMovement?: boolean;
+
+      /**
        * @title Gesture actions
        * @description Actions to trigger for each gesture direction.
        */

--- a/Documentation/Configuration.json
+++ b/Documentation/Configuration.json
@@ -340,6 +340,12 @@
           "title": "Enable gesture button",
           "type": "boolean"
         },
+        "suppressPointerMovement": {
+          "default": false,
+          "description": "Keep the pointer in place while the gesture trigger is held.",
+          "title": "Prevent pointer movement",
+          "type": "boolean"
+        },
         "threshold": {
           "$ref": "#/definitions/Int",
           "default": 50,

--- a/LinearMouse/EventTransformer/EventTransformerManager.swift
+++ b/LinearMouse/EventTransformer/EventTransformerManager.swift
@@ -778,6 +778,7 @@ class EventTransformerManager {
                 threshold: Double(gesture.threshold ?? 50),
                 deadZone: Double(gesture.deadZone ?? 40),
                 cooldownMs: gesture.cooldownMs ?? 500,
+                suppressPointerMovement: gesture.suppressPointerMovement ?? false,
                 actions: gesture.actions
             )
         } else {

--- a/LinearMouse/EventTransformer/GestureButtonTransformer.swift
+++ b/LinearMouse/EventTransformer/GestureButtonTransformer.swift
@@ -16,7 +16,9 @@ class GestureButtonTransformer {
     private let threshold: Double
     private let deadZone: Double
     private let cooldownMs: Int
+    private let suppressPointerMovement: Bool
     private let actions: Scheme.Buttons.Gesture.Actions
+    private let warpPointer: (CGPoint) -> Void
 
     /// State machine
     private enum State {
@@ -33,7 +35,11 @@ class GestureButtonTransformer {
         threshold: Double,
         deadZone: Double,
         cooldownMs: Int,
-        actions: Scheme.Buttons.Gesture.Actions
+        suppressPointerMovement: Bool,
+        actions: Scheme.Buttons.Gesture.Actions,
+        warpPointer: @escaping (CGPoint) -> Void = { position in
+            _ = CGWarpMouseCursorPosition(position)
+        }
     ) {
         self.trigger = trigger
         let defaultButton = UInt32(CGMouseButton.center.rawValue)
@@ -42,7 +48,9 @@ class GestureButtonTransformer {
         self.threshold = threshold
         self.deadZone = deadZone
         self.cooldownMs = cooldownMs
+        self.suppressPointerMovement = suppressPointerMovement
         self.actions = actions
+        self.warpPointer = warpPointer
     }
 }
 
@@ -54,6 +62,13 @@ extension GestureButtonTransformer: EventTransformer {
 
         // Check if we're in cooldown
         if case let .cooldown(until, released) = state {
+            // Logitech gesture controls report pointer movement without a
+            // button number. Keep the pointer stationary until their trigger
+            // release, even after a gesture has entered cooldown.
+            if suppressPointerMovement, !released, event.type == .mouseMoved {
+                return suppressPointerMovementEvent(event)
+            }
+
             if DispatchTime.now().uptimeNanoseconds < until {
                 // Still in cooldown - consume our button events
                 if matchesTriggerButton(event) {
@@ -191,15 +206,30 @@ extension GestureButtonTransformer: EventTransformer {
                 state = .idle
             }
 
-            // Consume the event
-            return nil
+            // Consume the event. mouseMoved still changes the system cursor
+            // unless its pre-event location is restored explicitly.
+            return isMouseMoved && suppressPointerMovement
+                ? suppressPointerMovementEvent(event)
+                : nil
         }
 
         // Update state with new deltas
         state = .tracking(startTime: startTime, deltaX: deltaX, deltaY: deltaY)
 
-        // Consume drag events while tracking; pass through mouseMoved events
+        // Drag events are always consumed. Logitech gesture controls report
+        // movement as mouseMoved, which remains opt-in to preserve existing
+        // pointer behavior.
+        if isMouseMoved, suppressPointerMovement {
+            return suppressPointerMovementEvent(event)
+        }
         return isMouseMoved ? event : nil
+    }
+
+    /// Returning nil from a HID event tap does not prevent macOS from moving
+    /// the cursor for mouseMoved events, so restore the pre-event location too.
+    private func suppressPointerMovementEvent(_ event: CGEvent) -> CGEvent? {
+        warpPointer(event.location)
+        return nil
     }
 
     private func handleButtonUp(_ event: CGEvent) -> CGEvent? {

--- a/LinearMouse/Localizable.xcstrings
+++ b/LinearMouse/Localizable.xcstrings
@@ -34418,6 +34418,29 @@
         }
       }
     },
+    "Keep the pointer in place while the gesture trigger is held." : {
+      "comment" : "Explains the gesture button option that prevents pointer movement.",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "按住手势触发按钮时保持指针不动。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "按住手勢觸發按鈕時保持指標不動。"
+          }
+        },
+        "zh-Hant-HK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "按住手勢觸發按鈕時保持指標不動。"
+          }
+        }
+      }
+    },
     "Keep scrolling after release" : {
       "comment" : "Checkbox label for keeping autoscroll active after releasing its trigger.",
       "localizations" : {
@@ -47126,6 +47149,29 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "指標速度"
+          }
+        }
+      }
+    },
+    "Prevent pointer movement" : {
+      "comment" : "Gesture button option that keeps the pointer stationary.",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "防止指针移动"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "防止指標移動"
+          }
+        },
+        "zh-Hant-HK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "防止指標移動"
           }
         }
       }

--- a/LinearMouse/Model/Configuration/Scheme/Buttons/Gesture/Gesture.swift
+++ b/LinearMouse/Model/Configuration/Scheme/Buttons/Gesture/Gesture.swift
@@ -10,6 +10,7 @@ extension Scheme.Buttons {
         var threshold: Int?
         var deadZone: Int?
         var cooldownMs: Int?
+        var suppressPointerMovement: Bool?
 
         @ImplicitOptional var actions: Actions
 
@@ -44,6 +45,7 @@ extension Scheme.Buttons.Gesture: Codable {
         case threshold
         case deadZone
         case cooldownMs
+        case suppressPointerMovement
         case actions
     }
 
@@ -54,6 +56,7 @@ extension Scheme.Buttons.Gesture: Codable {
         threshold = try container.decodeIfPresent(Int.self, forKey: .threshold)
         deadZone = try container.decodeIfPresent(Int.self, forKey: .deadZone)
         cooldownMs = try container.decodeIfPresent(Int.self, forKey: .cooldownMs)
+        suppressPointerMovement = try container.decodeIfPresent(Bool.self, forKey: .suppressPointerMovement)
         _actions = try container.decodeIfPresent(ImplicitOptional<Actions>.self, forKey: .actions) ?? .init()
 
         // Migrate legacy "button" field to "trigger"
@@ -71,6 +74,7 @@ extension Scheme.Buttons.Gesture: Codable {
         try container.encodeIfPresent(threshold, forKey: .threshold)
         try container.encodeIfPresent(deadZone, forKey: .deadZone)
         try container.encodeIfPresent(cooldownMs, forKey: .cooldownMs)
+        try container.encodeIfPresent(suppressPointerMovement, forKey: .suppressPointerMovement)
         try container.encodeIfPresent($actions, forKey: .actions)
     }
 }

--- a/LinearMouse/UI/ButtonsSettings/ButtonsSettingsState.swift
+++ b/LinearMouse/UI/ButtonsSettings/ButtonsSettingsState.swift
@@ -361,6 +361,15 @@ extension ButtonsSettingsState {
         }
     }
 
+    var gestureSuppressPointerMovement: Bool {
+        get {
+            mergedScheme.buttons.gesture.suppressPointerMovement ?? false
+        }
+        set {
+            scheme.buttons.gesture.suppressPointerMovement = newValue
+        }
+    }
+
     var gestureActionLeft: Scheme.Buttons.Gesture.GestureAction {
         get {
             mergedScheme.buttons.gesture.actions.left ?? .spaceLeft

--- a/LinearMouse/UI/ButtonsSettings/GestureButtonSection/GestureButtonSection.swift
+++ b/LinearMouse/UI/ButtonsSettings/GestureButtonSection/GestureButtonSection.swift
@@ -49,6 +49,13 @@ struct GestureButtonSection: View {
                         Slider(value: $state.gestureThresholdDouble, in: 20 ... 200, step: 5)
                     }
 
+                    Toggle(isOn: $state.gestureSuppressPointerMovement) {
+                        withDescription {
+                            Text("Prevent pointer movement")
+                            Text("Keep the pointer in place while the gesture trigger is held.")
+                        }
+                    }
+
                     Divider()
 
                     Text("Gesture Actions")

--- a/LinearMouseUnitTests/EventTransformer/ButtonMappingTransformerTests.swift
+++ b/LinearMouseUnitTests/EventTransformer/ButtonMappingTransformerTests.swift
@@ -1300,6 +1300,7 @@ final class ButtonMappingTransformerTests: XCTestCase {
             threshold: 10,
             deadZone: 40,
             cooldownMs: 500,
+            suppressPointerMovement: false,
             actions: .init(right: .some(.none))
         )
     }

--- a/LinearMouseUnitTests/EventTransformer/GestureButtonTransformerTests.swift
+++ b/LinearMouseUnitTests/EventTransformer/GestureButtonTransformerTests.swift
@@ -29,22 +29,30 @@ private func makeLogitechGestureTransformer(
     trigger: Scheme.Buttons.Mapping = .init(
         button: .logitechControl(.init(controlID: testLogitechControlID))
     ),
-    cooldownMs: Int = testGestureCooldownMs
+    cooldownMs: Int = testGestureCooldownMs,
+    suppressPointerMovement: Bool = false,
+    warpPointer: @escaping (CGPoint) -> Void = { _ in }
 ) -> GestureButtonTransformer {
     GestureButtonTransformer(
         trigger: trigger,
         threshold: testGestureThreshold,
         deadZone: testGestureDeadZone,
         cooldownMs: cooldownMs,
-        actions: .init(right: Scheme.Buttons.Gesture.GestureAction.none)
+        suppressPointerMovement: suppressPointerMovement,
+        actions: .init(right: Scheme.Buttons.Gesture.GestureAction.none),
+        warpPointer: warpPointer
     )
 }
 
-private func makeMouseMovedEvent(deltaX: Double, deltaY: Double = 0) throws -> CGEvent {
+private func makeMouseMovedEvent(
+    deltaX: Double,
+    deltaY: Double = 0,
+    location: CGPoint = .zero
+) throws -> CGEvent {
     let event = try XCTUnwrap(CGEvent(
         mouseEventSource: nil,
         mouseType: .mouseMoved,
-        mouseCursorPosition: .zero,
+        mouseCursorPosition: location,
         mouseButton: .center
     ))
     event.setDoubleValueField(.mouseEventDeltaX, value: deltaX)
@@ -81,6 +89,7 @@ final class GestureButtonTransformerTests: XCTestCase {
             threshold: testGestureThreshold,
             deadZone: testGestureDeadZone,
             cooldownMs: testGestureCooldownMs,
+            suppressPointerMovement: false,
             actions: .init(right: .some(.none))
         )
         SettingsState.shared.beginButtonMappingRecording(sessionID: UUID())
@@ -119,6 +128,51 @@ final class GestureButtonTransformerTests: XCTestCase {
             transformer.handleLogitechControlEvent(logitechContext(pressed: true)),
             .notHandled
         )
+    }
+
+    func testLogitechControlGestureAllowsPointerMovementByDefault() throws {
+        let transformer = makeLogitechGestureTransformer()
+
+        XCTAssertEqual(
+            transformer.handleLogitechControlEvent(logitechContext(pressed: true)),
+            .handledDeferringSyntheticFallback
+        )
+        XCTAssertNotNil(try transformer.transform(
+            makeMouseMovedEvent(deltaX: 1),
+            in: EventTransformerContext(device: nil)
+        ))
+    }
+
+    func testLogitechControlGestureSuppressesPointerMovementUntilReleased() throws {
+        var warpedLocations = [CGPoint]()
+        let transformer = makeLogitechGestureTransformer(
+            suppressPointerMovement: true,
+            warpPointer: { warpedLocations.append($0) }
+        )
+        let gestureLocation = CGPoint(x: 100, y: 200)
+        let cooldownLocation = CGPoint(x: 110, y: 200)
+
+        XCTAssertEqual(
+            transformer.handleLogitechControlEvent(logitechContext(pressed: true)),
+            .handledDeferringSyntheticFallback
+        )
+        XCTAssertNil(try transformer.transform(
+            makeMouseMovedEvent(deltaX: testGestureThreshold, location: gestureLocation),
+            in: EventTransformerContext(device: nil)
+        ))
+        XCTAssertNil(try transformer.transform(
+            makeMouseMovedEvent(deltaX: 1, location: cooldownLocation),
+            in: EventTransformerContext(device: nil)
+        ))
+        XCTAssertEqual(warpedLocations, [gestureLocation, cooldownLocation])
+        XCTAssertEqual(
+            transformer.handleLogitechControlEvent(logitechContext(pressed: false)),
+            .handled
+        )
+        XCTAssertNotNil(try transformer.transform(
+            makeMouseMovedEvent(deltaX: 1),
+            in: EventTransformerContext(device: nil)
+        ))
     }
 
     func testLogitechControlGestureSuppressesSyntheticFallbackForCleanupRelease() throws {

--- a/LinearMouseUnitTests/Model/Scheme/Buttons/GestureTests.swift
+++ b/LinearMouseUnitTests/Model/Scheme/Buttons/GestureTests.swift
@@ -99,6 +99,7 @@ final class GestureTests: XCTestCase {
         gesture.threshold = 70
         gesture.deadZone = 30
         gesture.cooldownMs = 300
+        gesture.suppressPointerMovement = true
         gesture.actions.left = .spaceLeft
         gesture.actions.right = .spaceRight
 
@@ -110,6 +111,7 @@ final class GestureTests: XCTestCase {
         XCTAssertEqual(decoded.threshold, 70)
         XCTAssertEqual(decoded.deadZone, 30)
         XCTAssertEqual(decoded.cooldownMs, 300)
+        XCTAssertEqual(decoded.suppressPointerMovement, true)
         XCTAssertEqual(decoded.actions.left, .spaceLeft)
         XCTAssertEqual(decoded.actions.right, .spaceRight)
     }


### PR DESCRIPTION

Closes #1356.


## Summary

- Add a **Prevent pointer movement** option to the Gesture Button settings.
- Keep the pointer stationary while the gesture trigger is held.
- Preserve the current pointer behavior by default.
- Add configuration schema, localization, and regression test coverage.

## Implementation

macOS can move the pointer even when an HID event tap discards a `mouseMoved` event. When this option is enabled, the gesture transformer discards the event and restores the pointer to its previous location.

This behavior applies while the gesture is tracking and during the cooldown period until the user releases the trigger.

## Screenshot

<img width="962" height="732" alt="Screenshot 2026-08-22 at 14 24 53" src="https://github.com/user-attachments/assets/ffdb2538-262a-4912-8f1f-567760fec32f" />


## Testing

- Manually tested the option with an MX Master 3 gesture button.
- Passed the focused `GestureButtonTransformerTests` suite.
- Passed the complete macOS test suite.
- Built a signed Release archive.
- Passed strict code-signature verification.
- Did not run SwiftFormat or SwiftLint because they are not installed.
